### PR TITLE
fix: address scorecard findings - permissions and Docker pinning

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,6 +16,9 @@ on:
     branches: [ "main" ]
     types: [ closed ]
 
+permissions:
+  contents: read
+
 jobs:
   e2e-tests:
 

--- a/integration-testing/src/main/docker/Dockerfile
+++ b/integration-testing/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/nifi:2.4.0
+FROM apache/nifi:2.4.0@sha256:8ff76efca5b855e72d8d1afb31a6ae609d5e38188257b4d2c09e5fc31d99f165
 
 # Set environment variables for faster startup and better HTTP configuration
 ENV NIFI_WEB_HTTPS_PORT=9095


### PR DESCRIPTION
## Summary
- Add top-level `permissions: contents: read` to e2e-tests.yml (Scorecard TokenPermissionsID)
- Pin Docker image `apache/nifi:2.4.0` by SHA256 hash (Scorecard PinnedDependenciesID)