### PR TITLE
Fix critical security vulnerabilities in Custom UI endpoints

### DIFF
--- a/doc/specification/security.adoc
+++ b/doc/specification/security.adoc
@@ -85,6 +85,60 @@ private HttpClient createSecureHttpClient() {
 
 For more details on JWKS configuration, see link:configuration.adoc#jwks-configuration[JWKS Configuration].
 
+== Custom UI Endpoint Security
+
+The processor's Custom UI is deployed as a WAR file within NiFi's web container and is accessed via an iframe within the authenticated NiFi session.
+
+=== Exposed Endpoints
+
+The Custom UI exposes these administration endpoints:
+
+[cols="2,3"]
+|===
+|Endpoint |Purpose
+
+|`/nifi-api/processors/jwt/verify-token`
+|JWT token verification
+
+|`/nifi-api/processors/jwt/validate-jwks-url`
+|JWKS URL validation
+
+|`/nifi-api/processors/jwt/validate-jwks-file`
+|JWKS file validation
+
+|`/nifi-api/processors/jwt/validate-jwks-content`
+|JWKS content validation
+
+|`/nifi-api/processors/jwt/metrics`
+|Validation metrics
+|===
+
+=== Security Model
+
+The endpoints are protected through multiple layers:
+
+1. **NiFi Session Authentication**: The Custom UI runs inside NiFi's web container as an iframe within an authenticated NiFi session. Unauthenticated users cannot reach the Custom UI at all.
+2. **Processor ID Validation**: The `ApiKeyAuthenticationFilter` requires an `X-Processor-Id` header on every request. This is a UUID passed to the iframe via URL parameter (`?id=<uuid>`), only available to authenticated NiFi users.
+3. **Security Response Headers**: The `SecurityHeadersFilter` adds defense-in-depth headers (`X-Content-Type-Options`, `X-Frame-Options: SAMEORIGIN`, `Referrer-Policy`) to all responses.
+4. **Full Signature Verification**: All token verification uses the processor's real configuration with full cryptographic signature verification. No test or bypass modes exist.
+
+=== JWKS File Path Protection
+
+JWKS file validation uses a two-layer defense against path traversal:
+
+1. **Security Pipeline Validation**: The `cui-http` library's `URLPathValidationPipeline` detects path traversal patterns including `../`, URL-encoded variants, and Unicode normalization attacks.
+2. **Base Directory Restriction**: File access is restricted to the NiFi configuration directory (resolved from `nifi.properties.file.path` or configurable via `nifi.jwks.allowed.base.path`).
+
+=== JWKS URL Protection
+
+JWKS URL validation uses the `cui-http` library's `HttpHandler` for secure HTTP communication with built-in timeouts and URL structure validation via `URLPathValidationPipeline`.
+
+=== Design Decisions
+
+* No test or E2E bypass endpoints exist in production deployments
+* `X-Frame-Options` is set to `SAMEORIGIN` (not `DENY`) because the Custom UI runs inside an iframe within NiFi
+* Token logging uses masking (first 8 characters only) to prevent sensitive data exposure
+
 == Multi-Issuer Security
 [.requirement]
 _See Requirement: link:../Requirements.adoc#NIFI-AUTH-8.3[NIFI-AUTH-8.3: Multi-Issuer Security]_

--- a/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/MetricsServlet.java
+++ b/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/MetricsServlet.java
@@ -291,7 +291,7 @@ public class MetricsServlet extends HttpServlet {
         public final List<ErrorCount> topErrors;
 
         public SecurityMetrics(long totalTokensValidated, long validTokens, long invalidTokens,
-                double errorRate, Instant lastValidation, List<ErrorCount> topErrors) {
+                               double errorRate, Instant lastValidation, List<ErrorCount> topErrors) {
             this.totalTokensValidated = totalTokensValidated;
             this.validTokens = validTokens;
             this.invalidTokens = invalidTokens;

--- a/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/SecurityHeadersFilter.java
+++ b/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/SecurityHeadersFilter.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.nifi.ui.servlets;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+/**
+ * Filter that adds security response headers to all servlet responses.
+ * These headers provide additional defense-in-depth protection.
+ *
+ * <p>Note: {@code X-Frame-Options} is set to {@code SAMEORIGIN} rather than
+ * {@code DENY} because the Custom UI runs inside an iframe within the NiFi web container.</p>
+ */
+public class SecurityHeadersFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+        httpResponse.setHeader("X-Content-Type-Options", "nosniff");
+        httpResponse.setHeader("X-Frame-Options", "SAMEORIGIN");
+        httpResponse.setHeader("Referrer-Policy", "strict-origin-when-cross-origin");
+        chain.doFilter(request, response);
+    }
+}

--- a/nifi-cuioss-ui/src/main/webapp/WEB-INF/web.xml
+++ b/nifi-cuioss-ui/src/main/webapp/WEB-INF/web.xml
@@ -41,6 +41,16 @@
         <mime-type>image/svg+xml</mime-type>
     </mime-mapping>
 
+    <!-- Security Headers Filter - adds defense-in-depth response headers -->
+    <filter>
+        <filter-name>SecurityHeadersFilter</filter-name>
+        <filter-class>de.cuioss.nifi.ui.servlets.SecurityHeadersFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>SecurityHeadersFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
     <!-- API Key Authentication Filter -->
     <filter>
         <filter-name>ApiKeyAuthenticationFilter</filter-name>
@@ -49,16 +59,6 @@
     <filter-mapping>
         <filter-name>ApiKeyAuthenticationFilter</filter-name>
         <url-pattern>/nifi-api/processors/jwt/*</url-pattern>
-    </filter-mapping>
-    <!-- Additional mapping for E2E test compatibility -->
-    <filter-mapping>
-        <filter-name>ApiKeyAuthenticationFilter</filter-name>
-        <url-pattern>/api/token/*</url-pattern>
-    </filter-mapping>
-    <!-- Mapping for JWT endpoints accessed directly -->
-    <filter-mapping>
-        <filter-name>ApiKeyAuthenticationFilter</filter-name>
-        <url-pattern>/jwt/*</url-pattern>
     </filter-mapping>
 
     <!-- JWT API Servlets -->
@@ -69,15 +69,6 @@
     <servlet-mapping>
         <servlet-name>JwtVerificationServlet</servlet-name>
         <url-pattern>/nifi-api/processors/jwt/verify-token</url-pattern>
-    </servlet-mapping>
-    <servlet-mapping>
-        <servlet-name>JwtVerificationServlet</servlet-name>
-        <url-pattern>/jwt/verify-token</url-pattern>
-    </servlet-mapping>
-    <!-- Additional mapping for E2E test compatibility -->
-    <servlet-mapping>
-        <servlet-name>JwtVerificationServlet</servlet-name>
-        <url-pattern>/api/token/verify</url-pattern>
     </servlet-mapping>
 
     <servlet>
@@ -96,18 +87,6 @@
         <servlet-name>JwksValidationServlet</servlet-name>
         <url-pattern>/nifi-api/processors/jwt/validate-jwks-content</url-pattern>
     </servlet-mapping>
-    <servlet-mapping>
-        <servlet-name>JwksValidationServlet</servlet-name>
-        <url-pattern>/jwt/validate-jwks-url</url-pattern>
-    </servlet-mapping>
-    <servlet-mapping>
-        <servlet-name>JwksValidationServlet</servlet-name>
-        <url-pattern>/jwt/validate-jwks-file</url-pattern>
-    </servlet-mapping>
-    <servlet-mapping>
-        <servlet-name>JwksValidationServlet</servlet-name>
-        <url-pattern>/jwt/validate-jwks-content</url-pattern>
-    </servlet-mapping>
 
     <servlet>
         <servlet-name>MetricsServlet</servlet-name>
@@ -116,10 +95,6 @@
     <servlet-mapping>
         <servlet-name>MetricsServlet</servlet-name>
         <url-pattern>/nifi-api/processors/jwt/metrics</url-pattern>
-    </servlet-mapping>
-    <servlet-mapping>
-        <servlet-name>MetricsServlet</servlet-name>
-        <url-pattern>/jwt/metrics</url-pattern>
     </servlet-mapping>
 
 </web-app>

--- a/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/SecurityHeadersFilterTest.java
+++ b/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/SecurityHeadersFilterTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.nifi.ui.servlets;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.easymock.EasyMock.*;
+
+@DisplayName("Security Headers Filter Tests")
+class SecurityHeadersFilterTest {
+
+    private SecurityHeadersFilter filter;
+    private HttpServletRequest mockRequest;
+    private HttpServletResponse mockResponse;
+    private FilterChain mockChain;
+
+    @BeforeEach
+    void setUp() {
+        filter = new SecurityHeadersFilter();
+        mockRequest = createMock(HttpServletRequest.class);
+        mockResponse = createMock(HttpServletResponse.class);
+        mockChain = createMock(FilterChain.class);
+    }
+
+    @Test
+    @DisplayName("Should set X-Content-Type-Options header")
+    void shouldSetXContentTypeOptionsHeader() throws Exception {
+        mockResponse.setHeader("X-Content-Type-Options", "nosniff");
+        expectLastCall().once();
+        mockResponse.setHeader("X-Frame-Options", "SAMEORIGIN");
+        expectLastCall().once();
+        mockResponse.setHeader("Referrer-Policy", "strict-origin-when-cross-origin");
+        expectLastCall().once();
+        mockChain.doFilter(mockRequest, mockResponse);
+        expectLastCall().once();
+
+        replay(mockRequest, mockResponse, mockChain);
+
+        filter.doFilter(mockRequest, mockResponse, mockChain);
+
+        verify(mockRequest, mockResponse, mockChain);
+    }
+
+    @Test
+    @DisplayName("Should set X-Frame-Options to SAMEORIGIN for NiFi iframe")
+    void shouldSetXFrameOptionsToSameOrigin() throws Exception {
+        mockResponse.setHeader("X-Content-Type-Options", "nosniff");
+        expectLastCall().once();
+        mockResponse.setHeader("X-Frame-Options", "SAMEORIGIN");
+        expectLastCall().once();
+        mockResponse.setHeader("Referrer-Policy", "strict-origin-when-cross-origin");
+        expectLastCall().once();
+        mockChain.doFilter(mockRequest, mockResponse);
+        expectLastCall().once();
+
+        replay(mockRequest, mockResponse, mockChain);
+
+        filter.doFilter(mockRequest, mockResponse, mockChain);
+
+        verify(mockRequest, mockResponse, mockChain);
+    }
+
+    @Test
+    @DisplayName("Should continue filter chain after setting headers")
+    void shouldContinueFilterChain() throws Exception {
+        mockResponse.setHeader(anyString(), anyString());
+        expectLastCall().anyTimes();
+        mockChain.doFilter(mockRequest, mockResponse);
+        expectLastCall().once();
+
+        replay(mockRequest, mockResponse, mockChain);
+
+        filter.doFilter(mockRequest, mockResponse, mockChain);
+
+        verify(mockChain);
+    }
+}

--- a/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/integration/BackendEndpointsIntegrationTest.java
+++ b/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/integration/BackendEndpointsIntegrationTest.java
@@ -155,7 +155,7 @@ class BackendEndpointsIntegrationTest {
     }
 
     @Test
-    void e2eTokenVerificationEndpointAccessible() {
+    void removedE2eEndpointReturns404() {
         String requestBody = """
             {
                 "token": "test-token",
@@ -170,11 +170,7 @@ class BackendEndpointsIntegrationTest {
                 .when()
                 .post("/api/token/verify")
                 .then()
-                .statusCode(not(equalTo(404))) // Should not be Not Found
-                .contentType(ContentType.JSON)
-                .body("valid", notNullValue())
-                .body("error", notNullValue())
-                .body("claims", notNullValue());
+                .statusCode(equalTo(404)); // E2E endpoint removed for security
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **[CRITICAL]** Remove test mode bypass that allowed JWT verification without signature checking — any JWT with valid base64 and future `exp` was accepted via `/api/token/verify` and `/jwt/verify-token` endpoints
- **[HIGH]** Fix SSRF in JWKS URL validation — replace hand-rolled HttpClient with cui-http `HttpHandler` and add URL path validation via `URLPathValidationPipeline`
- **[HIGH]** Fix path traversal in JWKS file validation — add cui-http security pipeline + base directory restriction
- **[MEDIUM]** Fix JSON escaping bug in `ApiKeyAuthenticationFilter` — replace manual string construction with Jakarta JSON-P
- **[MEDIUM]** Mask JWT tokens in log statements (first 8 chars only) and downgrade to DEBUG level
- **[MEDIUM]** Add `SecurityHeadersFilter` with `X-Content-Type-Options`, `X-Frame-Options: SAMEORIGIN`, `Referrer-Policy`
- Document Custom UI endpoint security model in `security.adoc`
- Created #88 for SSRF IP denylist (future enhancement)

## Files Changed (14 files, -396 net lines)

**Production code:**
- `web.xml` — Remove E2E/test endpoint mappings, add SecurityHeadersFilter
- `ApiKeyAuthenticationFilter.java` — Remove E2E bypass, use Jakarta JSON-P
- `JwtVerificationServlet.java` — Remove test mode, add token masking
- `JwtValidationService.java` — Remove `verifyTokenWithTestConfig()` and all test-mode methods
- `JwksValidationServlet.java` — Add cui-http security pipeline, HttpHandler, base dir restriction
- `SecurityHeadersFilter.java` — **New** security response headers filter

**Tests:**
- Updated 5 test files, removed 16 test-mode tests, added path traversal + security header tests
- `BackendEndpointsIntegrationTest` — E2E endpoint now expects 404

**Documentation:**
- `security.adoc` — New "Custom UI Endpoint Security" section

## Test plan

- [x] `./mvnw -Ppre-commit clean install -DskipTests` passes
- [x] `./mvnw clean install` passes (78 Java tests, 678 JS tests, all modules)
- [ ] CI pipeline passes
- [ ] Integration tests pass (Docker: NiFi + Keycloak)
- [ ] E2E Playwright tests pass (interact via NiFi UI iframe, not removed endpoints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)