### PR TITLE
fix: deploy NAR to container volume before E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -57,17 +57,21 @@ jobs:
           restore-keys: ${{ runner.os }}-playwright-
 
       - name: Build NAR files and prepare deployment
-        run: ./mvnw -B --no-transfer-progress clean package -DskipTests
+        run: |
+          ./mvnw -B --no-transfer-progress clean package -DskipTests
+          mkdir -p target/nifi-deploy
+          cp nifi-cuioss-nar/target/nifi-cuioss-nar-*.nar target/nifi-deploy/
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: cd e-2-e-playwright && npx playwright install chromium
 
       - name: Run E2E Integration Tests with Maven-managed Containers
-        # This runs the full E2E test suite with Maven managing container lifecycle:
-        # 1. pre-integration-test: Start containers via start-integration-containers.sh
-        # 2. integration-test: Run playwright tests - linting skipped for speed
-        # 3. post-integration-test: Stop containers via stop-integration-containers.sh
+        # Maven manages the container lifecycle via exec-maven-plugin:
+        # 1. pre-integration-test: Start containers via start-nifi.sh
+        # 2. integration-test: Run playwright tests (self-tests, functional, accessibility)
+        # 3. post-integration-test: Stop containers via stop-test-container.sh
+        # Note: -pl limits clean to e-2-e-playwright only, preserving target/nifi-deploy
         run: ./mvnw -B --no-transfer-progress clean verify -pl e-2-e-playwright -Pintegration-tests
         env:
           PLAYWRIGHT_BASE_URL: https://localhost:9095/nifi


### PR DESCRIPTION
## Summary

- Copy the built NAR file to `target/nifi-deploy/` after building, so the Docker container can mount it
- The NiFi container's docker-compose.yml mounts `target/nifi-deploy` as `nar_extensions`, but no step was populating that directory in CI
- This is what `copy-deployment.sh` does for local development via `run-and-deploy.sh`

## Root Cause

The E2E workflow built NARs with `mvnw clean package` (output: `nifi-cuioss-nar/target/`), then started containers with `start-nifi.sh`. But `start-nifi.sh` doesn't copy the NAR to `target/nifi-deploy/` (unlike `run-and-deploy.sh` which calls `copy-deployment.sh` first). Result: NiFi started without the custom processor, causing all 19 self-tests to fail with `PRECONDITION FAILED: Cannot add MultiIssuerJWTTokenAuthenticator to canvas`.

## Test plan

- [x] `./mvnw -Ppre-commit clean install -DskipTests` passes
- [x] `./mvnw clean install` passes
- [ ] E2E workflow succeeds in CI (processor available in NiFi container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)