### PR TITLE
fix: increase E2E step timeout from 12 to 18 minutes

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -76,7 +76,7 @@ jobs:
         env:
           PLAYWRIGHT_BASE_URL: https://localhost:9095/nifi
           PLAYWRIGHT_KEYCLOAK_URL: http://localhost:9080
-        timeout-minutes: 12
+        timeout-minutes: 18
 
       - name: Generate E2E Analysis Reports
         run: |


### PR DESCRIPTION
## Summary
- The E2E step timeout of 12 minutes is now insufficient because self-tests and functional tests all pass (previously, self-test failures blocked functional tests, saving ~7 minutes)
- Self-tests: ~2.5 min, Functional: ~7 min, Accessibility: ~5 min = ~14.5 min needed
- Increase from 12 to 18 minutes (within the 20-minute job timeout)

## Test plan
- [ ] E2E workflow completes without timeout
- [ ] All three test phases run to completion (self-tests, functional, accessibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)