### PR TITLE
fix: remove S6819 ARIA violations and improve JS test coverage

### DIFF
--- a/nifi-cuioss-ui/src/main/webapp/css/modules/base.css
+++ b/nifi-cuioss-ui/src/main/webapp/css/modules/base.css
@@ -41,11 +41,8 @@ body {
 }
 
 .jwt-tabs-header .tabs .tab-item {
-    margin-right: 2px;
-}
-
-.jwt-tabs-header .tabs .tab-item a {
     display: block;
+    margin-right: 2px;
     padding: 10px 20px;
     text-decoration: none;
     color: var(--text-color);
@@ -56,11 +53,11 @@ body {
     transition: all 0.2s ease;
 }
 
-.jwt-tabs-header .tabs .tab-item a:hover {
+.jwt-tabs-header .tabs .tab-item:hover {
     background-color: var(--tab-hover-background);
 }
 
-.jwt-tabs-header .tabs .tab-item.active a {
+.jwt-tabs-header .tabs .tab-item.active {
     background-color: var(--container-background);
     color: var(--primary-color);
     border-bottom: 2px solid var(--container-background);

--- a/nifi-cuioss-ui/src/main/webapp/index.html
+++ b/nifi-cuioss-ui/src/main/webapp/index.html
@@ -32,18 +32,10 @@
         <main id="jwt-validator-tabs" class="jwt-tabs-container hidden">
             <div class="jwt-tabs-header" data-testid="jwt-config-tabs">
                 <div class="tabs" role="tablist">
-                    <div class="tab-item active" role="presentation">
-                        <a href="#issuer-config" role="tab" data-toggle="tab">Configuration</a>
-                    </div>
-                    <div class="tab-item" role="presentation">
-                        <a href="#token-verification" role="tab" data-toggle="tab">Token Verification</a>
-                    </div>
-                    <div class="tab-item" role="presentation">
-                        <a href="#metrics" role="tab" data-toggle="tab">Metrics</a>
-                    </div>
-                    <div class="tab-item" role="presentation">
-                        <a href="#help" role="tab" data-toggle="tab">Help</a>
-                    </div>
+                    <a href="#issuer-config" class="tab-item active" role="tab" data-toggle="tab">Configuration</a>
+                    <a href="#token-verification" class="tab-item" role="tab" data-toggle="tab">Token Verification</a>
+                    <a href="#metrics" class="tab-item" role="tab" data-toggle="tab">Metrics</a>
+                    <a href="#help" class="tab-item" role="tab" data-toggle="tab">Help</a>
                 </div>
             </div>
             <div class="jwt-tabs-content">

--- a/nifi-cuioss-ui/src/main/webapp/js/app.js
+++ b/nifi-cuioss-ui/src/main/webapp/js/app.js
@@ -50,7 +50,7 @@ const initTabs = () => {
             for (const pane of tabPanes) pane.classList.remove('active');
 
             // Activate clicked
-            link.parentElement.classList.add('active');
+            link.classList.add('active');
             const targetPane = document.querySelector(target);
             if (targetPane) targetPane.classList.add('active');
         });

--- a/nifi-cuioss-ui/src/test/js/app.test.js
+++ b/nifi-cuioss-ui/src/test/js/app.test.js
@@ -1,0 +1,120 @@
+'use strict';
+
+/**
+ * Tests for app.js — tab switching, collapsibles, loading state.
+ */
+
+// Mock the imported modules before importing app.js
+jest.mock('../../main/webapp/js/issuer-config.js', () => ({
+    init: jest.fn(),
+    cleanup: jest.fn()
+}));
+jest.mock('../../main/webapp/js/token-verifier.js', () => ({
+    init: jest.fn()
+}));
+jest.mock('../../main/webapp/js/metrics.js', () => ({
+    init: jest.fn(),
+    cleanup: jest.fn()
+}));
+
+describe('app.js', () => {
+    beforeEach(() => {
+        // Set up the DOM from index.html tab structure
+        document.body.innerHTML = `
+            <div id="jwt-validator-container">
+                <div id="loading-indicator">Loading...</div>
+                <main id="jwt-validator-tabs" class="jwt-tabs-container hidden">
+                    <div class="jwt-tabs-header">
+                        <div class="tabs" role="tablist">
+                            <a href="#issuer-config" class="tab-item active" role="tab" data-toggle="tab">Configuration</a>
+                            <a href="#token-verification" class="tab-item" role="tab" data-toggle="tab">Token Verification</a>
+                            <a href="#metrics" class="tab-item" role="tab" data-toggle="tab">Metrics</a>
+                            <a href="#help" class="tab-item" role="tab" data-toggle="tab">Help</a>
+                        </div>
+                    </div>
+                    <div class="jwt-tabs-content">
+                        <div id="issuer-config" class="tab-pane active" role="tabpanel"></div>
+                        <div id="token-verification" class="tab-pane" role="tabpanel"></div>
+                        <div id="metrics" class="tab-pane" role="tabpanel"></div>
+                        <div id="help" class="tab-pane" role="tabpanel">
+                            <div class="help-sections">
+                                <h4 class="collapsible-header active">
+                                    <i class="fa fa-chevron-down"></i> Getting Started
+                                </h4>
+                                <div class="collapsible-content show">Content</div>
+                            </div>
+                        </div>
+                    </div>
+                </main>
+            </div>`;
+
+        jest.resetModules();
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+        delete globalThis.jwtUICleanup;
+    });
+
+    it('should hide loading indicator and show tabs on DOMContentLoaded', async () => {
+        await import('../../main/webapp/js/app.js');
+        document.dispatchEvent(new Event('DOMContentLoaded'));
+
+        const loading = document.getElementById('loading-indicator');
+        const tabs = document.getElementById('jwt-validator-tabs');
+        expect(loading.classList.contains('hidden')).toBe(true);
+        expect(loading.getAttribute('aria-hidden')).toBe('true');
+        expect(tabs.classList.contains('hidden')).toBe(false);
+    });
+
+    it('should initialize components on DOMContentLoaded', async () => {
+        const issuerConfig = (await import('../../main/webapp/js/issuer-config.js'));
+        const tokenVerifier = (await import('../../main/webapp/js/token-verifier.js'));
+        const metrics = (await import('../../main/webapp/js/metrics.js'));
+
+        await import('../../main/webapp/js/app.js');
+        document.dispatchEvent(new Event('DOMContentLoaded'));
+
+        expect(issuerConfig.init).toHaveBeenCalled();
+        expect(tokenVerifier.init).toHaveBeenCalled();
+        expect(metrics.init).toHaveBeenCalled();
+    });
+
+    it('should switch tabs when tab link is clicked', async () => {
+        await import('../../main/webapp/js/app.js');
+        document.dispatchEvent(new Event('DOMContentLoaded'));
+
+        // Click the "Token Verification" tab
+        const tokenTab = document.querySelector('a[href="#token-verification"]');
+        tokenTab.click();
+
+        // Verify tab switching
+        const configPane = document.getElementById('issuer-config');
+        const tokenPane = document.getElementById('token-verification');
+        expect(configPane.classList.contains('active')).toBe(false);
+        expect(tokenPane.classList.contains('active')).toBe(true);
+
+        // Verify tab-item classes
+        const tabItems = document.querySelectorAll('.tab-item');
+        expect(tabItems[0].classList.contains('active')).toBe(false);
+        expect(tabItems[1].classList.contains('active')).toBe(true);
+    });
+
+    it('should register collapsible click handlers', async () => {
+        await import('../../main/webapp/js/app.js');
+        document.dispatchEvent(new Event('DOMContentLoaded'));
+
+        const header = document.querySelector('.collapsible-header');
+        expect(header).not.toBeNull();
+        const content = header.nextElementSibling;
+        expect(content.classList.contains('collapsible-content')).toBe(true);
+    });
+
+    it('should expose jwtUICleanup on globalThis', async () => {
+        await import('../../main/webapp/js/app.js');
+
+        expect(typeof globalThis.jwtUICleanup).toBe('function');
+        // Should call cleanupMetrics without error
+        globalThis.jwtUICleanup();
+    });
+});

--- a/nifi-cuioss-ui/src/test/js/issuer-config.test.js
+++ b/nifi-cuioss-ui/src/test/js/issuer-config.test.js
@@ -1,0 +1,350 @@
+'use strict';
+
+/**
+ * Tests for issuer-config.js — Issuer Configuration editor component.
+ */
+
+jest.mock('../../main/webapp/js/api.js');
+jest.mock('../../main/webapp/js/utils.js');
+
+import { init, cleanup } from '../../main/webapp/js/issuer-config.js';
+import * as api from '../../main/webapp/js/api.js';
+import * as utils from '../../main/webapp/js/utils.js';
+
+describe('issuer-config', () => {
+    let container;
+
+    beforeEach(() => {
+        // Re-apply mock implementations (resetMocks clears them between tests)
+        utils.sanitizeHtml.mockImplementation((s) => s);
+        utils.displayUiError.mockImplementation(() => {});
+        utils.displayUiSuccess.mockImplementation(() => {});
+        utils.confirmRemoveIssuer.mockImplementation((name, cb) => cb());
+        utils.validateIssuerConfig.mockImplementation(() => ({ isValid: true }));
+        utils.validateProcessorIdFromUrl.mockImplementation((url) => {
+            const match = url.match(/[?&]id=([^&]+)/);
+            if (match) return { isValid: true, sanitizedValue: match[1] };
+            return { isValid: false, sanitizedValue: '' };
+        });
+        // eslint-disable-next-line no-import-assign -- Jest auto-mock requires manual log stub
+        utils.log = { info: jest.fn(), debug: jest.fn(), error: jest.fn(), warn: jest.fn() };
+
+        container = document.createElement('div');
+        container.id = 'issuer-config';
+        document.body.appendChild(container);
+
+        // Default: no processor ID in URL (standalone mode)
+        delete globalThis.location;
+        globalThis.location = { href: 'http://localhost:8080/nifi-cuioss-ui/' };
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('should initialize the issuer config editor', async () => {
+        await init(container);
+
+        expect(container.querySelector('.issuer-config-editor')).not.toBeNull();
+        expect(container.querySelector('.issuers-container')).not.toBeNull();
+        expect(container.querySelector('.add-issuer-button')).not.toBeNull();
+    });
+
+    it('should not re-initialize if already initialized', async () => {
+        await init(container);
+        const firstContent = container.innerHTML;
+        await init(container);
+        expect(container.innerHTML).toBe(firstContent);
+    });
+
+    it('should return early for null container', async () => {
+        await init(null);
+        expect(document.body.children.length).toBe(1); // only the test container
+    });
+
+    it('should show sample issuer form in standalone mode', async () => {
+        await init(container);
+
+        const issuerForms = container.querySelectorAll('.issuer-form');
+        expect(issuerForms.length).toBe(1);
+
+        const nameInput = issuerForms[0].querySelector('.issuer-name');
+        expect(nameInput.value).toBe('sample-issuer');
+    });
+
+    it('should load existing issuers when processor ID is present', async () => {
+        globalThis.location = { href: 'http://localhost:8080/nifi-cuioss-ui/?id=test-processor-123' };
+        api.getProcessorProperties.mockResolvedValue({
+            properties: {
+                'issuer.keycloak.issuer': 'https://kc.example.com',
+                'issuer.keycloak.jwks-url': 'https://kc.example.com/jwks',
+                'issuer.auth0.issuer': 'https://auth0.example.com',
+                'issuer.auth0.jwks-url': 'https://auth0.example.com/jwks'
+            }
+        });
+
+        await init(container);
+        await new Promise((r) => setTimeout(r, 10));
+
+        const issuerForms = container.querySelectorAll('.issuer-form');
+        expect(issuerForms.length).toBe(2);
+    });
+
+    it('should fall back to sample issuer when API fails', async () => {
+        globalThis.location = { href: 'http://localhost:8080/nifi-cuioss-ui/?id=test-processor-123' };
+        api.getProcessorProperties.mockRejectedValue(new Error('API error'));
+
+        await init(container);
+        await new Promise((r) => setTimeout(r, 10));
+
+        const nameInput = container.querySelector('.issuer-name');
+        expect(nameInput.value).toBe('sample-issuer');
+    });
+
+    it('should add new issuer form when Add Issuer button is clicked', async () => {
+        await init(container);
+
+        container.querySelector('.add-issuer-button').click();
+
+        const issuerForms = container.querySelectorAll('.issuer-form');
+        expect(issuerForms.length).toBe(2);
+    });
+
+    it('should have correct form fields in issuer form', async () => {
+        await init(container);
+
+        const form = container.querySelector('.issuer-form');
+        expect(form.querySelector('.issuer-name')).not.toBeNull();
+        expect(form.querySelector('.field-issuer')).not.toBeNull();
+        expect(form.querySelector('.field-jwks-url')).not.toBeNull();
+        expect(form.querySelector('.field-jwks-type')).not.toBeNull();
+        expect(form.querySelector('.field-audience')).not.toBeNull();
+        expect(form.querySelector('.field-client-id')).not.toBeNull();
+        expect(form.querySelector('.save-issuer-button')).not.toBeNull();
+        expect(form.querySelector('.remove-issuer-button')).not.toBeNull();
+        expect(form.querySelector('.verify-jwks-button')).not.toBeNull();
+    });
+
+    it('should toggle JWKS field visibility when type changes', async () => {
+        await init(container);
+
+        const form = container.querySelector('.issuer-form');
+        const typeSelect = form.querySelector('.field-jwks-type');
+
+        // Switch to file
+        typeSelect.value = 'file';
+        typeSelect.dispatchEvent(new Event('change'));
+
+        expect(form.querySelector('.jwks-type-url').classList.contains('hidden')).toBe(true);
+        expect(form.querySelector('.jwks-type-file').classList.contains('hidden')).toBe(false);
+
+        // Switch to memory
+        typeSelect.value = 'memory';
+        typeSelect.dispatchEvent(new Event('change'));
+
+        expect(form.querySelector('.jwks-type-file').classList.contains('hidden')).toBe(true);
+        expect(form.querySelector('.jwks-type-memory').classList.contains('hidden')).toBe(false);
+    });
+
+    it('should save issuer in standalone mode', async () => {
+        await init(container);
+
+        const form = container.querySelector('.issuer-form');
+        form.querySelector('.issuer-name').value = 'test-issuer';
+        form.querySelector('.field-issuer').value = 'https://test.example.com';
+        form.querySelector('.field-jwks-url').value = 'https://test.example.com/jwks';
+
+        form.querySelector('.save-issuer-button').click();
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(utils.displayUiSuccess).toHaveBeenCalledWith(
+            expect.any(Element),
+            'Issuer configuration saved successfully (standalone mode).'
+        );
+    });
+
+    it('should validate required fields before saving', async () => {
+        await init(container);
+
+        const form = container.querySelector('.issuer-form');
+        form.querySelector('.issuer-name').value = '';
+        form.querySelector('.field-issuer').value = '';
+
+        form.querySelector('.save-issuer-button').click();
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(utils.displayUiError).toHaveBeenCalled();
+    });
+
+    it('should save issuer via API when processor ID is present', async () => {
+        globalThis.location = { href: 'http://localhost:8080/nifi-cuioss-ui/?id=test-processor-123' };
+        api.getProcessorProperties.mockResolvedValue({ properties: {} });
+        api.updateProcessorProperties.mockResolvedValue({});
+
+        await init(container);
+        await new Promise((r) => setTimeout(r, 10));
+
+        // Empty properties produce no forms; add one manually
+        container.querySelector('.add-issuer-button').click();
+
+        const form = container.querySelector('.issuer-form');
+        form.querySelector('.issuer-name').value = 'my-issuer';
+        form.querySelector('.field-issuer').value = 'https://issuer.example.com';
+        form.querySelector('.field-jwks-url').value = 'https://issuer.example.com/jwks';
+
+        form.querySelector('.save-issuer-button').click();
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(api.updateProcessorProperties).toHaveBeenCalledWith(
+            'test-processor-123',
+            expect.objectContaining({
+                'issuer.my-issuer.jwks-type': 'url',
+                'issuer.my-issuer.issuer': 'https://issuer.example.com',
+                'issuer.my-issuer.jwks-url': 'https://issuer.example.com/jwks'
+            })
+        );
+    });
+
+    it('should remove issuer form when remove button is clicked', async () => {
+        await init(container);
+
+        const form = container.querySelector('.issuer-form');
+        expect(form).not.toBeNull();
+
+        form.querySelector('.remove-issuer-button').click();
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(container.querySelectorAll('.issuer-form').length).toBe(0);
+    });
+
+    it('should test JWKS URL connection', async () => {
+        api.validateJwksUrl.mockResolvedValue({ valid: true, keyCount: 3 });
+
+        await init(container);
+
+        const form = container.querySelector('.issuer-form');
+        form.querySelector('.field-jwks-url').value = 'https://test.example.com/jwks';
+
+        form.querySelector('.verify-jwks-button').click();
+        await new Promise((r) => setTimeout(r, 10));
+
+        const result = form.querySelector('.verification-result');
+        expect(result.textContent).toContain('Valid JWKS');
+        expect(result.textContent).toContain('3 keys found');
+    });
+
+    it('should show error for invalid JWKS URL validation', async () => {
+        api.validateJwksUrl.mockResolvedValue({ valid: false, error: 'Connection failed' });
+
+        await init(container);
+
+        const form = container.querySelector('.issuer-form');
+        form.querySelector('.field-jwks-url').value = 'https://bad.example.com/jwks';
+
+        form.querySelector('.verify-jwks-button').click();
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(utils.displayUiError).toHaveBeenCalled();
+    });
+
+    it('should handle JWKS file type validation', async () => {
+        api.validateJwksFile.mockResolvedValue({ valid: true, keyCount: 2 });
+
+        await init(container);
+
+        const form = container.querySelector('.issuer-form');
+        const typeSelect = form.querySelector('.field-jwks-type');
+        typeSelect.value = 'file';
+        typeSelect.dispatchEvent(new Event('change'));
+
+        form.querySelector('.field-jwks-file').value = '/path/to/jwks.json';
+        form.querySelector('.verify-jwks-button').click();
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(api.validateJwksFile).toHaveBeenCalledWith('/path/to/jwks.json');
+    });
+
+    it('should handle JWKS memory/content type validation', async () => {
+        api.validateJwksContent.mockResolvedValue({ valid: true, keyCount: 1 });
+
+        await init(container);
+
+        const form = container.querySelector('.issuer-form');
+        const typeSelect = form.querySelector('.field-jwks-type');
+        typeSelect.value = 'memory';
+        typeSelect.dispatchEvent(new Event('change'));
+
+        form.querySelector('.field-jwks-content').value = '{"keys":[]}';
+        form.querySelector('.verify-jwks-button').click();
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(api.validateJwksContent).toHaveBeenCalledWith('{"keys":[]}');
+    });
+
+    it('should show error when save via API fails', async () => {
+        globalThis.location = { href: 'http://localhost:8080/nifi-cuioss-ui/?id=test-processor-123' };
+        api.getProcessorProperties.mockResolvedValue({ properties: {} });
+        api.updateProcessorProperties.mockRejectedValue(new Error('Save failed'));
+
+        await init(container);
+        await new Promise((r) => setTimeout(r, 10));
+
+        container.querySelector('.add-issuer-button').click();
+
+        const form = container.querySelector('.issuer-form');
+        form.querySelector('.issuer-name').value = 'fail-issuer';
+        form.querySelector('.field-issuer').value = 'https://fail.example.com';
+        form.querySelector('.field-jwks-url').value = 'https://fail.example.com/jwks';
+
+        form.querySelector('.save-issuer-button').click();
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(utils.displayUiError).toHaveBeenCalled();
+    });
+
+    it('should show error when JWKS URL validation throws', async () => {
+        api.validateJwksUrl.mockRejectedValue(new Error('Network error'));
+
+        await init(container);
+
+        const form = container.querySelector('.issuer-form');
+        form.querySelector('.field-jwks-url').value = 'https://bad.example.com/jwks';
+
+        form.querySelector('.verify-jwks-button').click();
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(utils.displayUiError).toHaveBeenCalled();
+    });
+
+    it('should remove issuer and clear API properties when processor ID is present', async () => {
+        globalThis.location = { href: 'http://localhost:8080/nifi-cuioss-ui/?id=test-processor-123' };
+        api.getProcessorProperties.mockResolvedValue({
+            properties: {
+                'issuer.keycloak.issuer': 'https://kc.example.com',
+                'issuer.keycloak.jwks-url': 'https://kc.example.com/jwks'
+            }
+        });
+        api.updateProcessorProperties.mockResolvedValue({});
+
+        await init(container);
+        await new Promise((r) => setTimeout(r, 10));
+
+        const form = container.querySelector('.issuer-form');
+        expect(form).not.toBeNull();
+
+        form.querySelector('.remove-issuer-button').click();
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(api.updateProcessorProperties).toHaveBeenCalledWith(
+            'test-processor-123',
+            expect.objectContaining({
+                'issuer.keycloak.issuer': null,
+                'issuer.keycloak.jwks-url': null
+            })
+        );
+    });
+
+    it('should call cleanup without error', () => {
+        expect(() => cleanup()).not.toThrow();
+    });
+});

--- a/nifi-cuioss-ui/src/test/js/metrics.test.js
+++ b/nifi-cuioss-ui/src/test/js/metrics.test.js
@@ -1,0 +1,285 @@
+'use strict';
+
+/**
+ * Tests for metrics.js — Metrics dashboard tab component.
+ */
+
+jest.mock('../../main/webapp/js/api.js');
+jest.mock('../../main/webapp/js/utils.js');
+
+import { init, cleanup } from '../../main/webapp/js/metrics.js';
+import * as api from '../../main/webapp/js/api.js';
+import * as utils from '../../main/webapp/js/utils.js';
+
+describe('metrics', () => {
+    let container;
+
+    beforeEach(() => {
+        // Re-apply mock implementations (resetMocks clears them between tests)
+        utils.sanitizeHtml.mockImplementation((s) => s);
+        utils.formatNumber.mockImplementation((n) => String(n));
+        utils.formatDate.mockImplementation((d) => d instanceof Date ? d.toISOString() : String(d));
+        utils.t.mockImplementation((key) => key);
+        // eslint-disable-next-line no-import-assign -- Jest auto-mock requires manual log stub
+        utils.log = { info: jest.fn(), debug: jest.fn(), error: jest.fn(), warn: jest.fn() };
+
+        container = document.createElement('div');
+        container.id = 'metrics';
+        document.body.appendChild(container);
+
+        // Default successful metrics response
+        api.getSecurityMetrics.mockResolvedValue({
+            totalTokensValidated: 100,
+            validTokens: 90,
+            invalidTokens: 10,
+            averageResponseTime: 50,
+            minResponseTime: 5,
+            maxResponseTime: 200,
+            p95ResponseTime: 150,
+            activeIssuers: 2,
+            issuerMetrics: [
+                { name: 'keycloak', totalRequests: 80, successCount: 75, failureCount: 5, successRate: 93.75, avgResponseTime: 45 },
+                { name: 'auth0', totalRequests: 20, successCount: 15, failureCount: 5, successRate: 75.0, avgResponseTime: 60 }
+            ],
+            topErrors: [
+                { issuer: 'auth0', error: 'Token expired', count: 3, timestamp: '2026-01-15T10:00:00Z' }
+            ]
+        });
+    });
+
+    afterEach(() => {
+        cleanup();
+        document.body.innerHTML = '';
+    });
+
+    it('should initialize the metrics dashboard', async () => {
+        init(container);
+        await new Promise((r) => setTimeout(r, 50));
+
+        expect(container.querySelector('#jwt-metrics-content')).not.toBeNull();
+        expect(container.querySelector('#refresh-metrics-btn')).not.toBeNull();
+        expect(container.querySelector('#export-metrics-btn')).not.toBeNull();
+    });
+
+    it('should not re-initialize if already initialized', async () => {
+        init(container);
+        await new Promise((r) => setTimeout(r, 10));
+        const firstContent = container.innerHTML;
+        init(container);
+        expect(container.innerHTML).toBe(firstContent);
+    });
+
+    it('should return early for null container', () => {
+        expect(() => init(null)).not.toThrow();
+    });
+
+    it('should load and display metrics on initialization', async () => {
+        init(container);
+        await new Promise((r) => setTimeout(r, 50));
+
+        expect(document.getElementById('total-validations').textContent).toBe('100');
+        expect(document.getElementById('active-issuers').textContent).toBe('2');
+        expect(document.getElementById('avg-response-time').textContent).toBe('50 ms');
+    });
+
+    it('should render issuer metrics table', async () => {
+        init(container);
+        await new Promise((r) => setTimeout(r, 50));
+
+        const rows = document.querySelectorAll('[data-testid="issuer-metrics-row"]');
+        expect(rows.length).toBe(2);
+        expect(rows[0].querySelector('[data-testid="issuer-name"]').textContent).toBe('keycloak');
+    });
+
+    it('should render recent errors', async () => {
+        init(container);
+        await new Promise((r) => setTimeout(r, 50));
+
+        const errorList = document.getElementById('error-metrics-list');
+        expect(errorList.querySelector('.error-metric-item')).not.toBeNull();
+        expect(errorList.textContent).toContain('Token expired');
+    });
+
+    it('should show no-data message when no issuer metrics', async () => {
+        api.getSecurityMetrics.mockResolvedValue({
+            totalTokensValidated: 0,
+            validTokens: 0,
+            invalidTokens: 0,
+            activeIssuers: 0,
+            issuerMetrics: [],
+            topErrors: []
+        });
+
+        init(container);
+        await new Promise((r) => setTimeout(r, 50));
+
+        const tbody = document.getElementById('issuer-metrics-list');
+        expect(tbody.textContent).toContain('No issuer data available');
+    });
+
+    it('should handle refresh button click', async () => {
+        init(container);
+        await new Promise((r) => setTimeout(r, 50));
+
+        api.getSecurityMetrics.mockClear();
+        api.getSecurityMetrics.mockResolvedValue({
+            totalTokensValidated: 200,
+            validTokens: 180,
+            invalidTokens: 20,
+            issuerMetrics: [],
+            topErrors: []
+        });
+
+        document.getElementById('refresh-metrics-btn').click();
+        await new Promise((r) => setTimeout(r, 50));
+
+        expect(api.getSecurityMetrics).toHaveBeenCalled();
+    });
+
+    it('should toggle export options on export button click', async () => {
+        init(container);
+        await new Promise((r) => setTimeout(r, 10));
+
+        const exportBtn = document.getElementById('export-metrics-btn');
+        const exportOpts = document.getElementById('export-options');
+
+        exportBtn.click();
+        expect(exportOpts.classList.contains('visible')).toBe(true);
+
+        exportBtn.click();
+        expect(exportOpts.classList.contains('visible')).toBe(false);
+    });
+
+    it('should export metrics as JSON', async () => {
+        const mockUrl = 'blob:mock-url';
+        globalThis.URL.createObjectURL = jest.fn(() => mockUrl);
+        globalThis.URL.revokeObjectURL = jest.fn();
+
+        init(container);
+        await new Promise((r) => setTimeout(r, 50));
+
+        const clickSpy = jest.fn();
+        const origCreateElement = document.createElement.bind(document);
+        jest.spyOn(document, 'createElement').mockImplementation((tag) => {
+            const el = origCreateElement(tag);
+            if (tag === 'a') el.click = clickSpy;
+            return el;
+        });
+
+        document.querySelector('[data-format="json"]').click();
+
+        expect(globalThis.URL.createObjectURL).toHaveBeenCalled();
+        expect(clickSpy).toHaveBeenCalled();
+
+        document.createElement.mockRestore();
+    });
+
+    it('should export metrics as CSV', async () => {
+        globalThis.URL.createObjectURL = jest.fn(() => 'blob:mock');
+        globalThis.URL.revokeObjectURL = jest.fn();
+
+        init(container);
+        await new Promise((r) => setTimeout(r, 50));
+
+        const clickSpy = jest.fn();
+        const origCreateElement = document.createElement.bind(document);
+        jest.spyOn(document, 'createElement').mockImplementation((tag) => {
+            const el = origCreateElement(tag);
+            if (tag === 'a') el.click = clickSpy;
+            return el;
+        });
+
+        document.querySelector('[data-format="csv"]').click();
+
+        expect(globalThis.URL.createObjectURL).toHaveBeenCalled();
+        document.createElement.mockRestore();
+    });
+
+    it('should export metrics as Prometheus format', async () => {
+        globalThis.URL.createObjectURL = jest.fn(() => 'blob:mock');
+        globalThis.URL.revokeObjectURL = jest.fn();
+
+        init(container);
+        await new Promise((r) => setTimeout(r, 50));
+
+        const clickSpy = jest.fn();
+        const origCreateElement = document.createElement.bind(document);
+        jest.spyOn(document, 'createElement').mockImplementation((tag) => {
+            const el = origCreateElement(tag);
+            if (tag === 'a') el.click = clickSpy;
+            return el;
+        });
+
+        document.querySelector('[data-format="prometheus"]').click();
+
+        expect(globalThis.URL.createObjectURL).toHaveBeenCalled();
+        document.createElement.mockRestore();
+    });
+
+    it('should show error banner when API fails', async () => {
+        api.getSecurityMetrics.mockRejectedValue(new Error('Network error'));
+
+        init(container);
+        await new Promise((r) => setTimeout(r, 50));
+
+        const banner = document.querySelector('.metrics-status-banner.server-error');
+        expect(banner).not.toBeNull();
+        expect(banner.textContent).toContain('Unable to load metrics');
+    });
+
+    it('should show not-available banner for 404 and stop polling', async () => {
+        const error = new Error('Not Found');
+        error.status = 404;
+        api.getSecurityMetrics.mockRejectedValue(error);
+
+        init(container);
+        await new Promise((r) => setTimeout(r, 50));
+
+        const banner = document.querySelector('.metrics-status-banner.validation-error');
+        expect(banner).not.toBeNull();
+        expect(banner.textContent).toContain('Metrics Not Available');
+    });
+
+    it('should cleanup interval on cleanup()', async () => {
+        init(container);
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(() => cleanup()).not.toThrow();
+        expect(() => cleanup()).not.toThrow(); // Double cleanup should be safe
+    });
+
+    it('should handle unknown export format gracefully', async () => {
+        globalThis.URL.createObjectURL = jest.fn(() => 'blob:mock');
+        globalThis.URL.revokeObjectURL = jest.fn();
+
+        init(container);
+        await new Promise((r) => setTimeout(r, 50));
+
+        // Create a button with unknown format and click it
+        const exportOpts = document.getElementById('export-options');
+        const unknownBtn = document.createElement('button');
+        unknownBtn.setAttribute('data-format', 'unknown');
+        exportOpts.appendChild(unknownBtn);
+
+        unknownBtn.click();
+
+        // Should not have created a download (default branch returns early)
+        expect(globalThis.URL.createObjectURL).not.toHaveBeenCalled();
+    });
+
+    it('should show no-errors message when no recent errors', async () => {
+        api.getSecurityMetrics.mockResolvedValue({
+            totalTokensValidated: 10,
+            validTokens: 10,
+            invalidTokens: 0,
+            issuerMetrics: [],
+            topErrors: []
+        });
+
+        init(container);
+        await new Promise((r) => setTimeout(r, 50));
+
+        const errList = document.getElementById('error-metrics-list');
+        expect(errList.textContent).toContain('No recent errors');
+    });
+});

--- a/nifi-cuioss-ui/src/test/js/nifi-common-init.test.js
+++ b/nifi-cuioss-ui/src/test/js/nifi-common-init.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+/**
+ * Tests for nifi-common-init.js — NiFi Common API shim.
+ */
+
+describe('nifi-common-init', () => {
+    const originalNf = globalThis.nf;
+    const originalNfCommon = globalThis.nfCommon;
+
+    afterEach(() => {
+        // Restore original state
+        if (originalNf !== undefined) globalThis.nf = originalNf;
+        else delete globalThis.nf;
+        if (originalNfCommon !== undefined) globalThis.nfCommon = originalNfCommon;
+        else delete globalThis.nfCommon;
+
+        // Clear module cache so nifi-common-init.js re-executes
+        jest.resetModules();
+    });
+
+    it('should map nf.Common to nfCommon when nf.Common is available', () => {
+        const mockCommon = { registerCustomUiTab: jest.fn(), getI18n: jest.fn() };
+        globalThis.nf = { Common: mockCommon };
+        delete globalThis.nfCommon;
+
+        require('../../main/webapp/js/nifi-common-init.js');
+
+        expect(globalThis.nfCommon).toBe(mockCommon);
+    });
+
+    it('should create minimal stub when nf is not available', () => {
+        delete globalThis.nf;
+        delete globalThis.nfCommon;
+
+        require('../../main/webapp/js/nifi-common-init.js');
+
+        expect(globalThis.nfCommon).toBeDefined();
+        expect(typeof globalThis.nfCommon.registerCustomUiTab).toBe('function');
+        expect(typeof globalThis.nfCommon.getI18n).toBe('function');
+    });
+
+    it('should provide getI18n stub that returns key as property value', () => {
+        delete globalThis.nf;
+        delete globalThis.nfCommon;
+
+        require('../../main/webapp/js/nifi-common-init.js');
+
+        const i18n = globalThis.nfCommon.getI18n();
+        expect(i18n.getProperty('some.key')).toBe('some.key');
+    });
+
+    it('should not overwrite existing nfCommon', () => {
+        delete globalThis.nf;
+        const existing = { custom: true };
+        globalThis.nfCommon = existing;
+
+        require('../../main/webapp/js/nifi-common-init.js');
+
+        expect(globalThis.nfCommon).toBe(existing);
+    });
+});

--- a/nifi-cuioss-ui/src/test/js/token-verifier.test.js
+++ b/nifi-cuioss-ui/src/test/js/token-verifier.test.js
@@ -1,0 +1,204 @@
+'use strict';
+
+/**
+ * Tests for token-verifier.js — Token Verification tab component.
+ */
+
+jest.mock('../../main/webapp/js/api.js');
+jest.mock('../../main/webapp/js/utils.js');
+
+// eslint-disable-next-line no-unused-vars
+import { init } from '../../main/webapp/js/token-verifier.js';
+import * as api from '../../main/webapp/js/api.js';
+import * as utils from '../../main/webapp/js/utils.js';
+
+describe('token-verifier', () => {
+    let container;
+
+    beforeEach(() => {
+        // Re-apply mock implementations (resetMocks clears them between tests)
+        utils.sanitizeHtml.mockImplementation((s) => s);
+        utils.displayUiError.mockImplementation(() => {});
+        utils.confirmClearForm.mockImplementation((cb) => cb());
+        // eslint-disable-next-line no-import-assign -- Jest auto-mock requires manual log stub
+        utils.log = { info: jest.fn(), debug: jest.fn(), error: jest.fn(), warn: jest.fn() };
+
+        container = document.createElement('div');
+        container.id = 'token-verification';
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('should initialize the token verification UI', () => {
+        init(container);
+
+        expect(container.querySelector('.token-verification-container')).not.toBeNull();
+        expect(container.querySelector('#field-token-input')).not.toBeNull();
+        expect(container.querySelector('.verify-token-button')).not.toBeNull();
+        expect(container.querySelector('.clear-token-button')).not.toBeNull();
+    });
+
+    it('should not re-initialize if already initialized', () => {
+        init(container);
+        const firstContent = container.innerHTML;
+        init(container);
+        expect(container.innerHTML).toBe(firstContent);
+    });
+
+    it('should return early for null container', () => {
+        expect(() => init(null)).not.toThrow();
+    });
+
+    it('should show error when verifying empty token', async () => {
+        init(container);
+        container.querySelector('.verify-token-button').click();
+
+        await new Promise((r) => setTimeout(r, 0));
+
+        expect(utils.displayUiError).toHaveBeenCalledWith(
+            expect.any(Element), null, {}, 'processor.jwt.noTokenProvided'
+        );
+    });
+
+    it('should call verifyToken API and render valid results', async () => {
+        const mockResult = {
+            valid: true,
+            decoded: {
+                header: { alg: 'RS256', typ: 'JWT' },
+                payload: { sub: 'user1', iss: 'test-issuer', exp: Math.floor(Date.now() / 1000) + 3600 }
+            }
+        };
+        api.verifyToken.mockResolvedValue(mockResult);
+
+        init(container);
+        container.querySelector('#field-token-input').value = 'test.jwt.token';
+        container.querySelector('.verify-token-button').click();
+        await new Promise((r) => setTimeout(r, 10));
+
+        const results = container.querySelector('.token-results-content');
+        expect(results.querySelector('.verification-status.valid')).not.toBeNull();
+        expect(results.textContent).toContain('Token is valid');
+    });
+
+    it('should render invalid status for invalid token', async () => {
+        const mockResult = {
+            valid: false,
+            decoded: { header: { alg: 'RS256' }, payload: {} },
+            error: 'Signature verification failed'
+        };
+        api.verifyToken.mockResolvedValue(mockResult);
+
+        init(container);
+        container.querySelector('#field-token-input').value = 'invalid.jwt.token';
+        container.querySelector('.verify-token-button').click();
+        await new Promise((r) => setTimeout(r, 10));
+
+        const results = container.querySelector('.token-results-content');
+        expect(results.querySelector('.verification-status.invalid')).not.toBeNull();
+    });
+
+    it('should render expired status for expired token', async () => {
+        const mockResult = {
+            valid: true,
+            decoded: {
+                header: { alg: 'RS256' },
+                payload: { exp: Math.floor(Date.now() / 1000) - 3600 }
+            }
+        };
+        api.verifyToken.mockResolvedValue(mockResult);
+
+        init(container);
+        container.querySelector('#field-token-input').value = 'expired.jwt.token';
+        container.querySelector('.verify-token-button').click();
+        await new Promise((r) => setTimeout(r, 10));
+
+        const results = container.querySelector('.token-results-content');
+        expect(results.querySelector('.verification-status.expired')).not.toBeNull();
+    });
+
+    it('should display error when API call fails', async () => {
+        const error = new Error('Network error');
+        api.verifyToken.mockRejectedValue(error);
+
+        init(container);
+        container.querySelector('#field-token-input').value = 'test.jwt.token';
+        container.querySelector('.verify-token-button').click();
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(utils.displayUiError).toHaveBeenCalledWith(
+            expect.any(Element), error, {}
+        );
+    });
+
+    it('should clear form when clear button is clicked', () => {
+        init(container);
+        const tokenInput = container.querySelector('#field-token-input');
+        tokenInput.value = 'some-token';
+        container.querySelector('.token-results-content').innerHTML = 'Some results';
+
+        container.querySelector('.clear-token-button').click();
+
+        expect(utils.confirmClearForm).toHaveBeenCalled();
+        expect(tokenInput.value).toBe('');
+        expect(container.querySelector('.token-results-content').innerHTML).toBe('');
+    });
+
+    it('should render result without decoded section', async () => {
+        const mockResult = { valid: true };
+        api.verifyToken.mockResolvedValue(mockResult);
+
+        init(container);
+        container.querySelector('#field-token-input').value = 'minimal.jwt.token';
+        container.querySelector('.verify-token-button').click();
+        await new Promise((r) => setTimeout(r, 10));
+
+        const results = container.querySelector('.token-results-content');
+        expect(results.querySelector('.verification-status.valid')).not.toBeNull();
+        expect(results.querySelector('.token-details')).toBeNull();
+    });
+
+    it('should render result with header only (no payload)', async () => {
+        const mockResult = {
+            valid: true,
+            decoded: { header: { alg: 'RS256' } }
+        };
+        api.verifyToken.mockResolvedValue(mockResult);
+
+        init(container);
+        container.querySelector('#field-token-input').value = 'header-only.jwt.token';
+        container.querySelector('.verify-token-button').click();
+        await new Promise((r) => setTimeout(r, 10));
+
+        const results = container.querySelector('.token-results-content');
+        expect(results.textContent).toContain('Header');
+        expect(results.querySelector('.claims-table')).toBeNull();
+    });
+
+    it('should render claims with issuer and subject', async () => {
+        const mockResult = {
+            valid: true,
+            decoded: {
+                header: { alg: 'RS256' },
+                payload: {
+                    sub: 'user@example.com',
+                    iss: 'https://issuer.example.com',
+                    exp: Math.floor(Date.now() / 1000) + 3600
+                }
+            }
+        };
+        api.verifyToken.mockResolvedValue(mockResult);
+
+        init(container);
+        container.querySelector('#field-token-input').value = 'test.jwt.token';
+        container.querySelector('.verify-token-button').click();
+        await new Promise((r) => setTimeout(r, 10));
+
+        const results = container.querySelector('.token-results-content');
+        expect(results.textContent).toContain('Issuer:');
+        expect(results.textContent).toContain('Subject:');
+        expect(results.textContent).toContain('Expiration:');
+    });
+});


### PR DESCRIPTION
## Summary

- Remove `role="presentation"` from 4 `div.tab-item` elements in `index.html` — fixes 4 Web:S6819 Sonar violations introduced by PR #111
- Add comprehensive Jest tests for 5 previously untested JS modules: `app.js`, `issuer-config.js`, `metrics.js`, `token-verifier.js`, `nifi-common-init.js`
- Extend `utils.test.js` with branch coverage tests (responseText parsing, URL/token length limits, dialog Escape key, success auto-remove)
- JS test count: 57 existing -> 128 total (+71 new tests)
- JS coverage: ~28% -> 96.95% lines, 75.75% branches (all thresholds met)

## Test plan

- [x] `npm test -- --coverage` passes (128/128 tests, all coverage thresholds met)
- [x] `npm run lint` passes (0 errors, 7 pre-existing warnings)
- [x] `./mvnw -Ppre-commit clean install -DskipTests` passes
- [x] `./mvnw clean install` passes
- [ ] CI build passes
- [ ] SonarQube Quality Gate passes (expect 0 new violations, improved new_coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)