### PR TITLE
fix: use .first() for strict locator in E2E processor interaction test

### DIFF
--- a/e-2-e-playwright/tests/self-processor-advanced.spec.js
+++ b/e-2-e-playwright/tests/self-processor-advanced.spec.js
@@ -229,9 +229,7 @@ test.describe("Self-Test: Processor Advanced Configuration", () => {
             await page.waitForLoadState("networkidle");
 
             // Verify processor is still visible and functional
-            const verifyLocator =
-                processor.locator || page.locator(processor.element).first();
-            await expect(verifyLocator).toBeVisible({
+            await expect(locator).toBeVisible({
                 timeout: 5000,
             });
         } else {


### PR DESCRIPTION
## Summary

- Fix Playwright strict mode violation in `self-processor-advanced.spec.js` line 232
- The processor element locator (`g.processor, rect.processor`) matches multiple elements on the NiFi canvas, causing `toBeVisible()` to fail with strict mode error
- Apply `.first()` consistently — the same pattern already used at line 220 in the same test

## Test plan

- [ ] CI E2E tests pass (the failing test should now resolve correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)