### PR TITLE
fix: update release workflow to v0.2.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: write
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-release.yml@d38bc3643f0d0faa34ece1c2d854cf97f9a0abd4 # v0.2.8
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-release.yml@421483d5b133e02e6d6f1a0f2e800bedb7869122 # v0.2.9
     secrets:
       RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
       RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Update `release.yml` to pin `cuioss-organization` reusable workflow at **v0.2.9** (was v0.2.8)

## Root Cause
The release [run #21911665885](https://github.com/cuioss/nifi-extensions/actions/runs/21911665885) failed at the `site:site site:stage` step because:

1. `release:prepare` bumps all POM versions to `0.2.0-SNAPSHOT` and commits
2. `site:site` then tries to build `nifi-cuioss-ui` which depends on `nifi-cuioss-processors:0.2.0-SNAPSHOT`
3. That artifact doesn't exist in any repo (local or remote) — build fails

**v0.2.9** of the reusable workflow adds `./mvnw install -DskipTests` between `release:prepare` and `site:site` to populate the local Maven repo with the SNAPSHOT artifacts.

## Test plan
- [x] Verified v0.2.9 workflow contains the install step
- [ ] After merge, re-trigger the release via `workflow_dispatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)