### PR TITLE
fix: disable nexus-staging-maven-plugin from NiFi parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,6 +346,16 @@
     <build>
         <pluginManagement>
             <plugins>
+                <!-- Disable nexus-staging-maven-plugin inherited from NiFi parent POM.
+                     It targets repository.apache.org which is not our deployment target.
+                     We use central-publishing-maven-plugin for Sonatype Central instead. -->
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <configuration>
+                        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                    </configuration>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
## Summary
- Disable `nexus-staging-maven-plugin` inherited from NiFi parent POM (`nifi-extension-bundles:2.6.0`)

## Root Cause
The second release attempt ([run #21912997821](https://github.com/cuioss/nifi-extensions/actions/runs/21912997821)) failed at `release:perform` with:

```
Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.7.0:deploy
  Server credentials with ID "repository.apache.org" not found!
```

The NiFi parent POM configures `nexus-staging-maven-plugin` with `<extensions>true</extensions>` to deploy to Apache's Nexus (`repository.apache.org`). This hijacks the `deploy` lifecycle phase, conflicting with our `central-publishing-maven-plugin` which targets Sonatype Central.

## Fix
Set `skipNexusStagingDeployMojo=true` in `pluginManagement` so the inherited plugin is disabled and `central-publishing-maven-plugin` handles deployment.

## Test plan
- [x] `./mvnw -Ppre-commit clean install -DskipTests` passes
- [x] `./mvnw clean install` passes (all tests green)
- [x] Verified effective POM shows `skipNexusStagingDeployMojo=true`
- [ ] After merge, re-trigger release via `workflow_dispatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)