### PR TITLE
fix: skip deploy for e-2-e-playwright module

### DIFF
--- a/e-2-e-playwright/pom.xml
+++ b/e-2-e-playwright/pom.xml
@@ -16,6 +16,8 @@
     <description>End-to-End Playwright tests for NiFi Extensions</description>
 
     <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
         <docker.script.dir>${project.basedir}/../integration-testing/src/main/docker</docker.script.dir>
         <nifi.base.url>https://localhost:9095/nifi</nifi.base.url>
         <keycloak.url>http://localhost:9080</keycloak.url>


### PR DESCRIPTION
## Summary
- Skip Maven deploy/install for `e-2-e-playwright` module (test-only, not a publishable artifact)

## Root Cause
Release [run #21913978327](https://github.com/cuioss/nifi-extensions/actions/runs/21913978327) failed at `release:perform` because `central-publishing-maven-plugin` tried to publish the `e-2-e-playwright` POM to Maven Central, which was rejected.

The `integration-testing` module already had `maven.deploy.skip=true` but `e-2-e-playwright` was missing it.

## Test plan
- [x] Matches existing pattern in `integration-testing/pom.xml`
- [ ] After merge, re-trigger release via `workflow_dispatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)