### PR TITLE
fix: configure maven-release-plugin releaseProfiles for inner build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,6 +346,16 @@
     <build>
         <pluginManagement>
             <plugins>
+                <!-- Configure maven-release-plugin to pass release profiles to inner build.
+                     Without this, release:perform runs 'deploy' without -Prelease, causing
+                     all modules (including e-2-e-playwright) to be built and published. -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <configuration>
+                        <releaseProfiles>release,javadoc</releaseProfiles>
+                    </configuration>
+                </plugin>
                 <!-- Disable nexus-staging-maven-plugin inherited from NiFi parent POM.
                      It targets repository.apache.org which is not our deployment target.
                      We use central-publishing-maven-plugin for Sonatype Central instead. -->


### PR DESCRIPTION
## Summary
- Configures `maven-release-plugin` with `<releaseProfiles>release,javadoc</releaseProfiles>` so that `release:perform` activates the `release` profile in its inner Maven build
- Without this, the inner build runs `deploy` on ALL modules (including `e-2-e-playwright`), and the `central-publishing-maven-plugin` tries to publish the test module to Maven Central, failing the release

## Root cause
The reusable workflow passes `-Prelease,javadoc` to the outer `release:perform` invocation, but `release:perform` spawns a **separate Maven process** for the checked-out tag. The inner process does not inherit `-P` from the outer one — it needs `releaseProfiles` configured in the plugin.

## Context
This is the 4th release blocker found during the 0.1.0 release (PRs #123, #124, #125).

## Test plan
- [ ] CI build passes
- [ ] Re-trigger release workflow and verify `release:perform` inner build only includes 4 modules (not e-2-e-playwright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)