### PR TITLE
fix: exclude e-2-e-playwright from release reactor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,14 +346,18 @@
     <build>
         <pluginManagement>
             <plugins>
-                <!-- Configure maven-release-plugin to pass release profiles to inner build.
-                     Without this, release:perform runs 'deploy' without -Prelease, causing
-                     all modules (including e-2-e-playwright) to be built and published. -->
+                <!-- Configure maven-release-plugin for Sonatype Central publishing.
+                     - releaseProfiles: activate release/javadoc profiles in inner build
+                     - arguments: exclude e-2-e-playwright from reactor since Maven profile
+                       modules are additive (cannot remove modules from the default list).
+                       The central-publishing-maven-plugin aggregates ALL reactor modules
+                       and publishes them, so test-only modules must be excluded via -pl. -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <configuration>
                         <releaseProfiles>release,javadoc</releaseProfiles>
+                        <arguments>-pl !e-2-e-playwright</arguments>
                     </configuration>
                 </plugin>
                 <!-- Disable nexus-staging-maven-plugin inherited from NiFi parent POM.


### PR DESCRIPTION
## Summary
- Adds `-pl !e-2-e-playwright` to `maven-release-plugin` arguments to exclude the test module from the Maven reactor during release
- The `central-publishing-maven-plugin` with `<extensions>true</extensions>` aggregates ALL reactor modules into a single deployment — test modules must be excluded from the reactor itself

## Why releaseProfiles alone doesn't work
Maven profile `<modules>` are **additive** — they merge with the default module list but cannot remove modules. The `release` profile's module list (which omits e-2-e-playwright) has no effect because e-2-e-playwright is already in the top-level `<modules>`.

## What -pl !e-2-e-playwright does
- During `release:prepare` goals (`clean verify`): excludes e-2-e-playwright from verification (safe — it's a test module)
- During `release:perform` goals (`deploy`): excludes e-2-e-playwright from the deployment reactor
- Version transformations are unaffected — the release plugin handles POM version bumps directly, independent of `-pl`

## Context
5th release fix for 0.1.0 (PRs #123-#126). Previous attempt confirmed `releaseProfiles` alone doesn't exclude modules.

## Test plan
- [ ] CI passes
- [ ] Release workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)