### PR TITLE
fix: add missing POM names and exclude integration-testing from release

### DIFF
--- a/nifi-cuioss-nar/pom.xml
+++ b/nifi-cuioss-nar/pom.xml
@@ -24,6 +24,7 @@
     </parent>
 
     <artifactId>nifi-cuioss-nar</artifactId>
+    <name>nifi-cuioss-nar</name>
     <version>1.0-SNAPSHOT</version>
     <packaging>nar</packaging>
 

--- a/nifi-cuioss-processors/pom.xml
+++ b/nifi-cuioss-processors/pom.xml
@@ -23,6 +23,7 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-cuioss-processors</artifactId>
+    <name>nifi-cuioss-processors</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/nifi-cuioss-ui/pom.xml
+++ b/nifi-cuioss-ui/pom.xml
@@ -23,6 +23,7 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
     <artifactId>nifi-cuioss-ui</artifactId>
+    <name>nifi-cuioss-ui</name>
     <packaging>war</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,7 @@
             <plugins>
                 <!-- Configure maven-release-plugin for Sonatype Central publishing.
                      - releaseProfiles: activate release/javadoc profiles in inner build
-                     - arguments: exclude e-2-e-playwright from reactor since Maven profile
+                     - arguments: exclude test-only modules from reactor since Maven profile
                        modules are additive (cannot remove modules from the default list).
                        The central-publishing-maven-plugin aggregates ALL reactor modules
                        and publishes them, so test-only modules must be excluded via -pl. -->
@@ -357,7 +357,7 @@
                     <artifactId>maven-release-plugin</artifactId>
                     <configuration>
                         <releaseProfiles>release,javadoc</releaseProfiles>
-                        <arguments>-pl !e-2-e-playwright</arguments>
+                        <arguments>-pl !e-2-e-playwright,!integration-testing</arguments>
                     </configuration>
                 </plugin>
                 <!-- Disable nexus-staging-maven-plugin inherited from NiFi parent POM.


### PR DESCRIPTION
## Summary
- Added `<name>` elements to `nifi-cuioss-processors`, `nifi-cuioss-ui`, and `nifi-cuioss-nar` POMs (required by Sonatype Central for publishing)
- Excluded `integration-testing` from release reactor (`-pl !e-2-e-playwright,!integration-testing`) since it's a test-only module

## Context
Release attempt #6 (run 21917919152) successfully excluded `e-2-e-playwright` via PR #127's `-pl` fix, but the deployment bundle was rejected by Sonatype Central because:
1. All three publishable modules were missing the required `<name>` POM element
2. `integration-testing` was still in the reactor and included in the deployment bundle

## Test plan
- [ ] CI builds pass
- [ ] Trigger release workflow after merge and verify successful publication to Maven Central

🤖 Generated with [Claude Code](https://claude.com/claude-code)