### PR TITLE
fix: disable Maven site deployment during release

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -21,7 +21,7 @@ sonar:
 
 pages:
   reference: nifi-extensions
-  deploy-at-release: true
+  deploy-at-release: false
 
 github-automation:
   auto-merge-build-versions: true


### PR DESCRIPTION
## Summary
- Disable `pages.deploy-at-release` in project.yml since Maven site is not generated during the release build

## Context
Release attempt #7 (run 21918953940) **successfully published artifacts to Maven Central** but the workflow failed at "Deploy Maven Site" because `target/site` doesn't exist. This blocked the tag push and GitHub release creation.

## Test plan
- [ ] CI passes
- [ ] Trigger release and verify tag + GitHub release are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)