### PR TITLE
refactor: simplify Maven release POM structure

### DIFF
--- a/integration-testing/pom.xml
+++ b/integration-testing/pom.xml
@@ -52,21 +52,6 @@
 
     <build>
         <plugins>
-            <!-- This module is for testing only and should never be released to any Maven or Docker repository -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-install-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/nifi-cuioss-nar/pom.xml
+++ b/nifi-cuioss-nar/pom.xml
@@ -30,6 +30,8 @@
 
     <properties>
         <!-- Enforcer plugin configuration will be handled by parent -->
+        <maven.source.skip>true</maven.source.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
 
     <dependencies>

--- a/nifi-cuioss-ui/pom.xml
+++ b/nifi-cuioss-ui/pom.xml
@@ -29,6 +29,8 @@
     <properties>
         <enforcer.skip>true</enforcer.skip>
         <sonar.javascript.lcov.reportPaths>target/coverage/lcov.info</sonar.javascript.lcov.reportPaths>
+        <maven.source.skip>true</maven.source.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <maven.compiler.plugin.version>3.14.1</maven.compiler.plugin.version>
         <maven.gpg.plugin.version>3.2.8</maven.gpg.plugin.version>
         <maven.exec.plugin.version>3.6.2</maven.exec.plugin.version>
-        <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
         <sonar.maven.plugin.version>5.2.0.4988</sonar.maven.plugin.version>
         <jacoco.maven.plugin.version>0.8.14</jacoco.maven.plugin.version>
         <!-- Sonatype -->
@@ -348,16 +348,15 @@
             <plugins>
                 <!-- Configure maven-release-plugin for Sonatype Central publishing.
                      - releaseProfiles: activate release/javadoc profiles in inner build
-                     - arguments: exclude test-only modules from reactor since Maven profile
-                       modules are additive (cannot remove modules from the default list).
-                       The central-publishing-maven-plugin aggregates ALL reactor modules
-                       and publishes them, so test-only modules must be excluded via -pl. -->
+                     - arguments: exclude e-2-e-playwright from reactor (npm build fails
+                       in release context). Other test-only modules stay in reactor but are
+                       excluded from Central bundle via excludeArtifacts. -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <configuration>
                         <releaseProfiles>release,javadoc</releaseProfiles>
-                        <arguments>-pl !e-2-e-playwright,!integration-testing</arguments>
+                        <arguments>-pl !e-2-e-playwright</arguments>
                     </configuration>
                 </plugin>
                 <!-- Disable nexus-staging-maven-plugin inherited from NiFi parent POM.
@@ -419,6 +418,10 @@
                         <publishingServerId>central</publishingServerId>
                         <autoPublish>true</autoPublish>
                         <waitUntil>published</waitUntil>
+                        <excludeArtifacts>
+                            <excludeArtifact>nifi-cuioss-ui</excludeArtifact>
+                            <excludeArtifact>integration-testing</excludeArtifact>
+                        </excludeArtifacts>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -623,13 +626,6 @@
         </profile>
         <profile>
             <id>release-snapshot</id>
-            <modules>
-                <module>nifi-cuioss-processors</module>
-                <module>nifi-cuioss-ui</module>
-                <module>nifi-cuioss-nar</module>
-                <module>integration-testing</module>
-                <!-- e-2-e-playwright module excluded from release snapshots -->
-            </modules>
             <build>
                 <plugins>
                     <plugin>
@@ -653,13 +649,6 @@
         </profile>
         <profile>
             <id>release</id>
-            <modules>
-                <module>nifi-cuioss-processors</module>
-                <module>nifi-cuioss-ui</module>
-                <module>nifi-cuioss-nar</module>
-                <module>integration-testing</module>
-                <!-- e-2-e-playwright module excluded from releases -->
-            </modules>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
## Summary

Closes #130

- Upgrade `central-publishing-maven-plugin` from `0.9.0` to `0.10.0` which adds `excludeArtifacts` support
- Use `excludeArtifacts` to exclude `nifi-cuioss-ui` and `integration-testing` from the Central publishing bundle, replacing the `-pl` reactor exclusion workaround for `integration-testing`
- Remove dead `<modules>` blocks from `release` and `release-snapshot` profiles (Maven profile modules are additive — these could not actually remove modules from the default list)
- Skip source/javadoc JAR generation for NAR and WAR modules (no meaningful content)
- Remove redundant `maven-deploy-plugin` and `maven-install-plugin` skip configurations from `integration-testing` (properties already handle this)

Net result: **-35 lines, +13 lines** — cleaner POM with fewer workarounds and less dead code.

## Test plan

- [x] `./mvnw -Ppre-commit clean install -DskipTests` passes
- [x] `./mvnw clean install` full build with tests passes
- [x] No source/javadoc JARs generated for NAR and WAR modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)