### PR TITLE
fix: correct E2E reports-folder path

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -23,10 +23,6 @@ pages:
   reference: nifi-extensions
   deploy-at-release: false
 
-integration-tests:
-  deploy-reports: true
-  maven-profiles: integration-tests
-
 github-automation:
   auto-merge-build-versions: true
   auto-merge-build-timeout: 300

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,7 +19,7 @@ jobs:
       maven-module: e-2-e-playwright
       timeout-minutes: 20
       npm-cache: true
-      reports-folder: e-2-e-playwright/target/playwright-report
+      reports-folder: e-2-e-playwright/target/test-results
       reports-subfolder: nifi-extensions/e2e-reports
     secrets:
       RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}


### PR DESCRIPTION
## Summary
- Fix `reports-folder` in `e2e-tests.yml` from `e-2-e-playwright/target/playwright-report` (non-existent) to `e-2-e-playwright/target/test-results` (actual Playwright output)
- Remove redundant `integration-tests` section from `project.yml` — both `deploy-reports: true` and `maven-profiles: integration-tests` already match the reusable workflow defaults

## Test plan
- [ ] CI passes on this branch (no workflow behavior change expected since deploy requires cuioss/cuioss-organization#92)
- [ ] Verify `project.yml` still works for integration-tests workflow with defaults

Closes #138 (partially — deploy will work once cuioss/cuioss-organization#92 is resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)