### PR TITLE
chore: add Dependabot cooldown and update auto-merge to v0.5.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,19 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 1
 
   - package-ecosystem: npm
     directory: "/nifi-cuioss-processors"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 1

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   auto-merge:
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-dependabot-auto-merge.yml@7f9eecb85e04771d0dacfe2b102fd094558eff1d # v0.4.0
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-dependabot-auto-merge.yml@fbb87b2940f43cd3c6907c194dbbd437b2a78aa4 # v0.5.0
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

- Add tiered cooldown to `dependabot.yml` (patch: 1d, minor: 3d, major: 7d) as supply chain security measure
- Update auto-merge caller to v0.5.0 — now auto-merges all minor/patch updates (major requires manual review)

## Test plan

- [ ] CI passes
- [ ] dependabot.yml is valid YAML with cooldown on all ecosystems
- [ ] Auto-merge workflow references correct SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)