### PR TITLE
fix(ui): export missing route fields and persist tracking-mode on new routes

### DIFF
--- a/nifi-cuioss-common/src/main/java/de/cuioss/nifi/jwt/util/AuthorizationRequirements.java
+++ b/nifi-cuioss-common/src/main/java/de/cuioss/nifi/jwt/util/AuthorizationRequirements.java
@@ -22,7 +22,6 @@ import org.apache.nifi.processor.util.StandardValidators;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -126,7 +125,7 @@ Set<String> requiredScopes) {
 
     private static Set<String> parseCommaSeparated(@Nullable String value) {
         if (value == null || value.isBlank()) {
-            return Collections.emptySet();
+            return Set.of();
         }
         return Arrays.stream(value.split(","))
                 .map(String::trim)

--- a/nifi-cuioss-common/src/main/java/de/cuioss/nifi/jwt/util/AuthorizationValidator.java
+++ b/nifi-cuioss-common/src/main/java/de/cuioss/nifi/jwt/util/AuthorizationValidator.java
@@ -21,7 +21,10 @@ import lombok.Builder;
 import lombok.experimental.UtilityClass;
 import org.jspecify.annotations.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * Validates JWT token authorization using the oauth-sheriff API
@@ -64,7 +67,7 @@ public class AuthorizationValidator {
         if (!requirements.hasAuthorizationRequirements()) {
             return AuthorizationResult.builder()
                     .authorized(true)
-                    .missingScopes(Collections.emptySet()).missingRoles(Collections.emptySet())
+                    .missingScopes(Set.of()).missingRoles(Set.of())
                     .build();
         }
 
@@ -75,9 +78,9 @@ public class AuthorizationValidator {
         boolean hasRoleReqs = !requiredRoles.isEmpty();
 
         Set<String> missingScopes = hasScopeReqs
-                ? token.determineMissingScopes(requiredScopes) : Collections.emptySet();
+                ? token.determineMissingScopes(requiredScopes) : Set.of();
         Set<String> missingRoles = hasRoleReqs
-                ? token.determineMissingRoles(requiredRoles) : Collections.emptySet();
+                ? token.determineMissingRoles(requiredRoles) : Set.of();
 
         boolean scopesOk = !hasScopeReqs || missingScopes.isEmpty();
         boolean rolesOk = !hasRoleReqs || missingRoles.isEmpty();

--- a/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/service/JwtValidationService.java
+++ b/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/service/JwtValidationService.java
@@ -30,7 +30,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.apache.nifi.web.NiFiWebConfigurationContext;
 import org.jspecify.annotations.Nullable;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import static de.cuioss.nifi.jwt.util.TokenMasking.maskToken;
 
@@ -387,7 +390,7 @@ public class JwtValidationService {
 
                 return claims;
             }
-            return Collections.emptyMap();
+            return Map.of();
         }
     }
 

--- a/nifi-cuioss-ui/src/main/webapp/js/rest-endpoint-config.js
+++ b/nifi-cuioss-ui/src/main/webapp/js/rest-endpoint-config.js
@@ -1615,6 +1615,13 @@ const buildRouteExportLines = (data, props) => {
     if (authModeValue) lines.push(`${p}.auth-mode = ${authModeValue}`);
     if (!enabled) lines.push(`${p}.enabled = false`);
 
+    const requiredRoles = props?.['required-roles'];
+    if (requiredRoles) lines.push(`${p}.required-roles = ${requiredRoles}`);
+    const requiredScopes = props?.['required-scopes'];
+    if (requiredScopes) lines.push(`${p}.required-scopes = ${requiredScopes}`);
+    const maxRequestSize = props?.['max-request-size'];
+    if (maxRequestSize) lines.push(`${p}.max-request-size = ${maxRequestSize}`);
+
     if (outcomeDash) {
         lines.push(`${p}.create-flowfile = false`);
     } else if (outcomeText) {
@@ -1907,7 +1914,11 @@ const addRowToTable = (routesContainer, formData, componentId, origin = 'new') =
         'max-request-size': formData['max-request-size'] || '',
         schema: formData.schema,
         'success-outcome': formData['success-outcome'] || '',
-        'create-flowfile': formData['create-flowfile'] === false ? 'false' : 'true'
+        'create-flowfile': formData['create-flowfile'] === false ? 'false' : 'true',
+        'tracking-mode': formData['tracking-mode'] || 'none',
+        'attachments-min-count': formData['attachments-min-count'] || '',
+        'attachments-max-count': formData['attachments-max-count'] || '',
+        'attachments-timeout': formData['attachments-timeout'] || ''
     };
     const row = createTableRow(formData.routeName, props, componentId, routesContainer, origin);
     tbody.appendChild(row);

--- a/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/service/JwtValidationServiceTest.java
+++ b/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/service/JwtValidationServiceTest.java
@@ -391,7 +391,7 @@ class JwtValidationServiceTest {
             ComponentDetails details = new ComponentDetails.Builder()
                     .id(processorId)
                     .type("SomeProcessor")
-                    .properties(Collections.emptyMap())
+                    .properties(Map.of())
                     .build();
 
             expect(mockConfigContext.getComponentDetails(anyObject(NiFiWebRequestContext.class)))

--- a/nifi-cuioss-ui/src/test/js/rest-endpoint-config.test.js
+++ b/nifi-cuioss-ui/src/test/js/rest-endpoint-config.test.js
@@ -1338,6 +1338,84 @@ describe('rest-endpoint-config', () => {
         expect(textarea.value).toContain('success-outcome = api-data');
     });
 
+    it('should include required-roles in export text when route has them', async () => {
+        api.getComponentProperties.mockResolvedValue({
+            properties: SAMPLE_PROPERTIES,
+            revision: { version: 1 }
+        });
+        api.updateComponentProperties.mockResolvedValue({});
+
+        await init(container);
+
+        // Trigger export refresh by saving the data route (index 1 — has required-roles="admin")
+        container.querySelectorAll('.edit-route-button')[1].click();
+        container.querySelector('.save-route-button').click();
+        await tick();
+
+        const textarea = container.querySelector('.property-export-textarea');
+        expect(textarea.value).toContain('restapi.data.required-roles = admin');
+    });
+
+    it('should include required-scopes in export text when route has them', async () => {
+        api.getComponentProperties.mockResolvedValue({
+            properties: SAMPLE_PROPERTIES,
+            revision: { version: 1 }
+        });
+        api.updateComponentProperties.mockResolvedValue({});
+
+        await init(container);
+
+        container.querySelectorAll('.edit-route-button')[1].click();
+        container.querySelector('.save-route-button').click();
+        await tick();
+
+        const textarea = container.querySelector('.property-export-textarea');
+        expect(textarea.value).toContain('restapi.data.required-scopes = read,write');
+    });
+
+    it('should include max-request-size in export text when route has it', async () => {
+        api.getComponentProperties.mockResolvedValue({
+            properties: {
+                ...SAMPLE_PROPERTIES,
+                'restapi.data.max-request-size': '2097152'
+            },
+            revision: { version: 1 }
+        });
+        api.updateComponentProperties.mockResolvedValue({});
+
+        await init(container);
+
+        container.querySelectorAll('.edit-route-button')[1].click();
+        container.querySelector('.save-route-button').click();
+        await tick();
+
+        const textarea = container.querySelector('.property-export-textarea');
+        expect(textarea.value).toContain('restapi.data.max-request-size = 2097152');
+    });
+
+    it('should omit required-roles/required-scopes/max-request-size in export when empty', async () => {
+        api.getComponentProperties.mockResolvedValue({
+            properties: SAMPLE_PROPERTIES,
+            revision: { version: 1 }
+        });
+        api.updateComponentProperties.mockResolvedValue({});
+
+        await init(container);
+
+        // health route (index 0) has empty required-roles and required-scopes
+        container.querySelector('.edit-route-button').click();
+        container.querySelector('.save-route-button').click();
+        await tick();
+
+        const textarea = container.querySelector('.property-export-textarea');
+        const healthLines = textarea.value.split('\n').filter((l) => l.startsWith('restapi.health.'));
+        for (const line of healthLines) {
+            expect(line).not.toContain('.required-roles');
+            expect(line).not.toContain('.required-scopes');
+            expect(line).not.toContain('.max-request-size');
+        }
+    });
+
     // -----------------------------------------------------------------------
     // Management endpoint export
     // -----------------------------------------------------------------------
@@ -2671,6 +2749,84 @@ describe('rest-endpoint-config', () => {
 
         // Badge should now appear
         expect(dataRow.querySelector('.tracking-badge')).not.toBeNull();
+    });
+
+    it('should persist tracking-mode in export when creating a new route', async () => {
+        api.getComponentProperties.mockResolvedValue({
+            properties: SAMPLE_PROPERTIES,
+            revision: { version: 1 }
+        });
+        api.updateComponentProperties.mockResolvedValue({});
+
+        await init(container);
+
+        // Add new route via "add route" button
+        container.querySelector('.add-route-button').click();
+        const form = container.querySelector('.route-form');
+        form.querySelector('.route-name').value = 'new-tracked';
+        form.querySelector('.field-path').value = '/api/new-tracked';
+        form.querySelector('.field-methods').value = 'POST';
+        form.querySelector('.tracking-mode-select').value = 'simple';
+
+        form.querySelector('.save-route-button').click();
+        await tick();
+
+        const textarea = container.querySelector('.property-export-textarea');
+        expect(textarea.value).toContain('restapi.new-tracked.tracking-mode = simple');
+    });
+
+    it('should retain tracking-mode in dropdown when reopening a newly created route', async () => {
+        api.getComponentProperties.mockResolvedValue({
+            properties: SAMPLE_PROPERTIES,
+            revision: { version: 1 }
+        });
+        api.updateComponentProperties.mockResolvedValue({});
+
+        await init(container);
+
+        // Add new route with tracking-mode=simple
+        container.querySelector('.add-route-button').click();
+        let form = container.querySelector('.route-form');
+        form.querySelector('.route-name').value = 'new-tracked';
+        form.querySelector('.field-path').value = '/api/new-tracked';
+        form.querySelector('.field-methods').value = 'POST';
+        form.querySelector('.tracking-mode-select').value = 'simple';
+        form.querySelector('.save-route-button').click();
+        await tick();
+
+        // Reopen the newly-created route for editing
+        const newRow = container.querySelector('tr[data-route-name="new-tracked"]');
+        newRow.querySelector('.edit-route-button').click();
+        form = container.querySelector('.route-form');
+
+        expect(form.querySelector('.tracking-mode-select').value).toBe('simple');
+    });
+
+    it('should persist attachments bounds in export when creating a new route', async () => {
+        api.getComponentProperties.mockResolvedValue({
+            properties: SAMPLE_PROPERTIES,
+            revision: { version: 1 }
+        });
+        api.updateComponentProperties.mockResolvedValue({});
+
+        await init(container);
+
+        // Add new route with tracking-mode=attachments + bounds
+        container.querySelector('.add-route-button').click();
+        const form = container.querySelector('.route-form');
+        form.querySelector('.route-name').value = 'new-attached';
+        form.querySelector('.field-path').value = '/api/new-attached';
+        form.querySelector('.field-methods').value = 'POST';
+        form.querySelector('.tracking-mode-select').value = 'attachments';
+        form.querySelector('.field-attachments-min-count').value = '2';
+        form.querySelector('.field-attachments-max-count').value = '4';
+        form.querySelector('.save-route-button').click();
+        await tick();
+
+        const textarea = container.querySelector('.property-export-textarea');
+        expect(textarea.value).toContain('restapi.new-attached.tracking-mode = attachments');
+        expect(textarea.value).toContain('restapi.new-attached.attachments-min-count = 2');
+        expect(textarea.value).toContain('restapi.new-attached.attachments-max-count = 4');
     });
 
     it('should show attachment bounds fields only when mode is attachments', async () => {


### PR DESCRIPTION
## Summary

Two related defects in `rest-endpoint-config.js` dropped route fields from the property export and reset the tracking-mode dropdown on new routes:

- **`buildRouteExportLines`** never emitted `required-roles`, `required-scopes`, or `max-request-size`, even though they were stored on `row._routeProps` and sent to NiFi.
- **`addRowToTable`** (used when creating a new route) omitted `tracking-mode` and `attachments-*` from the props object — export lacked those lines and reopening the editor showed `tracking-mode="none"`.

## Changes

- `rest-endpoint-config.js:1618-1623`: emit the three missing fields in `buildRouteExportLines` when non-empty.
- `rest-endpoint-config.js:1907-1922`: copy `tracking-mode` and `attachments-*` into props inside `addRowToTable`.
- Added 7 tests (TDD red → green) in `rest-endpoint-config.test.js`.
- Separate commit: OpenRewrite auto-cleanup applied by the pre-commit profile (`Collections.emptyX` → `X.of()`, star-import expansion).

## Test plan

- [x] New tests for all 3 missing export fields + empty-omission case (4 tests)
- [x] New tests for new-route tracking-mode export line + dropdown re-display + attachments bounds (3 tests)
- [x] Full `rest-endpoint-config` Jest suite passes (143 tests)
- [x] `./mvnw -Ppre-commit clean install -DskipTests` passes
- [x] `./mvnw clean install -pl nifi-cuioss-ui -am` passes