### PR TITLE
chore: integrate plan-marshall build system configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,9 +34,9 @@ jest_stdout.log
 !.claude/skills/
 
 # Planning system (managed by /marshall-steward)
+# Runtime state (plans, run-configuration, lessons-learned, memory, logs — managed by plan-marshall)
 .plan/*
 !.plan/marshal.json
 !.plan/project-structure.json
-
-# Planning system (managed by /marshall-steward)
 !.plan/project-architecture/
+.plan/local/worktrees/

--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -1,0 +1,219 @@
+{
+  "plan": {
+    "effort": "level-3",
+    "open_in_ide": true,
+    "coverage": {
+      "thoroughness": "inherit",
+      "scope": "inherit"
+    },
+    "phase-1-init": {
+      "branch_strategy": "feature",
+      "use_worktree": true,
+      "effort": "level-3",
+      "init_without_asking": true,
+      "deep_lane": "auto",
+      "escalation": "auto"
+    },
+    "phase-2-refine": {
+      "confidence_threshold": 95,
+      "compatibility": "breaking",
+      "simplicity": "lean",
+      "effort": "level-3",
+      "revalidation": "auto"
+    },
+    "phase-3-outline": {
+      "plan_without_asking": false,
+      "qgate": "auto",
+      "effort": "level-4"
+    },
+    "phase-4-plan": {
+      "execute_without_asking": true,
+      "effort": "level-3"
+    },
+    "phase-5-execute": {
+      "commit_and_push": true,
+      "max_iterations": 5,
+      "per_deliverable_build": "compile+scoped-test",
+      "per_task_budget_reserve_tokens": "50K",
+      "steps": [
+        "default:quality_check",
+        "default:build_verify"
+      ],
+      "effort": {
+        "default": "level-4",
+        "verification-feedback": "level-3"
+      }
+    },
+    "phase-6-finalize": {
+      "max_iterations": 3,
+      "review_bot_buffer_seconds": 180,
+      "pr_merge_strategy": "squash",
+      "finalize_without_asking": true,
+      "loop_back_without_asking": false,
+      "auto_merge_after_ci": true,
+      "self_review": "auto",
+      "qgate": "auto",
+      "plugin_doctor": "auto",
+      "simplify": "auto",
+      "checks_wait_timeout_seconds": 600,
+      "auto_rebase_threshold": "no_overlap_only",
+      "drop_review_on_scope_gate": false,
+      "steps": [
+        "default:pre-push-quality-gate",
+        "default:finalize-step-simplify",
+        "default:finalize-step-whole-tree-gate",
+        "default:commit-push",
+        "default:create-pr",
+        "default:ci-verify",
+        "default:automated-review",
+        "default:sonar-roundtrip",
+        "default:lessons-capture",
+        "default:branch-cleanup",
+        "default:record-metrics",
+        "default:finalize-step-print-phase-breakdown",
+        "default:archive-plan"
+      ],
+      "effort": {
+        "default": "level-3",
+        "verification-feedback": "level-3",
+        "post-run-review": "level-4"
+      }
+    }
+  },
+  "build": {
+    "queue": {
+      "max_slots": 5,
+      "max_retries": 10,
+      "upper_limit_seconds": 600
+    },
+    "map": {
+      "java": [
+        {
+          "glob": "*/src/main/*.java",
+          "role": "production",
+          "build_class": "compile"
+        },
+        {
+          "glob": "*/src/test/*.java",
+          "role": "test",
+          "build_class": "module-tests"
+        },
+        {
+          "glob": "pom.xml",
+          "role": "config",
+          "build_class": "verify"
+        }
+      ],
+      "javascript": [
+        {
+          "glob": "*.js",
+          "role": "production",
+          "build_class": "compile"
+        },
+        {
+          "glob": "*.spec.js",
+          "role": "test",
+          "build_class": "module-tests"
+        },
+        {
+          "glob": "*.test.js",
+          "role": "test",
+          "build_class": "module-tests"
+        },
+        {
+          "glob": "package.json",
+          "role": "config",
+          "build_class": "verify"
+        }
+      ]
+    }
+  },
+  "project": {
+    "default_base_branch": "main",
+    "working_prefixes": [
+      "feature/",
+      "fix/",
+      "chore/"
+    ]
+  },
+  "providers": [
+    {
+      "skill_name": "plan-marshall:workflow-integration-sonar",
+      "category": "other",
+      "description": "SonarCloud/SonarQube code analysis platform",
+      "url": "https://sonarcloud.io"
+    },
+    {
+      "skill_name": "plan-marshall:workflow-integration-github",
+      "category": "ci",
+      "verify_command": "gh auth status",
+      "description": "GitHub CI provider via gh CLI — PRs, issues, CI status, reviews",
+      "url": "https://api.github.com"
+    },
+    {
+      "skill_name": "plan-marshall:workflow-integration-git",
+      "category": "version-control",
+      "verify_command": "git config user.name",
+      "description": "Git version control via git CLI — commit, push, branch operations",
+      "url": "https://github.com/cuioss/nifi-extensions.git"
+    }
+  ],
+  "skill_domains": {
+    "system": {
+      "defaults": [],
+      "optionals": [],
+      "execute_task_skills": {
+        "documentation": "plan-marshall:execute-task",
+        "implementation": "plan-marshall:execute-task",
+        "module_testing": "plan-marshall:execute-task"
+      }
+    },
+    "java": {
+      "bundle": "pm-dev-java",
+      "workflow_skill_extensions": {
+        "triage": "pm-dev-java:ext-triage-java"
+      }
+    },
+    "java-cui": {
+      "bundle": "pm-dev-java-cui"
+    },
+    "javascript": {
+      "bundle": "pm-dev-frontend",
+      "workflow_skill_extensions": {
+        "triage": "pm-dev-frontend:ext-triage-js"
+      }
+    },
+    "documentation": {
+      "bundle": "pm-documents",
+      "workflow_skill_extensions": {
+        "triage": "pm-documents:ext-triage-docs"
+      },
+      "project_skills": [
+        "project:update-guide-screenshots"
+      ]
+    },
+    "general-dev": {
+      "bundle": "plan-marshall"
+    },
+    "active_profiles": [
+      "implementation",
+      "module_testing",
+      "quality"
+    ]
+  },
+  "system": {
+    "retention": {
+      "logs_days": 1,
+      "archived_plans_days": 5,
+      "lessons_superseded_days": 0,
+      "temp_on_maintenance": true
+    }
+  },
+  "credentials_config": {
+    "plan-marshall:workflow-integration-sonar": {
+      "url": "https://sonarcloud.io",
+      "organization": "cuioss",
+      "project_key": "cuioss_nifi-extensions"
+    }
+  }
+}

--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -212,7 +212,7 @@
   "credentials_config": {
     "plan-marshall:workflow-integration-sonar": {
       "url": "https://sonarcloud.io",
-      "organization": "cuioss",
+      "organization": "cuioss-github",
       "project_key": "cuioss_nifi-extensions"
     }
   }

--- a/.plan/project-architecture/_project.json
+++ b/.plan/project-architecture/_project.json
@@ -1,0 +1,24 @@
+{
+  "description": "Custom Apache NiFi extensions providing a self-contained REST API gateway (RestApiGatewayProcessor) with an embedded Jetty server, route-based dispatching and per-route JWT authorization, plus a MultiIssuerJWTTokenAuthenticator for FlowFile-based JWT validation. Both share JWT validation via a common JwtIssuerConfigService controller service supporting multiple identity providers (Keycloak, Entra ID, Auth0), shipped as NiFi NAR bundles with a web-based configuration UI.",
+  "description_reasoning": "README.adoc + doc/README.adoc",
+  "extensions_used": [
+    "plan-marshall",
+    "pm-documents"
+  ],
+  "modules": {
+    "documentation": {},
+    "e-2-e-playwright-maven": {},
+    "e-2-e-playwright-npm": {},
+    "integration-testing": {},
+    "nifi-cuioss-api": {},
+    "nifi-cuioss-api-nar": {},
+    "nifi-cuioss-common": {},
+    "nifi-cuioss-nar": {},
+    "nifi-cuioss-processors": {},
+    "nifi-cuioss-rest-processors": {},
+    "nifi-cuioss-ui-maven": {},
+    "nifi-cuioss-ui-npm": {},
+    "nifi-extensions": {}
+  },
+  "name": "nifi-extensions"
+}

--- a/.plan/project-architecture/documentation/enriched.json
+++ b/.plan/project-architecture/documentation/enriched.json
@@ -1,0 +1,46 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {
+    "doc.architecture": {
+      "description": "Architecture overviews: module relationships, gateway request pipeline, JWT processor lifecycle, and standards compliance."
+    },
+    "doc.plantuml": {
+      "description": "PlantUML diagram sources and generation script for architecture and request-tracking diagrams."
+    },
+    "doc.reference": {
+      "description": "Reference material: property tables, configuration formats, RFC 9457 error types, and request-tracking/attachments API specs."
+    }
+  },
+  "purpose": "runtime",
+  "purpose_reasoning": "documentation-only module, no compiled artifact; closest non-code role",
+  "responsibility": "Project documentation set in AsciiDoc covering architecture overviews, processor selection guides, configuration/error/request-tracking reference, and PlantUML diagram generation.",
+  "responsibility_reasoning": "README (doc/README.adoc)",
+  "skills_by_profile": {
+    "documentation": {
+      "defaults": [
+        {
+          "description": "AsciiDoc formatting, validation, link verification, and template creation",
+          "skill": "pm-documents:ref-asciidoc"
+        },
+        {
+          "description": "Content quality, tone analysis, organization standards, and review orchestration",
+          "skill": "pm-documents:ref-documentation"
+        },
+        {
+          "description": "Narrative styles for technical documentation \u2014 tone, voice, and arc per surface (concept pages, user guides, spec references)",
+          "skill": "pm-documents:ref-narrative-styles"
+        },
+        {
+          "description": "SVG diagram authoring standards \u2014 visual language, theme handling, AsciiDoc embedding, per-diagram-type patterns",
+          "skill": "pm-documents:ref-svg-diagrams"
+        }
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "wizard architectural enrichment; post domain-config skills_by_profile population",
+  "tips": []
+}

--- a/.plan/project-architecture/e-2-e-playwright-maven/enriched.json
+++ b/.plan/project-architecture/e-2-e-playwright-maven/enriched.json
@@ -1,0 +1,81 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [
+    "e-2-e-playwright-npm"
+  ],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "Maven module drives the npm Playwright project",
+  "key_packages": {},
+  "purpose": "integration-tests",
+  "purpose_reasoning": "pom wrapper around E2E test project, runs in integration-tests profile",
+  "responsibility": "Maven wrapper module that orchestrates the Playwright E2E test suite within the Maven reactor and integration-test lifecycle, delegating execution to the sibling npm project.",
+  "responsibility_reasoning": "README (e-2-e-playwright/README.adoc) + pom packaging=pom",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:dev-general-module-testing"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "wizard architectural enrichment; post domain-config skills_by_profile population",
+  "tips": []
+}

--- a/.plan/project-architecture/e-2-e-playwright-npm/enriched.json
+++ b/.plan/project-architecture/e-2-e-playwright-npm/enriched.json
@@ -1,0 +1,82 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [
+    "@playwright/test",
+    "@axe-core/playwright",
+    "eslint"
+  ],
+  "key_dependencies_reasoning": "Playwright drives browser E2E; axe-core powers WCAG accessibility checks",
+  "key_packages": {
+    "fixtures": {
+      "description": "Playwright test fixtures for authentication and shared test setup."
+    },
+    "tests": {
+      "description": "Playwright spec files covering configuration/JWKS/token-verification/metrics/help/gateway tabs, context help, WCAG compliance, and self-tests."
+    },
+    "utils": {
+      "description": "Test support utilities: auth/keycloak token services, processor API manager, navigation helpers, accessibility helper, and critical-error detection."
+    }
+  },
+  "purpose": "integration-tests",
+  "purpose_reasoning": "only test specs and test utilities, no shipped artifact",
+  "responsibility": "Playwright end-to-end and WCAG accessibility test suite validating JWT processor behavior, custom UI components/tabs, and login against a live NiFi + Keycloak environment.",
+  "responsibility_reasoning": "README (e-2-e-playwright/README.adoc) + tests/ specs",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core JavaScript development standards covering ES modules, modern patterns, and code quality",
+          "skill": "pm-dev-frontend:javascript"
+        }
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:dev-general-module-testing"
+        },
+        {
+          "description": "Core JavaScript development standards covering ES modules, modern patterns, and code quality",
+          "skill": "pm-dev-frontend:javascript"
+        },
+        {
+          "description": "JavaScript unit testing with Jest, DOM testing, mocking, async patterns",
+          "skill": "pm-dev-frontend:jest-testing"
+        }
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        }
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "wizard architectural enrichment; post domain-config skills_by_profile population",
+  "tips": []
+}

--- a/.plan/project-architecture/integration-testing/enriched.json
+++ b/.plan/project-architecture/integration-testing/enriched.json
@@ -1,0 +1,83 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {
+    "de.cuioss.nifi.integration": {
+      "description": "Failsafe integration tests (AttachmentFlowIT, RestApiGatewayIT, NiFiFlowPipelineIT, NiFiProcessorMetricsIT, CustomUIEndpointsIT, KeycloakRealmConfigIT) plus shared test support against the dockerized NiFi+Keycloak stack."
+    }
+  },
+  "purpose": "integration-tests",
+  "purpose_reasoning": "jar with only test sources (IT classes) and Docker orchestration scripts",
+  "responsibility": "Docker-based integration test environment providing containerized NiFi (HTTPS) and Keycloak instances, with Failsafe ITs exercising JWT validation, the REST API gateway, attachment flows, metrics, and custom UI endpoints against real JWT tokens.",
+  "responsibility_reasoning": "README (integration-testing/README.adoc) + test sources",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:dev-general-module-testing"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "wizard architectural enrichment; post domain-config skills_by_profile population",
+  "tips": []
+}

--- a/.plan/project-architecture/nifi-cuioss-api-nar/enriched.json
+++ b/.plan/project-architecture/nifi-cuioss-api-nar/enriched.json
@@ -1,0 +1,81 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [
+    "nifi-cuioss-api"
+  ],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "NAR bundles the API jar for NiFi classloader separation",
+  "key_packages": {},
+  "purpose": "extension",
+  "purpose_reasoning": "NAR bundle packaging the Controller Service API for NiFi deployment",
+  "responsibility": "NiFi Archive (NAR) bundling the nifi-cuioss-api Controller Service API types. Required as a standalone NAR so NiFi 2.x can load the Controller Service interface separately from its implementation NAR.",
+  "responsibility_reasoning": "inferred from source (packaging=nar, depends on nifi-cuioss-api)",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:dev-general-module-testing"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "wizard architectural enrichment; post domain-config skills_by_profile population",
+  "tips": []
+}

--- a/.plan/project-architecture/nifi-cuioss-api/enriched.json
+++ b/.plan/project-architecture/nifi-cuioss-api/enriched.json
@@ -1,0 +1,83 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {
+    "de.cuioss.nifi.jwt.config": {
+      "description": "Public Controller Service contract: JwtIssuerConfigService interface and the JwtAuthenticationConfig configuration record shared across processors and the implementation."
+    }
+  },
+  "purpose": "library",
+  "purpose_reasoning": "jar exposing API interface/record types consumed by processors and impl",
+  "responsibility": "Controller Service API types: the JwtIssuerConfigService interface and JwtAuthenticationConfig record. Packaged separately to satisfy NiFi 2.x classloader separation between Controller Service APIs and their implementations.",
+  "responsibility_reasoning": "README (nifi-cuioss-api/README.adoc)",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:dev-general-module-testing"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "wizard architectural enrichment; post domain-config skills_by_profile population",
+  "tips": []
+}

--- a/.plan/project-architecture/nifi-cuioss-common/enriched.json
+++ b/.plan/project-architecture/nifi-cuioss-common/enriched.json
@@ -1,0 +1,94 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [
+    "nifi-cuioss-api"
+  ],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "Implements the JwtIssuerConfigService API contract",
+  "key_packages": {
+    "de.cuioss.nifi.jwt": {
+      "description": "Shared cross-cutting constants and contracts: JwtAttributes, JwtConstants, JwtPropertyKeys, JwtTranslationKeys, and JwtLogMessages."
+    },
+    "de.cuioss.nifi.jwt.config": {
+      "description": "Controller Service implementation and configuration: StandardJwtIssuerConfigService, ConfigurationManager, and IssuerConfigurationParser that build JWT validation config from NiFi properties."
+    },
+    "de.cuioss.nifi.jwt.i18n": {
+      "description": "Internationalization resolution (I18nResolver, NiFiI18nResolver) for UI labels and processor messages."
+    },
+    "de.cuioss.nifi.jwt.util": {
+      "description": "Reusable JWT utilities: AuthorizationValidator/Requirements, TokenClaimMapper, TokenMasking, DynamicPropertyGroupParser, and error modeling (ErrorContext, ProcessingError)."
+    }
+  },
+  "purpose": "library",
+  "purpose_reasoning": "jar of shared implementation code consumed by processor and rest modules",
+  "responsibility": "Shared JWT infrastructure: the StandardJwtIssuerConfigService implementation, configuration management and issuer parsing, authorization validation, token claim mapping/masking, dynamic property parsing, and i18n resolution reused by both processors and the UI.",
+  "responsibility_reasoning": "README (nifi-cuioss-common/README.adoc)",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:dev-general-module-testing"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "wizard architectural enrichment; post domain-config skills_by_profile population",
+  "tips": []
+}

--- a/.plan/project-architecture/nifi-cuioss-nar/enriched.json
+++ b/.plan/project-architecture/nifi-cuioss-nar/enriched.json
@@ -1,0 +1,84 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [
+    "nifi-cuioss-processors",
+    "nifi-cuioss-rest-processors",
+    "nifi-cuioss-common",
+    "nifi-cuioss-ui-maven"
+  ],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "Bundles processor implementations, shared infrastructure, and the UI WAR into the deployable NAR",
+  "key_packages": {},
+  "purpose": "deployment",
+  "purpose_reasoning": "NAR bundle that packages processors+impl+UI for NiFi deployment",
+  "responsibility": "Primary NiFi Archive (NAR) deployment bundle aggregating the processors, the Controller Service implementation, the configuration UI WAR, and all runtime dependencies into a single deployable unit for NiFi 2.x.",
+  "responsibility_reasoning": "inferred from source (packaging=nar) + README.adoc installation section",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:dev-general-module-testing"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "wizard architectural enrichment; post domain-config skills_by_profile population",
+  "tips": []
+}

--- a/.plan/project-architecture/nifi-cuioss-processors/enriched.json
+++ b/.plan/project-architecture/nifi-cuioss-processors/enriched.json
@@ -1,0 +1,86 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [
+    "nifi-cuioss-api",
+    "nifi-cuioss-common"
+  ],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "Uses the JwtIssuerConfigService API and shared JWT infrastructure for validation",
+  "key_packages": {
+    "de.cuioss.nifi.processors.auth": {
+      "description": "MultiIssuerJWTTokenAuthenticator FlowFile-based JWT validation processor plus its constants and log messages."
+    }
+  },
+  "purpose": "library",
+  "purpose_reasoning": "jar of NiFi processor implementation classes, bundled into nifi-cuioss-nar",
+  "responsibility": "Hosts the MultiIssuerJWTTokenAuthenticator processor that validates JWT tokens from a configurable FlowFile attribute against multiple identity providers and routes FlowFiles to success or authentication-failed.",
+  "responsibility_reasoning": "README (nifi-cuioss-processors/README.adoc)",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:dev-general-module-testing"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "wizard architectural enrichment; post domain-config skills_by_profile population",
+  "tips": []
+}

--- a/.plan/project-architecture/nifi-cuioss-rest-processors/enriched.json
+++ b/.plan/project-architecture/nifi-cuioss-rest-processors/enriched.json
@@ -1,0 +1,95 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [
+    "nifi-cuioss-api",
+    "nifi-cuioss-common"
+  ],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "Reuses JwtIssuerConfigService API and shared JWT/authorization utilities for per-route auth",
+  "key_packages": {
+    "de.cuioss.nifi.rest": {
+      "description": "RestApiGatewayProcessor entry point with gateway constants, FlowFile attributes, and log messages."
+    },
+    "de.cuioss.nifi.rest.config": {
+      "description": "Gateway configuration model: RouteConfiguration and its parser, AuthMode, and TrackingMode enums driving per-route behavior."
+    },
+    "de.cuioss.nifi.rest.handler": {
+      "description": "HTTP request handling pipeline: route dispatch (ApiRouteHandler), management endpoints (health/metrics/status/attachments), RFC 9457 ProblemDetail, request sanitization, and async request-status tracking store."
+    },
+    "de.cuioss.nifi.rest.server": {
+      "description": "Embedded Jetty lifecycle management (JettyServerManager) hosting the gateway HTTP server inside the processor."
+    }
+  },
+  "purpose": "library",
+  "purpose_reasoning": "jar of NiFi processor + embedded-server code, bundled into nifi-cuioss-nar",
+  "responsibility": "Hosts the RestApiGatewayProcessor: a self-contained REST API gateway embedding a Jetty 12 server with route-based dispatching, per-route JWT authorization, RFC 9457 error responses, request-tracking/attachment handling, and management endpoints (/metrics, /health, /status).",
+  "responsibility_reasoning": "README (nifi-cuioss-rest-processors/README.adoc) + gateway.adoc",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:dev-general-module-testing"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "wizard architectural enrichment; post domain-config skills_by_profile population",
+  "tips": []
+}

--- a/.plan/project-architecture/nifi-cuioss-ui-maven/enriched.json
+++ b/.plan/project-architecture/nifi-cuioss-ui-maven/enriched.json
@@ -1,0 +1,92 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [
+    "nifi-cuioss-api",
+    "nifi-cuioss-common"
+  ],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "UI servlets validate tokens and read issuer config via the shared JWT API and infrastructure",
+  "key_packages": {
+    "de.cuioss.nifi.ui.service": {
+      "description": "JwtValidationService backing the UI's token verification and JWKS endpoint testing features."
+    },
+    "de.cuioss.nifi.ui.servlets": {
+      "description": "Backend servlets and filters: JwksValidationServlet, JwtVerificationServlet, ComponentInfoServlet, GatewayProxyServlet, plus SecurityHeadersFilter and ProcessorIdValidationFilter."
+    },
+    "de.cuioss.nifi.ui.util": {
+      "description": "ComponentConfigReader and UI utilities for reading processor/controller-service configuration exposed to the UI."
+    }
+  },
+  "purpose": "runtime",
+  "purpose_reasoning": "war providing the runtime web UI entry point served inside NiFi",
+  "responsibility": "Web configuration UI packaged as a WAR: Java servlets and filters (JWKS/JWT verification, component-info, gateway proxy, security headers, processor-id validation) backing the JavaScript configuration front-end for the processors.",
+  "responsibility_reasoning": "inferred from source (packaging=war, servlets package) + project README",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:dev-general-module-testing"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "wizard architectural enrichment; post domain-config skills_by_profile population",
+  "tips": []
+}

--- a/.plan/project-architecture/nifi-cuioss-ui-npm/enriched.json
+++ b/.plan/project-architecture/nifi-cuioss-ui-npm/enriched.json
@@ -1,0 +1,75 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [
+    "jest",
+    "eslint"
+  ],
+  "key_dependencies_reasoning": "Jest unit tests and ESLint quality gates for the JavaScript UI",
+  "key_packages": {
+    "src.main.webapp.js": {
+      "description": "UI front-end modules: app bootstrap, issuer-config editor, chip inputs (auth-mode/method), endpoint/JWKS tester, REST endpoint config, metrics, context-help, and the api client."
+    }
+  },
+  "purpose": "runtime",
+  "purpose_reasoning": "browser runtime UI assets served inside NiFi; sibling of the WAR module",
+  "responsibility": "JavaScript front-end of the NiFi processor configuration UI: issuer-config editor, chip inputs, JWKS/endpoint testers, metrics view, and context help, built and unit-tested (Jest) with ESLint/Stylelint, then packaged into the UI WAR.",
+  "responsibility_reasoning": "inferred from source (src/main/webapp/js, package.json scripts)",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core JavaScript development standards covering ES modules, modern patterns, and code quality",
+          "skill": "pm-dev-frontend:javascript"
+        }
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:dev-general-module-testing"
+        },
+        {
+          "description": "Core JavaScript development standards covering ES modules, modern patterns, and code quality",
+          "skill": "pm-dev-frontend:javascript"
+        },
+        {
+          "description": "JavaScript unit testing with Jest, DOM testing, mocking, async patterns",
+          "skill": "pm-dev-frontend:jest-testing"
+        }
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        }
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "wizard architectural enrichment; post domain-config skills_by_profile population",
+  "tips": []
+}

--- a/.plan/project-architecture/nifi-extensions/enriched.json
+++ b/.plan/project-architecture/nifi-extensions/enriched.json
@@ -1,0 +1,90 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [
+    "nifi-cuioss-api",
+    "nifi-cuioss-common",
+    "nifi-cuioss-processors",
+    "nifi-cuioss-rest-processors",
+    "nifi-cuioss-ui-maven",
+    "nifi-cuioss-api-nar",
+    "nifi-cuioss-nar",
+    "integration-testing",
+    "e-2-e-playwright-maven",
+    "documentation"
+  ],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "Parent POM aggregates all build modules",
+  "key_packages": {},
+  "purpose": "parent",
+  "purpose_reasoning": "root packaging=pom aggregating 12 submodules",
+  "responsibility": "Root Maven aggregator and parent POM for the NiFi Extensions project. Defines shared build configuration, dependency management, quality-gate/coverage/integration-test profiles, and aggregates all submodules.",
+  "responsibility_reasoning": "inferred from source (root pom.xml, packaging=pom, README.adoc)",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:dev-general-module-testing"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:dev-agent-behavior-rules"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:dev-general-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging"
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "wizard architectural enrichment; post domain-config skills_by_profile population",
+  "tips": []
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,20 +13,15 @@ Custom Apache NiFi processors for JWT authentication and validation with a web-b
 
 ## Build Commands
 
-```bash
-./mvnw clean install                                    # Full build + tests
-./mvnw -Ppre-commit clean install -DskipTests           # Pre-commit quality checks (MANDATORY before commits)
-./mvnw clean verify -Psonar                             # SonarQube analysis
-./mvnw verify -Pintegration-tests -pl integration-testing -am  # Java integration tests (Docker)
-./mvnw verify -Pintegration-tests -pl e-2-e-playwright -am    # E2E Playwright tests (Docker)
+**Never hard-code build tool commands** (`./mvnw`, `npm run`, …). Invoke builds via the canonical plan-marshall executor commands below so module/profile resolution stays correct. Always use a 10-minute Bash timeout (`600000` ms) for build commands, and analyze each build's TOON result (`status`, `errors[N]{file,line,message,category}`, `log_file`) rather than scanning raw stdout.
 
-# Frontend (from nifi-cuioss-ui/)
-npm test                                                # Jest tests
-npm run lint                                            # ESLint check
-
-# E2E (from e-2-e-playwright/)
-npm run playwright:test                                 # Playwright tests
-```
+- **Compile:** `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "compile"`
+- **Quality gate:** `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Psonar"`
+- **Full verify:** `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify"`
+- **Integration tests:** `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Pintegration-tests"`
+- **Coverage:** `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Pcoverage"`
+- **Module tests (e-2-e-playwright-npm):** `python3 .plan/execute-script.py plan-marshall:build-npm:npm run --command-args "run test --prefix=e-2-e-playwright"` — only on e-2-e-playwright-npm
+- **Module tests (nifi-cuioss-ui-npm):** `python3 .plan/execute-script.py plan-marshall:build-npm:npm run --command-args "run test --prefix=nifi-cuioss-ui"` — only on nifi-cuioss-ui-npm
 
 ## Docker E2E Deployment
 
@@ -85,3 +80,8 @@ All cuioss repositories have branch protection on `main`. Direct pushes to `main
 ## Deep Reference
 
 See `doc/` for detailed architecture, configuration reference, guides, and step-by-step instructions. Key entry points: `doc/README.adoc` (documentation index), `doc/architecture/README.adoc` (module overview), `doc/reference/configuration.adoc` (all properties).
+
+## Tool Usage
+
+- Use proper tools (Edit, Read, Write) instead of shell commands (echo, cat)
+- Never use Bash for file operations (find, grep, cat, ls) — use Glob, Read, Grep tools instead


### PR DESCRIPTION
## Summary

Integrates the plan-marshall build system configuration into the repository.

- Replace hard-coded Maven/npm commands in `CLAUDE.md` with canonical plan-marshall executor commands so module/profile resolution stays correct
- Update `.gitignore` to ignore plan-marshall runtime state (plans, run-configuration, lessons-learned, memory, logs, worktrees) while tracking the committed configuration
- Add tracked plan-marshall project configuration (`.plan/marshal.json`, `.plan/project-architecture/`)
- Add a Tool Usage section to `CLAUDE.md`

## Test plan

- No code changes; documentation and configuration only