### PR TITLE
refactor(tests): align all test classes with module-testing profile standards

### DIFF
--- a/integration-testing/src/test/java/de/cuioss/nifi/integration/NiFiFlowPipelineIT.java
+++ b/integration-testing/src/test/java/de/cuioss/nifi/integration/NiFiFlowPipelineIT.java
@@ -17,6 +17,7 @@
 package de.cuioss.nifi.integration;
 
 import jakarta.json.Json;
+import jakarta.json.JsonException;
 import jakarta.json.JsonObject;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -235,7 +236,7 @@ class NiFiFlowPipelineIT {
         }
         try {
             return Json.createReader(new StringReader(body)).readObject();
-        } catch (Exception e) {
+        } catch (JsonException e) {
             fail("Failed to parse response body as JSON: " + body);
             return null; // unreachable
         }

--- a/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/JwtLogMessagesTest.java
+++ b/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/JwtLogMessagesTest.java
@@ -15,115 +15,64 @@
  */
 package de.cuioss.nifi.jwt;
 
+import de.cuioss.tools.logging.LogRecord;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("JwtLogMessages")
 class JwtLogMessagesTest {
+
+    private static final String EXPECTED_PREFIX = "JWT";
+
+    private static void assertWellFormed(LogRecord record) {
+        assertAll("LogRecord is well-formed",
+                () -> assertNotNull(record, "LogRecord should be defined"),
+                () -> assertNotNull(record.getTemplate(), "Template should be defined"),
+                () -> assertFalseBlank(record.getTemplate()),
+                () -> assertTrue(record.resolveIdentifierString().startsWith(EXPECTED_PREFIX + "-"),
+                        "Resolved identifier should carry the JWT prefix"));
+    }
+
+    private static void assertFalseBlank(String template) {
+        assertTrue(template != null && !template.isBlank(), "Template should not be blank");
+    }
 
     @Nested
     @DisplayName("INFO LogRecords")
     class InfoLogRecordsTest {
 
-        @Test
-        @DisplayName("Should initialize CONFIG_LOADED LogRecord")
-        void shouldInitializeConfigLoaded() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.INFO.CONFIG_LOADED);
+        static Stream<Arguments> infoRecords() {
+            return Stream.of(
+                    Arguments.of("CONFIG_LOADED", JwtLogMessages.INFO.CONFIG_LOADED),
+                    Arguments.of("NO_EXTERNAL_CONFIG", JwtLogMessages.INFO.NO_EXTERNAL_CONFIG),
+                    Arguments.of("CONFIG_FILE_RELOADING", JwtLogMessages.INFO.CONFIG_FILE_RELOADING),
+                    Arguments.of("NO_CONFIG_FILE", JwtLogMessages.INFO.NO_CONFIG_FILE),
+                    Arguments.of("LOADED_PROPERTIES_CONFIG", JwtLogMessages.INFO.LOADED_PROPERTIES_CONFIG),
+                    Arguments.of("LOADED_YAML_CONFIG", JwtLogMessages.INFO.LOADED_YAML_CONFIG),
+                    Arguments.of("LOADING_EXTERNAL_CONFIGS", JwtLogMessages.INFO.LOADING_EXTERNAL_CONFIGS),
+                    Arguments.of("CREATED_ISSUER_CONFIG_FOR", JwtLogMessages.INFO.CREATED_ISSUER_CONFIG_FOR),
+                    Arguments.of("ISSUER_DISABLED", JwtLogMessages.INFO.ISSUER_DISABLED),
+                    Arguments.of("TOKEN_VALIDATOR_INITIALIZED", JwtLogMessages.INFO.TOKEN_VALIDATOR_INITIALIZED),
+                    Arguments.of("CONTROLLER_SERVICE_ENABLED", JwtLogMessages.INFO.CONTROLLER_SERVICE_ENABLED),
+                    Arguments.of("CONTROLLER_SERVICE_DISABLED", JwtLogMessages.INFO.CONTROLLER_SERVICE_DISABLED),
+                    Arguments.of("METRICS_SNAPSHOT_CREATED", JwtLogMessages.INFO.METRICS_SNAPSHOT_CREATED),
+                    Arguments.of("VALIDATION_SUCCESS", JwtLogMessages.INFO.VALIDATION_SUCCESS));
         }
 
-        @Test
-        @DisplayName("Should initialize NO_EXTERNAL_CONFIG LogRecord")
-        void shouldInitializeNoExternalConfig() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.INFO.NO_EXTERNAL_CONFIG);
-        }
-
-        @Test
-        @DisplayName("Should initialize CONFIG_FILE_RELOADING LogRecord")
-        void shouldInitializeConfigFileReloading() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.INFO.CONFIG_FILE_RELOADING);
-        }
-
-        @Test
-        @DisplayName("Should initialize NO_CONFIG_FILE LogRecord")
-        void shouldInitializeNoConfigFile() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.INFO.NO_CONFIG_FILE);
-        }
-
-        @Test
-        @DisplayName("Should initialize LOADED_PROPERTIES_CONFIG LogRecord")
-        void shouldInitializeLoadedPropertiesConfig() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.INFO.LOADED_PROPERTIES_CONFIG);
-        }
-
-        @Test
-        @DisplayName("Should initialize LOADED_YAML_CONFIG LogRecord")
-        void shouldInitializeLoadedYamlConfig() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.INFO.LOADED_YAML_CONFIG);
-        }
-
-        @Test
-        @DisplayName("Should initialize LOADING_EXTERNAL_CONFIGS LogRecord")
-        void shouldInitializeLoadingExternalConfigs() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.INFO.LOADING_EXTERNAL_CONFIGS);
-        }
-
-        @Test
-        @DisplayName("Should initialize CREATED_ISSUER_CONFIG_FOR LogRecord")
-        void shouldInitializeCreatedIssuerConfigFor() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.INFO.CREATED_ISSUER_CONFIG_FOR);
-        }
-
-        @Test
-        @DisplayName("Should initialize ISSUER_DISABLED LogRecord")
-        void shouldInitializeIssuerDisabled() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.INFO.ISSUER_DISABLED);
-        }
-
-        @Test
-        @DisplayName("Should initialize TOKEN_VALIDATOR_INITIALIZED LogRecord")
-        void shouldInitializeTokenValidatorInitialized() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.INFO.TOKEN_VALIDATOR_INITIALIZED);
-        }
-
-        @Test
-        @DisplayName("Should initialize CONTROLLER_SERVICE_ENABLED LogRecord")
-        void shouldInitializeControllerServiceEnabled() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.INFO.CONTROLLER_SERVICE_ENABLED);
-        }
-
-        @Test
-        @DisplayName("Should initialize CONTROLLER_SERVICE_DISABLED LogRecord")
-        void shouldInitializeControllerServiceDisabled() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.INFO.CONTROLLER_SERVICE_DISABLED);
-        }
-
-        @Test
-        @DisplayName("Should initialize METRICS_SNAPSHOT_CREATED LogRecord")
-        void shouldInitializeMetricsSnapshotCreated() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.INFO.METRICS_SNAPSHOT_CREATED);
-        }
-
-        @Test
-        @DisplayName("Should initialize VALIDATION_SUCCESS LogRecord")
-        void shouldInitializeValidationSuccess() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.INFO.VALIDATION_SUCCESS);
+        @ParameterizedTest(name = "INFO.{0} should be a well-formed LogRecord")
+        @MethodSource("infoRecords")
+        @DisplayName("Should define well-formed INFO LogRecords")
+        void shouldDefineWellFormedInfoRecord(String name, LogRecord record) {
+            assertWellFormed(record);
         }
     }
 
@@ -131,74 +80,26 @@ class JwtLogMessagesTest {
     @DisplayName("WARN LogRecords")
     class WarnLogRecordsTest {
 
-        @Test
-        @DisplayName("Should initialize AUTHORIZATION_BYPASS_SECURITY_WARNING LogRecord")
-        void shouldInitializeAuthorizationBypassSecurityWarning() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.WARN.AUTHORIZATION_BYPASS_SECURITY_WARNING);
+        static Stream<Arguments> warnRecords() {
+            return Stream.of(
+                    Arguments.of("AUTHORIZATION_BYPASS_SECURITY_WARNING",
+                            JwtLogMessages.WARN.AUTHORIZATION_BYPASS_SECURITY_WARNING),
+                    Arguments.of("INVALID_CONFIG_VALUE", JwtLogMessages.WARN.INVALID_CONFIG_VALUE),
+                    Arguments.of("ISSUER_NO_NAME", JwtLogMessages.WARN.ISSUER_NO_NAME),
+                    Arguments.of("JWKS_CONTENT_NOT_SUPPORTED", JwtLogMessages.WARN.JWKS_CONTENT_NOT_SUPPORTED),
+                    Arguments.of("ISSUER_NO_JWKS_SOURCE", JwtLogMessages.WARN.ISSUER_NO_JWKS_SOURCE),
+                    Arguments.of("CONFIG_FILE_NOT_FOUND", JwtLogMessages.WARN.CONFIG_FILE_NOT_FOUND),
+                    Arguments.of("UNSUPPORTED_CONFIG_FORMAT", JwtLogMessages.WARN.UNSUPPORTED_CONFIG_FORMAT),
+                    Arguments.of("YAML_EMPTY_OR_INVALID", JwtLogMessages.WARN.YAML_EMPTY_OR_INVALID),
+                    Arguments.of("NO_VALID_ISSUER_CONFIGS", JwtLogMessages.WARN.NO_VALID_ISSUER_CONFIGS),
+                    Arguments.of("TOKEN_VALIDATION_FAILED", JwtLogMessages.WARN.TOKEN_VALIDATION_FAILED));
         }
 
-        @Test
-        @DisplayName("Should initialize INVALID_CONFIG_VALUE LogRecord")
-        void shouldInitializeInvalidConfigValue() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.WARN.INVALID_CONFIG_VALUE);
-        }
-
-        @Test
-        @DisplayName("Should initialize ISSUER_NO_NAME LogRecord")
-        void shouldInitializeIssuerNoName() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.WARN.ISSUER_NO_NAME);
-        }
-
-        @Test
-        @DisplayName("Should initialize JWKS_CONTENT_NOT_SUPPORTED LogRecord")
-        void shouldInitializeJwksContentNotSupported() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.WARN.JWKS_CONTENT_NOT_SUPPORTED);
-        }
-
-        @Test
-        @DisplayName("Should initialize ISSUER_NO_JWKS_SOURCE LogRecord")
-        void shouldInitializeIssuerNoJwksSource() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.WARN.ISSUER_NO_JWKS_SOURCE);
-        }
-
-        @Test
-        @DisplayName("Should initialize CONFIG_FILE_NOT_FOUND LogRecord")
-        void shouldInitializeConfigFileNotFound() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.WARN.CONFIG_FILE_NOT_FOUND);
-        }
-
-        @Test
-        @DisplayName("Should initialize UNSUPPORTED_CONFIG_FORMAT LogRecord")
-        void shouldInitializeUnsupportedConfigFormat() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.WARN.UNSUPPORTED_CONFIG_FORMAT);
-        }
-
-        @Test
-        @DisplayName("Should initialize YAML_EMPTY_OR_INVALID LogRecord")
-        void shouldInitializeYamlEmptyOrInvalid() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.WARN.YAML_EMPTY_OR_INVALID);
-        }
-
-        @Test
-        @DisplayName("Should initialize NO_VALID_ISSUER_CONFIGS LogRecord")
-        void shouldInitializeNoValidIssuerConfigs() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.WARN.NO_VALID_ISSUER_CONFIGS);
-        }
-
-        @Test
-        @DisplayName("Should initialize TOKEN_VALIDATION_FAILED LogRecord")
-        void shouldInitializeTokenValidationFailed() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.WARN.TOKEN_VALIDATION_FAILED);
+        @ParameterizedTest(name = "WARN.{0} should be a well-formed LogRecord")
+        @MethodSource("warnRecords")
+        @DisplayName("Should define well-formed WARN LogRecords")
+        void shouldDefineWellFormedWarnRecord(String name, LogRecord record) {
+            assertWellFormed(record);
         }
     }
 
@@ -206,46 +107,22 @@ class JwtLogMessagesTest {
     @DisplayName("ERROR LogRecords")
     class ErrorLogRecordsTest {
 
-        @Test
-        @DisplayName("Should initialize CONFIG_RELOAD_FAILED LogRecord")
-        void shouldInitializeConfigReloadFailed() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.ERROR.CONFIG_RELOAD_FAILED);
+        static Stream<Arguments> errorRecords() {
+            return Stream.of(
+                    Arguments.of("CONFIG_RELOAD_FAILED", JwtLogMessages.ERROR.CONFIG_RELOAD_FAILED),
+                    Arguments.of("CONFIG_FILE_IO_ERROR", JwtLogMessages.ERROR.CONFIG_FILE_IO_ERROR),
+                    Arguments.of("CONFIG_FILE_PARSE_ERROR", JwtLogMessages.ERROR.CONFIG_FILE_PARSE_ERROR),
+                    Arguments.of("ISSUER_CONFIG_PARSE_ERROR", JwtLogMessages.ERROR.ISSUER_CONFIG_PARSE_ERROR),
+                    Arguments.of("TOKEN_VALIDATION_ERROR", JwtLogMessages.ERROR.TOKEN_VALIDATION_ERROR),
+                    Arguments.of("CONTROLLER_SERVICE_ENABLE_FAILED",
+                            JwtLogMessages.ERROR.CONTROLLER_SERVICE_ENABLE_FAILED));
         }
 
-        @Test
-        @DisplayName("Should initialize CONFIG_FILE_IO_ERROR LogRecord")
-        void shouldInitializeConfigFileIoError() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.ERROR.CONFIG_FILE_IO_ERROR);
-        }
-
-        @Test
-        @DisplayName("Should initialize CONFIG_FILE_PARSE_ERROR LogRecord")
-        void shouldInitializeConfigFileParseError() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.ERROR.CONFIG_FILE_PARSE_ERROR);
-        }
-
-        @Test
-        @DisplayName("Should initialize ISSUER_CONFIG_PARSE_ERROR LogRecord")
-        void shouldInitializeIssuerConfigParseError() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.ERROR.ISSUER_CONFIG_PARSE_ERROR);
-        }
-
-        @Test
-        @DisplayName("Should initialize TOKEN_VALIDATION_ERROR LogRecord")
-        void shouldInitializeTokenValidationError() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.ERROR.TOKEN_VALIDATION_ERROR);
-        }
-
-        @Test
-        @DisplayName("Should initialize CONTROLLER_SERVICE_ENABLE_FAILED LogRecord")
-        void shouldInitializeControllerServiceEnableFailed() {
-            // Act & Assert
-            assertNotNull(JwtLogMessages.ERROR.CONTROLLER_SERVICE_ENABLE_FAILED);
+        @ParameterizedTest(name = "ERROR.{0} should be a well-formed LogRecord")
+        @MethodSource("errorRecords")
+        @DisplayName("Should define well-formed ERROR LogRecords")
+        void shouldDefineWellFormedErrorRecord(String name, LogRecord record) {
+            assertWellFormed(record);
         }
     }
 }

--- a/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/JwtLogMessagesTest.java
+++ b/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/JwtLogMessagesTest.java
@@ -37,13 +37,10 @@ class JwtLogMessagesTest {
         assertAll("LogRecord is well-formed",
                 () -> assertNotNull(record, "LogRecord should be defined"),
                 () -> assertNotNull(record.getTemplate(), "Template should be defined"),
-                () -> assertFalseBlank(record.getTemplate()),
+                () -> assertTrue(record.getTemplate() != null && !record.getTemplate().isBlank(),
+                        "Template should not be blank"),
                 () -> assertTrue(record.resolveIdentifierString().startsWith(EXPECTED_PREFIX + "-"),
                         "Resolved identifier should carry the JWT prefix"));
-    }
-
-    private static void assertFalseBlank(String template) {
-        assertTrue(template != null && !template.isBlank(), "Template should not be blank");
     }
 
     @Nested

--- a/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/config/ConfigurationManagerTest.java
+++ b/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/config/ConfigurationManagerTest.java
@@ -55,10 +55,8 @@ class ConfigurationManagerTest {
         @Test
         @DisplayName("Should initialize with configurationLoaded false when no config file exists")
         void shouldInitializeWithoutConfig() {
-            // Arrange & Act
             var configManager = new ConfigurationManager();
 
-            // Assert
             assertFalse(configManager.isConfigurationLoaded(),
                     "Configuration should not be loaded when no config file exists");
             assertTrue(configManager.getStaticProperties().isEmpty(),
@@ -75,7 +73,6 @@ class ConfigurationManagerTest {
         @Test
         @DisplayName("Should load properties file with issuer config and static props")
         void shouldLoadPropertiesFile(@TempDir Path tempDir) throws IOException {
-            // Arrange
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.properties");
             String content = """
@@ -87,10 +84,8 @@ class ConfigurationManagerTest {
                     """;
             Files.writeString(configFile, content);
 
-            // Act
             var configManager = new ConfigurationManager(basePath(tempDir));
 
-            // Assert
             assertTrue(configManager.isConfigurationLoaded(),
                     "Configuration should be loaded");
 
@@ -109,7 +104,6 @@ class ConfigurationManagerTest {
         @Test
         @DisplayName("Should load properties file with multiple issuers")
         void shouldLoadMultipleIssuersFromPropertiesFile(@TempDir Path tempDir) throws IOException {
-            // Arrange
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.properties");
             String content = """
@@ -122,10 +116,8 @@ class ConfigurationManagerTest {
                     """;
             Files.writeString(configFile, content);
 
-            // Act
             var configManager = new ConfigurationManager(basePath(tempDir));
 
-            // Assert
             List<String> issuerIds = configManager.getIssuerIds();
             assertEquals(3, issuerIds.size());
             assertTrue(issuerIds.contains("issuer1"));
@@ -141,7 +133,6 @@ class ConfigurationManagerTest {
         @Test
         @DisplayName("Should load YAML file with nested structure")
         void shouldLoadYamlFileWithNestedStructure(@TempDir Path tempDir) throws IOException {
-            // Arrange
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.yml");
             String content = """
@@ -158,10 +149,8 @@ class ConfigurationManagerTest {
                     """;
             Files.writeString(configFile, content);
 
-            // Act
             var configManager = new ConfigurationManager(basePath(tempDir));
 
-            // Assert
             assertTrue(configManager.isConfigurationLoaded());
             assertEquals("32768", configManager.getProperty("jwt.validation.max.token.size"));
 
@@ -174,7 +163,6 @@ class ConfigurationManagerTest {
         @Test
         @DisplayName("Should load YAML file with issuers list using id field")
         void shouldLoadYamlWithIssuersListUsingId(@TempDir Path tempDir) throws IOException {
-            // Arrange
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.yml");
             String content = """
@@ -190,10 +178,8 @@ class ConfigurationManagerTest {
                     """;
             Files.writeString(configFile, content);
 
-            // Act
             var configManager = new ConfigurationManager(basePath(tempDir));
 
-            // Assert
             List<String> issuerIds = configManager.getIssuerIds();
             assertEquals(2, issuerIds.size());
             assertTrue(issuerIds.contains("issuer1"));
@@ -207,7 +193,6 @@ class ConfigurationManagerTest {
         @Test
         @DisplayName("Should load YAML file with issuers list using name field when id missing")
         void shouldLoadYamlWithIssuersListUsingName(@TempDir Path tempDir) throws IOException {
-            // Arrange
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.yml");
             String content = """
@@ -221,10 +206,8 @@ class ConfigurationManagerTest {
                     """;
             Files.writeString(configFile, content);
 
-            // Act
             var configManager = new ConfigurationManager(basePath(tempDir));
 
-            // Assert
             List<String> issuerIds = configManager.getIssuerIds();
             assertEquals(2, issuerIds.size());
             assertTrue(issuerIds.contains("Issuer One"));
@@ -234,7 +217,6 @@ class ConfigurationManagerTest {
         @Test
         @DisplayName("Should load YAML file with issuers list using index when id and name missing")
         void shouldLoadYamlWithIssuersListUsingIndex(@TempDir Path tempDir) throws IOException {
-            // Arrange
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.yml");
             String content = """
@@ -246,10 +228,8 @@ class ConfigurationManagerTest {
                     """;
             Files.writeString(configFile, content);
 
-            // Act
             var configManager = new ConfigurationManager(basePath(tempDir));
 
-            // Assert
             List<String> issuerIds = configManager.getIssuerIds();
             assertEquals(2, issuerIds.size());
             assertTrue(issuerIds.contains("0"));
@@ -259,7 +239,6 @@ class ConfigurationManagerTest {
         @Test
         @DisplayName("Should skip non-map items in YAML issuers list")
         void shouldSkipNonMapItemsInIssuersList(@TempDir Path tempDir) throws IOException {
-            // Arrange
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.yml");
             String content = """
@@ -272,7 +251,6 @@ class ConfigurationManagerTest {
                     """;
             Files.writeString(configFile, content);
 
-            // Act
             var configManager = new ConfigurationManager(basePath(tempDir));
 
             // Assert — only the map item should be parsed; string item is silently skipped
@@ -284,15 +262,12 @@ class ConfigurationManagerTest {
         @Test
         @DisplayName("Should handle empty YAML file and return false")
         void shouldHandleEmptyYamlFile(@TempDir Path tempDir) throws IOException {
-            // Arrange
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.yml");
             Files.writeString(configFile, "");
 
-            // Act
             var configManager = new ConfigurationManager(basePath(tempDir));
 
-            // Assert
             assertFalse(configManager.isConfigurationLoaded(),
                     "Empty YAML file should not be considered loaded");
         }
@@ -305,7 +280,6 @@ class ConfigurationManagerTest {
         @Test
         @DisplayName("Should return false when file not modified")
         void shouldReturnFalseWhenNotModified(@TempDir Path tempDir) throws IOException {
-            // Arrange
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.properties");
             String content = """
@@ -315,17 +289,14 @@ class ConfigurationManagerTest {
 
             var configManager = new ConfigurationManager(basePath(tempDir));
 
-            // Act
             boolean reloaded = configManager.checkAndReloadConfiguration();
 
-            // Assert
             assertFalse(reloaded, "Should return false when file not modified");
         }
 
         @Test
         @DisplayName("Should return true when file modified")
         void shouldReturnTrueWhenModified(@TempDir Path tempDir) throws IOException {
-            // Arrange
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.properties");
             String content = """
@@ -347,7 +318,6 @@ class ConfigurationManagerTest {
             await().atMost(2, SECONDS)
                     .until(configManager::checkAndReloadConfiguration);
 
-            // Assert
             assertEquals("65536", configManager.getProperty("jwt.validation.max.token.size"));
         }
     }
@@ -359,33 +329,26 @@ class ConfigurationManagerTest {
         @Test
         @DisplayName("Should return null for missing key")
         void shouldReturnNullForMissingKey() {
-            // Arrange
             var configManager = new ConfigurationManager();
 
-            // Act
             String value = configManager.getProperty("non.existent.key");
 
-            // Assert
             assertNull(value, "Should return null for missing key");
         }
 
         @Test
         @DisplayName("Should return default value for missing key")
         void shouldReturnDefaultForMissingKey() {
-            // Arrange
             var configManager = new ConfigurationManager();
 
-            // Act
             String value = configManager.getProperty("non.existent.key", "default-value");
 
-            // Assert
             assertEquals("default-value", value, "Should return default value for missing key");
         }
 
         @Test
         @DisplayName("Should return actual value when key exists")
         void shouldReturnActualValue(@TempDir Path tempDir) throws IOException {
-            // Arrange
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.properties");
             String content = """
@@ -395,10 +358,8 @@ class ConfigurationManagerTest {
 
             var configManager = new ConfigurationManager(basePath(tempDir));
 
-            // Act
             String value = configManager.getProperty("jwt.validation.max.token.size", "default");
 
-            // Assert
             assertEquals("32768", value, "Should return actual value when key exists");
         }
     }
@@ -410,7 +371,6 @@ class ConfigurationManagerTest {
         @Test
         @DisplayName("Should return list of issuer IDs")
         void shouldReturnIssuerIds(@TempDir Path tempDir) throws IOException {
-            // Arrange
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.properties");
             String content = """
@@ -422,10 +382,8 @@ class ConfigurationManagerTest {
 
             var configManager = new ConfigurationManager(basePath(tempDir));
 
-            // Act
             List<String> issuerIds = configManager.getIssuerIds();
 
-            // Assert
             assertEquals(3, issuerIds.size());
             assertTrue(issuerIds.contains("issuer1"));
             assertTrue(issuerIds.contains("issuer2"));
@@ -435,20 +393,16 @@ class ConfigurationManagerTest {
         @Test
         @DisplayName("Should return empty map for unknown issuer")
         void shouldReturnEmptyMapForUnknownIssuer() {
-            // Arrange
             var configManager = new ConfigurationManager();
 
-            // Act
             Map<String, String> props = configManager.getIssuerProperties("unknown-issuer");
 
-            // Assert
             assertTrue(props.isEmpty(), "Should return empty map for unknown issuer");
         }
 
         @Test
         @DisplayName("Should return issuer properties for known issuer")
         void shouldReturnIssuerProperties(@TempDir Path tempDir) throws IOException {
-            // Arrange
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.properties");
             String content = """
@@ -460,10 +414,8 @@ class ConfigurationManagerTest {
 
             var configManager = new ConfigurationManager(basePath(tempDir));
 
-            // Act
             Map<String, String> props = configManager.getIssuerProperties("issuer1");
 
-            // Assert
             assertFalse(props.isEmpty());
             assertEquals("Issuer One", props.get("name"));
             assertEquals("https://example.com/jwks", props.get("jwks-url"));
@@ -478,7 +430,6 @@ class ConfigurationManagerTest {
         @Test
         @DisplayName("Should prefer properties file over YAML when both exist")
         void shouldPreferPropertiesOverYaml(@TempDir Path tempDir) throws IOException {
-            // Arrange
             Path confDir = createConfDir(tempDir);
             Path propsFile = confDir.resolve("cui-nifi-extensions.properties");
             Files.writeString(propsFile, "jwt.validation.max.token.size=11111\n");
@@ -491,10 +442,8 @@ class ConfigurationManagerTest {
                             size: 22222
                     """);
 
-            // Act
             var configManager = new ConfigurationManager(basePath(tempDir));
 
-            // Assert
             assertTrue(configManager.isConfigurationLoaded());
             assertEquals("11111", configManager.getProperty("jwt.validation.max.token.size"));
         }
@@ -507,7 +456,6 @@ class ConfigurationManagerTest {
         @Test
         @DisplayName("Should convert environment variable names to property names")
         void shouldConvertEnvToPropertyName(@TempDir Path tempDir) throws IOException {
-            // Arrange & Act
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.properties");
             String content = """
@@ -517,7 +465,6 @@ class ConfigurationManagerTest {
 
             var configManager = new ConfigurationManager(basePath(tempDir));
 
-            // Assert
             assertNotNull(configManager.getProperty("jwt.validation.max.token.size"),
                     "Property should exist in lowercase dot format");
         }
@@ -530,17 +477,14 @@ class ConfigurationManagerTest {
         @Test
         @DisplayName("Should handle invalid YAML syntax gracefully")
         void shouldHandleInvalidYaml(@TempDir Path tempDir) throws IOException {
-            // Arrange
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.yml");
             // Unmatched quote causes SnakeYAML to throw YAMLException
             String content = "key: 'unclosed string\nanother: line";
             Files.writeString(configFile, content);
 
-            // Act
             var configManager = new ConfigurationManager(basePath(tempDir));
 
-            // Assert
             assertFalse(configManager.isConfigurationLoaded(),
                     "Invalid YAML should not be loaded");
         }
@@ -548,7 +492,6 @@ class ConfigurationManagerTest {
         @Test
         @DisplayName("Should handle malformed YAML structure gracefully")
         void shouldHandleMalformedYaml(@TempDir Path tempDir) throws IOException {
-            // Arrange
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.yml");
             String content = """
@@ -558,10 +501,8 @@ class ConfigurationManagerTest {
                     """;
             Files.writeString(configFile, content);
 
-            // Act
             var configManager = new ConfigurationManager(basePath(tempDir));
 
-            // Assert
             assertFalse(configManager.isConfigurationLoaded(),
                     "Malformed YAML should not be loaded");
         }
@@ -574,7 +515,6 @@ class ConfigurationManagerTest {
         @Test
         @DisplayName("Should process generic YAML list as comma-separated string")
         void shouldProcessGenericListAsCommaSeparated(@TempDir Path tempDir) throws IOException {
-            // Arrange
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.yml");
             String content = """
@@ -587,10 +527,8 @@ class ConfigurationManagerTest {
                     """;
             Files.writeString(configFile, content);
 
-            // Act
             var configManager = new ConfigurationManager(basePath(tempDir));
 
-            // Assert
             assertTrue(configManager.isConfigurationLoaded());
             String algorithms = configManager.getProperty("jwt.validation.algorithms");
             assertNotNull(algorithms, "Algorithms property should exist");
@@ -601,7 +539,6 @@ class ConfigurationManagerTest {
         @Test
         @DisplayName("Should handle list with null values")
         void shouldHandleListWithNullValues(@TempDir Path tempDir) throws IOException {
-            // Arrange
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.yml");
             String content = """
@@ -613,10 +550,8 @@ class ConfigurationManagerTest {
                     """;
             Files.writeString(configFile, content);
 
-            // Act
             var configManager = new ConfigurationManager(basePath(tempDir));
 
-            // Assert
             assertTrue(configManager.isConfigurationLoaded());
             String claims = configManager.getProperty("jwt.validation.claims");
             assertNotNull(claims, "Claims property should exist");
@@ -631,7 +566,6 @@ class ConfigurationManagerTest {
         @Test
         @DisplayName("Should clear old config when reload encounters invalid YAML")
         void shouldClearOldConfigOnReloadWithInvalidYaml(@TempDir Path tempDir) throws IOException {
-            // Arrange
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.yml");
             String validContent = """
@@ -672,13 +606,10 @@ class ConfigurationManagerTest {
         @Test
         @DisplayName("Should return false when no config file exists")
         void shouldReturnFalseWhenNoConfigFile() {
-            // Arrange
             var configManager = new ConfigurationManager();
 
-            // Act
             boolean reloaded = configManager.checkAndReloadConfiguration();
 
-            // Assert
             assertFalse(reloaded, "Should return false when no config file exists");
         }
     }

--- a/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/config/IssuerConfigurationParserTest.java
+++ b/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/config/IssuerConfigurationParserTest.java
@@ -56,14 +56,11 @@ class IssuerConfigurationParserTest {
         @Test
         @DisplayName("Should return empty list for empty properties")
         void shouldReturnEmptyListForEmptyProperties() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             ConfigurationManager configManager = new ConfigurationManager();
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, configManager);
 
-            // Assert
             assertTrue(configs.isEmpty(), "Should return empty list for empty properties");
         }
     }
@@ -75,16 +72,13 @@ class IssuerConfigurationParserTest {
         @Test
         @DisplayName("Should create IssuerConfig from UI property with JWKS URL")
         void shouldCreateIssuerConfigWithJwksUrl() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("issuer.test.name", "TestIssuer");
             properties.put("issuer.test.jwks-url", "https://example.com/jwks");
             ConfigurationManager configManager = new ConfigurationManager();
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, configManager);
 
-            // Assert
             assertEquals(1, configs.size());
             IssuerConfig config = configs.getFirst();
             assertEquals("TestIssuer", config.getIssuerIdentifier());
@@ -102,10 +96,8 @@ class IssuerConfigurationParserTest {
             properties.put("issuer.test.jwks-file", jwksFile.toString());
             ConfigurationManager configManager = new ConfigurationManager();
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, configManager);
 
-            // Assert
             assertEquals(1, configs.size());
             assertEquals("TestIssuer", configs.getFirst().getIssuerIdentifier());
         }
@@ -113,32 +105,26 @@ class IssuerConfigurationParserTest {
         @Test
         @DisplayName("Should skip disabled issuer")
         void shouldSkipDisabledIssuer() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("issuer.test.name", "TestIssuer");
             properties.put("issuer.test.jwks-url", "https://example.com/jwks");
             properties.put("issuer.test.enabled", "false");
             ConfigurationManager configManager = new ConfigurationManager();
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, configManager);
 
-            // Assert
             assertTrue(configs.isEmpty(), "Disabled issuer should be skipped");
         }
 
         @Test
         @DisplayName("Should skip issuer with missing name")
         void shouldSkipIssuerWithMissingName() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("issuer.test.jwks-url", "https://example.com/jwks");
             ConfigurationManager configManager = new ConfigurationManager();
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, configManager);
 
-            // Assert
             assertTrue(configs.isEmpty(), "Issuer without name should be skipped");
             LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, "no name");
         }
@@ -146,15 +132,12 @@ class IssuerConfigurationParserTest {
         @Test
         @DisplayName("Should skip issuer with missing JWKS source")
         void shouldSkipIssuerWithMissingJwksSource() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("issuer.test.name", "TestIssuer");
             ConfigurationManager configManager = new ConfigurationManager();
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, configManager);
 
-            // Assert
             assertTrue(configs.isEmpty(), "Issuer without JWKS source should be skipped");
             LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, "JWKS");
         }
@@ -162,17 +145,14 @@ class IssuerConfigurationParserTest {
         @Test
         @DisplayName("Should set audience when present")
         void shouldSetAudience() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("issuer.test.name", "TestIssuer");
             properties.put("issuer.test.jwks-url", "https://example.com/jwks");
             properties.put("issuer.test.audience", "test-audience");
             ConfigurationManager configManager = new ConfigurationManager();
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, configManager);
 
-            // Assert
             assertEquals(1, configs.size());
             assertTrue(configs.getFirst().getExpectedAudience().contains("test-audience"),
                     "Expected audience should contain 'test-audience'");
@@ -181,17 +161,14 @@ class IssuerConfigurationParserTest {
         @Test
         @DisplayName("Should set client ID when present")
         void shouldSetClientId() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("issuer.test.name", "TestIssuer");
             properties.put("issuer.test.jwks-url", "https://example.com/jwks");
             properties.put("issuer.test.client-id", "test-client");
             ConfigurationManager configManager = new ConfigurationManager();
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, configManager);
 
-            // Assert
             assertEquals(1, configs.size());
             assertTrue(configs.getFirst().getExpectedClientId().contains("test-client"),
                     "Expected client ID should contain 'test-client'");
@@ -210,26 +187,21 @@ class IssuerConfigurationParserTest {
             properties.put("issuer.test3.jwks-url", "https://example3.com/jwks");
             ConfigurationManager configManager = new ConfigurationManager();
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, configManager);
 
-            // Assert
             assertEquals(3, configs.size());
         }
 
         @Test
         @DisplayName("Should use issuer key as fallback name")
         void shouldUseIssuerPropertyAsFallbackName() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("issuer.test.issuer", "FallbackIssuerName");
             properties.put("issuer.test.jwks-url", "https://example.com/jwks");
             ConfigurationManager configManager = new ConfigurationManager();
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, configManager);
 
-            // Assert
             assertEquals(1, configs.size());
             assertEquals("FallbackIssuerName", configs.getFirst().getIssuerIdentifier());
         }
@@ -237,16 +209,13 @@ class IssuerConfigurationParserTest {
         @Test
         @DisplayName("Should resolve jwksUri as alternative URL key")
         void shouldResolveJwksUri() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("issuer.test.name", "TestIssuer");
             properties.put("issuer.test.jwksUri", "https://example.com/jwks");
             ConfigurationManager configManager = new ConfigurationManager();
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, configManager);
 
-            // Assert
             assertEquals(1, configs.size());
             assertEquals("TestIssuer", configs.getFirst().getIssuerIdentifier());
         }
@@ -254,16 +223,13 @@ class IssuerConfigurationParserTest {
         @Test
         @DisplayName("Should warn when jwks-content is used")
         void shouldWarnOnJwksContent() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("issuer.test.name", "TestIssuer");
             properties.put("issuer.test.jwks-content", "{\"keys\":[]}");
             ConfigurationManager configManager = new ConfigurationManager();
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, configManager);
 
-            // Assert
             assertTrue(configs.isEmpty(), "JWKS content is not yet supported");
             LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, "not yet supported");
         }
@@ -276,17 +242,14 @@ class IssuerConfigurationParserTest {
         @Test
         @DisplayName("Should use explicit JWKS URL type when specified")
         void shouldUseExplicitUrlType() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("issuer.test.name", "TestIssuer");
             properties.put("issuer.test.jwks-url", "https://example.com/jwks");
             properties.put("issuer.test.jwks-type", "url");
             ConfigurationManager configManager = new ConfigurationManager();
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, configManager);
 
-            // Assert
             assertEquals(1, configs.size());
             assertNotNull(configs.getFirst().getJwksLoader());
         }
@@ -294,23 +257,19 @@ class IssuerConfigurationParserTest {
         @Test
         @DisplayName("Should infer URL type from jwks-url property")
         void shouldInferUrlTypeFromJwksUrl() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("issuer.test.name", "TestIssuer");
             properties.put("issuer.test.jwks-url", "https://example.com/jwks");
             ConfigurationManager configManager = new ConfigurationManager();
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, configManager);
 
-            // Assert
             assertEquals(1, configs.size());
         }
 
         @Test
         @DisplayName("Should infer file type from jwks-file property")
         void shouldInferFileTypeFromJwksFile(@TempDir Path tempDir) throws IOException {
-            // Arrange
             Path jwksFile = tempDir.resolve("test-jwks.json");
             Files.writeString(jwksFile, InMemoryKeyMaterialHandler.createDefaultJwks());
             Map<String, String> properties = new HashMap<>();
@@ -318,10 +277,8 @@ class IssuerConfigurationParserTest {
             properties.put("issuer.test.jwks-file", jwksFile.toString());
             ConfigurationManager configManager = new ConfigurationManager();
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, configManager);
 
-            // Assert
             assertEquals(1, configs.size());
         }
     }
@@ -333,28 +290,22 @@ class IssuerConfigurationParserTest {
         @Test
         @DisplayName("Should parse valid max token size")
         void shouldParseValidMaxTokenSize() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("Maximum Token Size", "32768");
 
-            // Act
             ParserConfig config = IssuerConfigurationParser.parseParserConfig(properties);
 
-            // Assert
             assertEquals(32768, config.getMaxTokenSize());
         }
 
         @Test
         @DisplayName("Should use default for invalid max token size")
         void shouldUseDefaultForInvalidMaxTokenSize() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("Maximum Token Size", "not-a-number");
 
-            // Act
             ParserConfig config = IssuerConfigurationParser.parseParserConfig(properties);
 
-            // Assert
             assertEquals(16384, config.getMaxTokenSize());
             LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, "not-a-number");
         }
@@ -362,13 +313,10 @@ class IssuerConfigurationParserTest {
         @Test
         @DisplayName("Should use default when max token size key missing")
         void shouldUseDefaultWhenKeyMissing() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
 
-            // Act
             ParserConfig config = IssuerConfigurationParser.parseParserConfig(properties);
 
-            // Assert
             assertEquals(16384, config.getMaxTokenSize());
         }
 
@@ -387,34 +335,28 @@ class IssuerConfigurationParserTest {
         @Test
         @DisplayName("Should apply valid JWKS refresh interval")
         void shouldApplyValidRefreshInterval() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("issuer.test.name", "TestIssuer");
             properties.put("issuer.test.jwks-url", "https://example.com/jwks");
             properties.put(JwtAttributes.Properties.Validation.JWKS_REFRESH_INTERVAL, "7200");
             ConfigurationManager configManager = new ConfigurationManager();
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, configManager);
 
-            // Assert
             assertEquals(1, configs.size(), "Should create one issuer config");
         }
 
         @Test
         @DisplayName("Should log warning for invalid refresh interval")
         void shouldLogWarningForInvalidRefreshInterval() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("issuer.test.name", "TestIssuer");
             properties.put("issuer.test.jwks-url", "https://example.com/jwks");
             properties.put(JwtAttributes.Properties.Validation.JWKS_REFRESH_INTERVAL, "invalid");
             ConfigurationManager configManager = new ConfigurationManager();
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, configManager);
 
-            // Assert
             assertEquals(1, configs.size());
             LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, "invalid");
         }
@@ -422,17 +364,14 @@ class IssuerConfigurationParserTest {
         @Test
         @DisplayName("Should log warning for invalid connection timeout")
         void shouldLogWarningForInvalidConnectionTimeout() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("issuer.test.name", "TestIssuer");
             properties.put("issuer.test.jwks-url", "https://example.com/jwks");
             properties.put(JwtAttributes.Properties.Validation.JWKS_CONNECTION_TIMEOUT, "invalid");
             ConfigurationManager configManager = new ConfigurationManager();
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, configManager);
 
-            // Assert
             assertEquals(1, configs.size());
             LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, "invalid");
         }
@@ -445,7 +384,6 @@ class IssuerConfigurationParserTest {
         @Test
         @DisplayName("Should load issuers from ConfigurationManager")
         void shouldLoadIssuersFromConfigManager(@TempDir Path tempDir) throws IOException {
-            // Arrange
             Path confDir = tempDir.resolve("conf");
             Files.createDirectories(confDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.properties");
@@ -458,10 +396,8 @@ class IssuerConfigurationParserTest {
             ConfigurationManager configManager = new ConfigurationManager(tempDir.toString() + "/");
             Map<String, String> properties = new HashMap<>();
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, configManager);
 
-            // Assert
             assertEquals(1, configs.size());
             assertEquals("External Issuer", configs.getFirst().getIssuerIdentifier());
         }
@@ -469,7 +405,6 @@ class IssuerConfigurationParserTest {
         @Test
         @DisplayName("Should merge UI and external configurations")
         void shouldMergeUIAndExternalConfigs(@TempDir Path tempDir) throws IOException {
-            // Arrange
             Path confDir = tempDir.resolve("conf");
             Files.createDirectories(confDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.properties");
@@ -484,41 +419,33 @@ class IssuerConfigurationParserTest {
             properties.put("issuer.ui1.name", "UI Issuer");
             properties.put("issuer.ui1.jwks-url", "https://ui.com/jwks");
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, configManager);
 
-            // Assert
             assertEquals(2, configs.size());
         }
 
         @Test
         @DisplayName("Should handle ConfigurationManager with no config loaded")
         void shouldHandleConfigManagerWithNoConfig() {
-            // Arrange
             ConfigurationManager configManager = new ConfigurationManager();
             Map<String, String> properties = new HashMap<>();
             properties.put("issuer.test.name", "TestIssuer");
             properties.put("issuer.test.jwks-url", "https://example.com/jwks");
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, configManager);
 
-            // Assert
             assertEquals(1, configs.size());
         }
 
         @Test
         @DisplayName("Should handle null ConfigurationManager")
         void shouldHandleNullConfigManager() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("issuer.test.name", "TestIssuer");
             properties.put("issuer.test.jwks-url", "https://example.com/jwks");
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, null);
 
-            // Assert
             assertEquals(1, configs.size());
         }
     }
@@ -530,18 +457,15 @@ class IssuerConfigurationParserTest {
         @Test
         @DisplayName("Should apply ParserConfig when provided")
         void shouldApplyParserConfig() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("issuer.test.name", "TestIssuer");
             properties.put("issuer.test.jwks-url", "https://example.com/jwks");
             ConfigurationManager configManager = new ConfigurationManager();
             ParserConfig parserConfig = ParserConfig.builder().maxTokenSize(32768).build();
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(
                     properties, configManager, parserConfig);
 
-            // Assert
             assertEquals(1, configs.size());
             assertNotNull(configs.getFirst().getJwksLoader());
         }
@@ -549,17 +473,14 @@ class IssuerConfigurationParserTest {
         @Test
         @DisplayName("Should work without ParserConfig")
         void shouldWorkWithoutParserConfig() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("issuer.test.name", "TestIssuer");
             properties.put("issuer.test.jwks-url", "https://example.com/jwks");
             ConfigurationManager configManager = new ConfigurationManager();
 
-            // Act
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(
                     properties, configManager, null);
 
-            // Assert
             assertEquals(1, configs.size());
         }
     }

--- a/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/config/JwtAuthenticationConfigTest.java
+++ b/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/config/JwtAuthenticationConfigTest.java
@@ -35,16 +35,13 @@ class JwtAuthenticationConfigTest {
         @Test
         @DisplayName("Should create record with valid values")
         void shouldCreateWithValidValues() {
-            // Arrange
             int maxTokenSize = 4096;
             Set<String> algorithms = Set.of("RS256", "RS384", "RS512");
             boolean requireHttps = true;
 
-            // Act
             JwtAuthenticationConfig config = new JwtAuthenticationConfig(
                     maxTokenSize, algorithms, requireHttps);
 
-            // Assert
             assertEquals(maxTokenSize, config.maxTokenSize());
             assertEquals(algorithms, config.allowedAlgorithms());
             assertEquals(requireHttps, config.requireHttpsForJwks());
@@ -53,19 +50,16 @@ class JwtAuthenticationConfigTest {
         @Test
         @DisplayName("Should create defensive copy of allowed algorithms")
         void shouldCreateDefensiveCopyOfAlgorithms() {
-            // Arrange
             Set<String> originalSet = new HashSet<>();
             originalSet.add("RS256");
             originalSet.add("RS512");
 
-            // Act
             JwtAuthenticationConfig config = new JwtAuthenticationConfig(
                     2048, originalSet, true);
 
             // Modify original set
             originalSet.add("HS256");
 
-            // Assert
             assertEquals(2, config.allowedAlgorithms().size());
             assertTrue(config.allowedAlgorithms().contains("RS256"));
             assertTrue(config.allowedAlgorithms().contains("RS512"));
@@ -76,11 +70,9 @@ class JwtAuthenticationConfigTest {
         @Test
         @DisplayName("Should handle null algorithms as empty set")
         void shouldHandleNullAlgorithms() {
-            // Act
             JwtAuthenticationConfig config = new JwtAuthenticationConfig(
                     2048, null, true);
 
-            // Assert
             assertNotNull(config.allowedAlgorithms());
             assertTrue(config.allowedAlgorithms().isEmpty());
         }
@@ -88,11 +80,9 @@ class JwtAuthenticationConfigTest {
         @Test
         @DisplayName("Should handle empty algorithms set")
         void shouldHandleEmptyAlgorithmsSet() {
-            // Act
             JwtAuthenticationConfig config = new JwtAuthenticationConfig(
                     2048, Set.of(), false);
 
-            // Assert
             assertNotNull(config.allowedAlgorithms());
             assertTrue(config.allowedAlgorithms().isEmpty());
         }
@@ -105,12 +95,10 @@ class JwtAuthenticationConfigTest {
         @Test
         @DisplayName("Should return unmodifiable algorithms set")
         void shouldReturnUnmodifiableAlgorithmsSet() {
-            // Arrange
             JwtAuthenticationConfig config = new JwtAuthenticationConfig(
                     2048, Set.of("RS256", "RS512"), true);
             var algorithms = config.allowedAlgorithms();
 
-            // Act & Assert
             assertThrows(UnsupportedOperationException.class,
                     () -> algorithms.add("HS256"));
         }
@@ -118,24 +106,20 @@ class JwtAuthenticationConfigTest {
         @Test
         @DisplayName("Should not allow clearing algorithms set")
         void shouldNotAllowClearingAlgorithmsSet() {
-            // Arrange
             JwtAuthenticationConfig config = new JwtAuthenticationConfig(
                     2048, Set.of("RS256"), true);
             var algorithms = config.allowedAlgorithms();
 
-            // Act & Assert
             assertThrows(UnsupportedOperationException.class, algorithms::clear);
         }
 
         @Test
         @DisplayName("Should not allow removing from algorithms set")
         void shouldNotAllowRemovingFromAlgorithmsSet() {
-            // Arrange
             JwtAuthenticationConfig config = new JwtAuthenticationConfig(
                     2048, Set.of("RS256", "RS512"), true);
             var algorithms = config.allowedAlgorithms();
 
-            // Act & Assert
             assertThrows(UnsupportedOperationException.class,
                     () -> algorithms.remove("RS256"));
         }
@@ -148,26 +132,21 @@ class JwtAuthenticationConfigTest {
         @Test
         @DisplayName("Should return correct maxTokenSize")
         void shouldReturnCorrectMaxTokenSize() {
-            // Arrange
             JwtAuthenticationConfig config = new JwtAuthenticationConfig(
                     8192, Set.of("RS256"), true);
 
-            // Act & Assert
             assertEquals(8192, config.maxTokenSize());
         }
 
         @Test
         @DisplayName("Should return correct allowedAlgorithms")
         void shouldReturnCorrectAllowedAlgorithms() {
-            // Arrange
             Set<String> algorithms = Set.of("RS256", "RS384", "RS512", "ES256");
             JwtAuthenticationConfig config = new JwtAuthenticationConfig(
                     4096, algorithms, true);
 
-            // Act
             Set<String> result = config.allowedAlgorithms();
 
-            // Assert
             assertEquals(4, result.size());
             assertTrue(result.contains("RS256"));
             assertTrue(result.contains("RS384"));
@@ -178,22 +157,18 @@ class JwtAuthenticationConfigTest {
         @Test
         @DisplayName("Should return correct requireHttpsForJwks when true")
         void shouldReturnTrueForRequireHttps() {
-            // Arrange
             JwtAuthenticationConfig config = new JwtAuthenticationConfig(
                     2048, Set.of("RS256"), true);
 
-            // Act & Assert
             assertTrue(config.requireHttpsForJwks());
         }
 
         @Test
         @DisplayName("Should return correct requireHttpsForJwks when false")
         void shouldReturnFalseForRequireHttps() {
-            // Arrange
             JwtAuthenticationConfig config = new JwtAuthenticationConfig(
                     2048, Set.of("RS256"), false);
 
-            // Act & Assert
             assertFalse(config.requireHttpsForJwks());
         }
     }
@@ -205,13 +180,11 @@ class JwtAuthenticationConfigTest {
         @Test
         @DisplayName("Should be equal when all fields match")
         void shouldBeEqualWhenAllFieldsMatch() {
-            // Arrange
             JwtAuthenticationConfig config1 = new JwtAuthenticationConfig(
                     2048, Set.of("RS256", "RS512"), true);
             JwtAuthenticationConfig config2 = new JwtAuthenticationConfig(
                     2048, Set.of("RS256", "RS512"), true);
 
-            // Act & Assert
             assertEquals(config1, config2);
             assertEquals(config1.hashCode(), config2.hashCode());
         }
@@ -219,61 +192,51 @@ class JwtAuthenticationConfigTest {
         @Test
         @DisplayName("Should not be equal when maxTokenSize differs")
         void shouldNotBeEqualWhenMaxTokenSizeDiffers() {
-            // Arrange
             JwtAuthenticationConfig config1 = new JwtAuthenticationConfig(
                     2048, Set.of("RS256"), true);
             JwtAuthenticationConfig config2 = new JwtAuthenticationConfig(
                     4096, Set.of("RS256"), true);
 
-            // Act & Assert
             assertNotEquals(config1, config2);
         }
 
         @Test
         @DisplayName("Should not be equal when allowedAlgorithms differs")
         void shouldNotBeEqualWhenAllowedAlgorithmsDiffers() {
-            // Arrange
             JwtAuthenticationConfig config1 = new JwtAuthenticationConfig(
                     2048, Set.of("RS256"), true);
             JwtAuthenticationConfig config2 = new JwtAuthenticationConfig(
                     2048, Set.of("RS512"), true);
 
-            // Act & Assert
             assertNotEquals(config1, config2);
         }
 
         @Test
         @DisplayName("Should not be equal when requireHttpsForJwks differs")
         void shouldNotBeEqualWhenRequireHttpsDiffers() {
-            // Arrange
             JwtAuthenticationConfig config1 = new JwtAuthenticationConfig(
                     2048, Set.of("RS256"), true);
             JwtAuthenticationConfig config2 = new JwtAuthenticationConfig(
                     2048, Set.of("RS256"), false);
 
-            // Act & Assert
             assertNotEquals(config1, config2);
         }
 
         @Test
         @DisplayName("Should be equal to itself")
         void shouldBeEqualToItself() {
-            // Arrange
             JwtAuthenticationConfig config = new JwtAuthenticationConfig(
                     2048, Set.of("RS256"), true);
 
-            // Act & Assert
             assertEquals(config, config);
         }
 
         @Test
         @DisplayName("Should not be equal to null")
         void shouldNotBeEqualToNull() {
-            // Arrange
             JwtAuthenticationConfig config = new JwtAuthenticationConfig(
                     2048, Set.of("RS256"), true);
 
-            // Act & Assert
             assertNotEquals(null, config);
         }
     }
@@ -285,14 +248,11 @@ class JwtAuthenticationConfigTest {
         @Test
         @DisplayName("Should include all fields in toString")
         void shouldIncludeAllFieldsInToString() {
-            // Arrange
             JwtAuthenticationConfig config = new JwtAuthenticationConfig(
                     4096, Set.of("RS256", "ES256"), true);
 
-            // Act
             String result = config.toString();
 
-            // Assert
             assertTrue(result.contains("4096"));
             assertTrue(result.contains("RS256") || result.contains("ES256"));
             assertTrue(result.contains("true"));

--- a/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/config/StandardJwtIssuerConfigServiceTest.java
+++ b/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/config/StandardJwtIssuerConfigServiceTest.java
@@ -75,22 +75,18 @@ class StandardJwtIssuerConfigServiceTest {
         @Test
         @DisplayName("Should return all 6 property descriptors")
         void shouldReturnAllPropertyDescriptors() throws Exception {
-            // Arrange
             TestRunner runner = TestRunners.newTestRunner(StubProcessor.class);
             StandardJwtIssuerConfigService service = new StandardJwtIssuerConfigService();
             runner.addControllerService(CS_ID, service);
 
-            // Act
             List<PropertyDescriptor> descriptors = service.getSupportedPropertyDescriptors();
 
-            // Assert
             assertEquals(6, descriptors.size());
         }
 
         @Test
         @DisplayName("Should include JWKS Refresh Interval property")
         void shouldIncludeJwksRefreshInterval() {
-            // Assert
             assertNotNull(StandardJwtIssuerConfigService.JWKS_REFRESH_INTERVAL);
             assertEquals("3600", StandardJwtIssuerConfigService.JWKS_REFRESH_INTERVAL.getDefaultValue());
             assertTrue(StandardJwtIssuerConfigService.JWKS_REFRESH_INTERVAL.isRequired());
@@ -99,7 +95,6 @@ class StandardJwtIssuerConfigServiceTest {
         @Test
         @DisplayName("Should include Maximum Token Size property")
         void shouldIncludeMaximumTokenSize() {
-            // Assert
             assertNotNull(StandardJwtIssuerConfigService.MAXIMUM_TOKEN_SIZE);
             assertEquals("16384", StandardJwtIssuerConfigService.MAXIMUM_TOKEN_SIZE.getDefaultValue());
             assertTrue(StandardJwtIssuerConfigService.MAXIMUM_TOKEN_SIZE.isRequired());
@@ -108,7 +103,6 @@ class StandardJwtIssuerConfigServiceTest {
         @Test
         @DisplayName("Should include Allowed Algorithms property")
         void shouldIncludeAllowedAlgorithms() {
-            // Assert
             assertNotNull(StandardJwtIssuerConfigService.ALLOWED_ALGORITHMS);
             assertNotNull(StandardJwtIssuerConfigService.ALLOWED_ALGORITHMS.getDefaultValue());
             assertFalse(StandardJwtIssuerConfigService.ALLOWED_ALGORITHMS.isRequired());
@@ -117,7 +111,6 @@ class StandardJwtIssuerConfigServiceTest {
         @Test
         @DisplayName("Should include Require HTTPS for JWKS property")
         void shouldIncludeRequireHttps() {
-            // Assert
             assertNotNull(StandardJwtIssuerConfigService.REQUIRE_HTTPS_FOR_JWKS);
             assertEquals("true", StandardJwtIssuerConfigService.REQUIRE_HTTPS_FOR_JWKS.getDefaultValue());
             assertTrue(StandardJwtIssuerConfigService.REQUIRE_HTTPS_FOR_JWKS.isRequired());
@@ -126,7 +119,6 @@ class StandardJwtIssuerConfigServiceTest {
         @Test
         @DisplayName("Should include JWKS Connection Timeout property")
         void shouldIncludeJwksConnectionTimeout() {
-            // Assert
             assertNotNull(StandardJwtIssuerConfigService.JWKS_CONNECTION_TIMEOUT);
             assertEquals("10", StandardJwtIssuerConfigService.JWKS_CONNECTION_TIMEOUT.getDefaultValue());
             assertTrue(StandardJwtIssuerConfigService.JWKS_CONNECTION_TIMEOUT.isRequired());
@@ -135,7 +127,6 @@ class StandardJwtIssuerConfigServiceTest {
         @Test
         @DisplayName("Should include Allow Private Network Addresses property with false default")
         void shouldIncludeAllowPrivateNetworkAddresses() {
-            // Assert
             assertNotNull(StandardJwtIssuerConfigService.JWKS_ALLOW_PRIVATE_NETWORK_ADDRESSES);
             assertEquals("false",
                     StandardJwtIssuerConfigService.JWKS_ALLOW_PRIVATE_NETWORK_ADDRESSES.getDefaultValue());
@@ -157,11 +148,9 @@ class StandardJwtIssuerConfigServiceTest {
         @Test
         @DisplayName("Should return dynamic descriptor for issuer-prefixed property")
         void shouldReturnDynamicDescriptorForIssuerPrefix() {
-            // Act
             PropertyDescriptor descriptor = service.getSupportedDynamicPropertyDescriptor(
                     JwtConstants.ISSUER_PREFIX + "myIssuer.jwksUrl");
 
-            // Assert
             assertNotNull(descriptor);
             assertTrue(descriptor.isDynamic());
             assertEquals("Issuer configuration property", descriptor.getDescription());
@@ -170,10 +159,8 @@ class StandardJwtIssuerConfigServiceTest {
         @Test
         @DisplayName("Should return dynamic descriptor for non-issuer property")
         void shouldReturnDynamicDescriptorForNonIssuerProperty() {
-            // Act
             PropertyDescriptor descriptor = service.getSupportedDynamicPropertyDescriptor("custom.property");
 
-            // Assert
             assertNotNull(descriptor);
             assertTrue(descriptor.isDynamic());
             assertEquals("Dynamic property", descriptor.getDescription());
@@ -194,7 +181,6 @@ class StandardJwtIssuerConfigServiceTest {
         @Test
         @DisplayName("Should throw NullPointerException when token is null")
         void shouldThrowNpeWhenTokenNull() {
-            // Act & Assert
             assertThrows(NullPointerException.class,
                     () -> service.validateToken(null));
         }
@@ -202,7 +188,6 @@ class StandardJwtIssuerConfigServiceTest {
         @Test
         @DisplayName("Should throw IllegalStateException when validating token before enable")
         void shouldThrowIseWhenNotEnabled() {
-            // Act & Assert
             IllegalStateException exception = assertThrows(IllegalStateException.class,
                     () -> service.validateToken("some.jwt.token"));
             assertTrue(exception.getMessage().contains("not enabled"));
@@ -211,7 +196,6 @@ class StandardJwtIssuerConfigServiceTest {
         @Test
         @DisplayName("Should throw IllegalStateException when getting auth config before enable")
         void shouldThrowIseForAuthConfigWhenNotEnabled() {
-            // Act & Assert
             IllegalStateException exception = assertThrows(IllegalStateException.class,
                     () -> service.getAuthenticationConfig());
             assertTrue(exception.getMessage().contains("not enabled"));
@@ -220,7 +204,6 @@ class StandardJwtIssuerConfigServiceTest {
         @Test
         @DisplayName("Should return empty Optional for security counter before enable")
         void shouldReturnEmptyCounterWhenNotEnabled() {
-            // Act & Assert
             assertTrue(service.getSecurityEventCounter().isEmpty());
         }
     }
@@ -236,7 +219,6 @@ class StandardJwtIssuerConfigServiceTest {
             // (onEnabled requires dsl-json ServiceLoader not available in test)
             StandardJwtIssuerConfigService service = new StandardJwtIssuerConfigService();
 
-            // Act
             service.onDisabled();
 
             // Assert — should be in clean disabled state

--- a/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/i18n/NiFiI18nResolverTest.java
+++ b/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/i18n/NiFiI18nResolverTest.java
@@ -35,36 +35,28 @@ class NiFiI18nResolverTest {
         @Test
         @DisplayName("Should create resolver with specific locale")
         void shouldCreateResolverWithLocale() {
-            // Arrange & Act
             I18nResolver resolver = NiFiI18nResolver.createResolver(Locale.ENGLISH);
 
-            // Assert
             assertNotNull(resolver, "Resolver should be created");
         }
 
         @Test
         @DisplayName("Should create default resolver with logger")
         void shouldCreateDefaultResolver() {
-            // Arrange
             var logger = new MockComponentLog("test", new Object());
 
-            // Act
             I18nResolver resolver = NiFiI18nResolver.createDefault(logger);
 
-            // Assert
             assertNotNull(resolver, "Default resolver should be created");
         }
 
         @Test
         @DisplayName("Should create resolver with unusual locale and fall back to default bundle")
         void shouldFallbackToDefaultBundleForUnusualLocale() {
-            // Arrange
             Locale unusualLocale = Locale.forLanguageTag("xx-YY");
 
-            // Act
             I18nResolver resolver = NiFiI18nResolver.createResolver(unusualLocale);
 
-            // Assert
             assertNotNull(resolver, "Resolver should be created even with unusual locale");
             String result = resolver.getTranslatedString("property.jwks.refresh.interval.name");
             assertNotNull(result, "Should return some value (key or translation)");
@@ -78,28 +70,22 @@ class NiFiI18nResolverTest {
         @Test
         @DisplayName("Should return key when key not found in bundle")
         void shouldReturnKeyWhenNotFound() {
-            // Arrange
             I18nResolver resolver = NiFiI18nResolver.createResolver(Locale.ENGLISH);
             String nonExistentKey = "this.key.does.not.exist.in.bundle";
 
-            // Act
             String result = resolver.getTranslatedString(nonExistentKey);
 
-            // Assert
             assertEquals(nonExistentKey, result, "Should return the key itself when translation not found");
         }
 
         @Test
         @DisplayName("Should return translated string for existing key")
         void shouldReturnTranslatedString() {
-            // Arrange
             I18nResolver resolver = NiFiI18nResolver.createResolver(Locale.ENGLISH);
             String existingKey = "property.jwks.refresh.interval.name";
 
-            // Act
             String result = resolver.getTranslatedString(existingKey);
 
-            // Assert
             assertNotNull(result, "Translation should not be null");
             assertFalse(result.isEmpty(), "Translation should not be empty");
         }
@@ -107,10 +93,8 @@ class NiFiI18nResolverTest {
         @Test
         @DisplayName("Should throw NullPointerException for null key")
         void shouldThrowExceptionForNullKey() {
-            // Arrange
             I18nResolver resolver = NiFiI18nResolver.createResolver(Locale.ENGLISH);
 
-            // Act & Assert
             assertThrows(NullPointerException.class,
                     () -> resolver.getTranslatedString(null),
                     "Should throw NullPointerException for null key");
@@ -124,10 +108,8 @@ class NiFiI18nResolverTest {
         @Test
         @DisplayName("Should throw NullPointerException for null key with arguments")
         void shouldThrowExceptionForNullKeyWithArgs() {
-            // Arrange
             I18nResolver resolver = NiFiI18nResolver.createResolver(Locale.ENGLISH);
 
-            // Act & Assert
             assertThrows(NullPointerException.class,
                     () -> resolver.getTranslatedString(null, "arg1", "arg2"),
                     "Should throw NullPointerException for null key");
@@ -136,16 +118,13 @@ class NiFiI18nResolverTest {
         @Test
         @DisplayName("Should format arguments into translated string")
         void shouldFormatArguments() {
-            // Arrange
             I18nResolver resolver = NiFiI18nResolver.createResolver(Locale.ENGLISH);
             String key = "property.issuer.jwks.url.description";
             String arg1 = "jwks-url";
             String arg2 = "myIssuer";
 
-            // Act
             String result = resolver.getTranslatedString(key, arg1, arg2);
 
-            // Assert
             assertNotNull(result, "Result should not be null");
             assertTrue(result.contains(arg1) || result.contains(arg2) || result.equals(key),
                     "Result should contain arguments or be the key if not found");
@@ -154,12 +133,10 @@ class NiFiI18nResolverTest {
         @Test
         @DisplayName("Should handle formatting for non-existent key with arguments")
         void shouldFormatNonExistentKeyWithArguments() {
-            // Arrange
             I18nResolver resolver = NiFiI18nResolver.createResolver(Locale.ENGLISH);
             String nonExistentKey = "non.existent.key.with.placeholder";
             String arg = "testArg";
 
-            // Act
             String result = resolver.getTranslatedString(nonExistentKey, arg);
 
             // Assert — lenientFormat appends args even when key is returned as-is
@@ -170,28 +147,23 @@ class NiFiI18nResolverTest {
         @Test
         @DisplayName("Should handle empty arguments array")
         void shouldHandleEmptyArguments() {
-            // Arrange
             I18nResolver resolver = NiFiI18nResolver.createResolver(Locale.ENGLISH);
             String key = "property.jwks.refresh.interval.name";
 
-            // Act
             String result = resolver.getTranslatedString(key);
 
-            // Assert
             assertNotNull(result, "Result should not be null");
         }
 
         @Test
         @DisplayName("Should handle lenient formatting with mismatched argument count")
         void shouldHandleMismatchedArguments() {
-            // Arrange
             I18nResolver resolver = NiFiI18nResolver.createResolver(Locale.ENGLISH);
             String key = "property.issuer.jwks.url.description";
 
             // Act - provide fewer arguments than placeholders
             String result = resolver.getTranslatedString(key, "onlyOneArg");
 
-            // Assert
             assertNotNull(result, "Should handle mismatched arguments gracefully");
         }
     }
@@ -203,42 +175,33 @@ class NiFiI18nResolverTest {
         @Test
         @DisplayName("Should work without logger")
         void shouldWorkWithoutLogger() {
-            // Arrange
             I18nResolver resolver = NiFiI18nResolver.createResolver(Locale.ENGLISH);
 
-            // Act
             String result = resolver.getTranslatedString("property.jwks.refresh.interval.name");
 
-            // Assert
             assertNotNull(result, "Should work without logger");
         }
 
         @Test
         @DisplayName("Should work with logger provided")
         void shouldWorkWithLogger() {
-            // Arrange
             var logger = new MockComponentLog("test", new Object());
             I18nResolver resolver = NiFiI18nResolver.createDefault(logger);
 
-            // Act
             String result = resolver.getTranslatedString("property.jwks.refresh.interval.name");
 
-            // Assert
             assertNotNull(result, "Should work with logger provided");
         }
 
         @Test
         @DisplayName("Should handle missing key gracefully with logger")
         void shouldHandleMissingKeyWithLogger() {
-            // Arrange
             var logger = new MockComponentLog("test", new Object());
             I18nResolver resolver = NiFiI18nResolver.createDefault(logger);
             String missingKey = "this.key.is.missing";
 
-            // Act
             String result = resolver.getTranslatedString(missingKey);
 
-            // Assert
             assertEquals(missingKey, result, "Should return key when missing");
         }
     }

--- a/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/test/DynamicPropertyTestHelper.java
+++ b/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/test/DynamicPropertyTestHelper.java
@@ -16,6 +16,7 @@
  */
 package de.cuioss.nifi.jwt.test;
 
+import lombok.experimental.UtilityClass;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.Processor;
@@ -25,53 +26,53 @@ import org.apache.nifi.util.TestRunner;
 import java.util.Map;
 
 /**
- * Helper class for testing NiFi components with dynamic properties.
+ * Helper utilities for testing NiFi components with dynamic properties.
  * <p>
- * Provides utilities to work around the limitation where TestRunner
- * doesn't properly handle dynamic properties in getProperties() method.
+ * Works around the limitation where {@link TestRunner} doesn't properly
+ * surface dynamic properties through the {@code getProperties()} method.
  */
+@UtilityClass
 public class DynamicPropertyTestHelper {
 
     /**
-     * Creates a ProcessContext from a TestRunner that properly includes dynamic properties.
+     * Creates a {@link ProcessContext} from a {@link TestRunner} that properly includes
+     * dynamic properties.
      *
-     * @param testRunner The test runner with configured properties
-     * @param processor  The processor being tested
-     * @return A ProcessContext that includes all dynamic properties
+     * @param testRunner the test runner with configured properties
+     * @param processor  the processor being tested
+     * @return a {@link ProcessContext} that includes all dynamic properties
      */
     public static ProcessContext createContextWithDynamicProperties(TestRunner testRunner, Processor processor) {
-        MockProcessContext context = new MockProcessContext(processor);
+        var context = new MockProcessContext(processor);
         Map<PropertyDescriptor, String> properties = testRunner.getProcessContext().getProperties();
-        for (Map.Entry<PropertyDescriptor, String> entry : properties.entrySet()) {
+        for (var entry : properties.entrySet()) {
             context.setProperty(entry.getKey(), entry.getValue());
         }
         return context;
     }
 
     /**
-     * Sets multiple dynamic properties with a common prefix.
+     * Sets multiple dynamic properties sharing a common prefix.
      *
-     * @param testRunner The test runner
-     * @param prefix     The property prefix (e.g., "issuer.test-issuer.")
-     * @param properties Map of property suffixes to values
+     * @param testRunner the test runner
+     * @param prefix     the property prefix (e.g. {@code "issuer.test-issuer."})
+     * @param properties map of property suffixes to values
      */
     public static void setDynamicProperties(TestRunner testRunner, String prefix, Map<String, String> properties) {
-        for (Map.Entry<String, String> entry : properties.entrySet()) {
-            String fullPropertyName = prefix + entry.getKey();
-            testRunner.setProperty(fullPropertyName, entry.getValue());
+        for (var entry : properties.entrySet()) {
+            testRunner.setProperty(prefix + entry.getKey(), entry.getValue());
         }
     }
 
     /**
      * Sets issuer properties for JWT testing.
      *
-     * @param testRunner       The test runner
-     * @param issuerName       The issuer name
-     * @param issuerProperties Map of issuer properties (without prefix)
+     * @param testRunner       the test runner
+     * @param issuerName       the issuer name
+     * @param issuerProperties map of issuer properties (without prefix)
      */
     public static void setIssuerProperties(TestRunner testRunner, String issuerName,
             Map<String, String> issuerProperties) {
-        String prefix = "issuer." + issuerName + ".";
-        setDynamicProperties(testRunner, prefix, issuerProperties);
+        setDynamicProperties(testRunner, "issuer." + issuerName + ".", issuerProperties);
     }
 }

--- a/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/test/TestJwtIssuerConfigService.java
+++ b/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/test/TestJwtIssuerConfigService.java
@@ -62,7 +62,8 @@ public class TestJwtIssuerConfigService extends AbstractControllerService implem
             throw exceptionToThrow;
         }
         if (tokenToReturn == null) {
-            throw new IllegalStateException("TestJwtIssuerConfigService not configured — call configureValidToken() or configureValidationFailure()");
+            throw new IllegalStateException(
+                    "TestJwtIssuerConfigService not configured — call configureValidToken() or configureValidationFailure()");
         }
         return tokenToReturn;
     }

--- a/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/util/AuthorizationRequirementsTest.java
+++ b/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/util/AuthorizationRequirementsTest.java
@@ -64,10 +64,8 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("Should create record with null roles as empty set")
         void shouldHandleNullRoles() {
-            // Arrange & Act
             var requirements = new AuthorizationRequirements(true, null, Set.of("scope1"));
 
-            // Assert
             assertNotNull(requirements.requiredRoles(), "Roles should not be null");
             assertTrue(requirements.requiredRoles().isEmpty(), "Roles should be empty set");
         }
@@ -75,10 +73,8 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("Should create record with null scopes as empty set")
         void shouldHandleNullScopes() {
-            // Arrange & Act
             var requirements = new AuthorizationRequirements(true, Set.of("role1"), null);
 
-            // Assert
             assertNotNull(requirements.requiredScopes(), "Scopes should not be null");
             assertTrue(requirements.requiredScopes().isEmpty(), "Scopes should be empty set");
         }
@@ -86,16 +82,13 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("Should create defensive copy of roles set")
         void shouldCreateDefensiveCopyOfRoles() {
-            // Arrange
             Set<String> originalRoles = new HashSet<>();
             originalRoles.add("role1");
             originalRoles.add("role2");
 
-            // Act
             var requirements = new AuthorizationRequirements(true, originalRoles, Set.of());
             originalRoles.add("role3");
 
-            // Assert
             assertEquals(2, requirements.requiredRoles().size(),
                     "Original set modification should not affect record");
             assertFalse(requirements.requiredRoles().contains("role3"),
@@ -105,16 +98,13 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("Should create defensive copy of scopes set")
         void shouldCreateDefensiveCopyOfScopes() {
-            // Arrange
             Set<String> originalScopes = new HashSet<>();
             originalScopes.add("scope1");
             originalScopes.add("scope2");
 
-            // Act
             var requirements = new AuthorizationRequirements(true, Set.of(), originalScopes);
             originalScopes.add("scope3");
 
-            // Assert
             assertEquals(2, requirements.requiredScopes().size(),
                     "Original set modification should not affect record");
             assertFalse(requirements.requiredScopes().contains("scope3"),
@@ -124,11 +114,9 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("Should return immutable roles set")
         void shouldReturnImmutableRolesSet() {
-            // Arrange
             var requirements = new AuthorizationRequirements(true, Set.of("role1"), Set.of());
             var roles = requirements.requiredRoles();
 
-            // Act & Assert
             assertThrows(UnsupportedOperationException.class,
                     () -> roles.add("newRole"),
                     "Returned roles set should be immutable");
@@ -137,11 +125,9 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("Should return immutable scopes set")
         void shouldReturnImmutableScopesSet() {
-            // Arrange
             var requirements = new AuthorizationRequirements(true, Set.of(), Set.of("scope1"));
             var scopes = requirements.requiredScopes();
 
-            // Act & Assert
             assertThrows(UnsupportedOperationException.class,
                     () -> scopes.add("newScope"),
                     "Returned scopes set should be immutable");
@@ -155,64 +141,50 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("Should return false when both roles and scopes are empty")
         void shouldReturnFalseWhenBothEmpty() {
-            // Arrange
             var requirements = new AuthorizationRequirements(true, Set.of(), Set.of());
 
-            // Act
             boolean hasRequirements = requirements.hasAuthorizationRequirements();
 
-            // Assert
             assertFalse(hasRequirements, "Should return false when both sets are empty");
         }
 
         @Test
         @DisplayName("Should return true when roles are present")
         void shouldReturnTrueWhenRolesPresent() {
-            // Arrange
             var requirements = new AuthorizationRequirements(true, Set.of("admin"), Set.of());
 
-            // Act
             boolean hasRequirements = requirements.hasAuthorizationRequirements();
 
-            // Assert
             assertTrue(hasRequirements, "Should return true when roles are present");
         }
 
         @Test
         @DisplayName("Should return true when scopes are present")
         void shouldReturnTrueWhenScopesPresent() {
-            // Arrange
             var requirements = new AuthorizationRequirements(true, Set.of(), Set.of("read"));
 
-            // Act
             boolean hasRequirements = requirements.hasAuthorizationRequirements();
 
-            // Assert
             assertTrue(hasRequirements, "Should return true when scopes are present");
         }
 
         @Test
         @DisplayName("Should return true when both roles and scopes are present")
         void shouldReturnTrueWhenBothPresent() {
-            // Arrange
             var requirements = new AuthorizationRequirements(
                     true, Set.of("admin", "user"), Set.of("read", "write"));
 
-            // Act
             boolean hasRequirements = requirements.hasAuthorizationRequirements();
 
-            // Assert
             assertTrue(hasRequirements, "Should return true when both roles and scopes are present");
         }
 
         @Test
         @DisplayName("Should not consider requireValidToken in authorization requirements check")
         void shouldNotConsiderRequireValidToken() {
-            // Arrange
             var requirementsTrue = new AuthorizationRequirements(true, Set.of(), Set.of());
             var requirementsFalse = new AuthorizationRequirements(false, Set.of(), Set.of());
 
-            // Act & Assert
             assertFalse(requirementsTrue.hasAuthorizationRequirements(),
                     "Should not consider requireValidToken flag");
             assertFalse(requirementsFalse.hasAuthorizationRequirements(),
@@ -227,10 +199,8 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("getPropertyDescriptors should return 3 descriptors")
         void shouldReturn3Descriptors() {
-            // Act
             List<PropertyDescriptor> descriptors = AuthorizationRequirements.getPropertyDescriptors();
 
-            // Assert
             assertNotNull(descriptors, "Descriptors list should not be null");
             assertEquals(3, descriptors.size(), "Should return exactly 3 descriptors");
         }
@@ -238,10 +208,8 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("REQUIRE_VALID_TOKEN descriptor should have default value 'true'")
         void requireValidTokenShouldHaveDefaultTrue() {
-            // Act
             PropertyDescriptor descriptor = AuthorizationRequirements.REQUIRE_VALID_TOKEN;
 
-            // Assert
             assertNotNull(descriptor, "REQUIRE_VALID_TOKEN should not be null");
             assertEquals("true", descriptor.getDefaultValue(), "Default value should be 'true'");
             assertTrue(descriptor.isRequired(), "REQUIRE_VALID_TOKEN should be required");
@@ -250,10 +218,8 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("REQUIRE_VALID_TOKEN should have correct name and display name")
         void requireValidTokenShouldHaveCorrectMetadata() {
-            // Act
             PropertyDescriptor descriptor = AuthorizationRequirements.REQUIRE_VALID_TOKEN;
 
-            // Assert
             assertEquals("jwt.validation.require.valid.token", descriptor.getName(),
                     "Name should match");
             assertEquals("Require Valid Token", descriptor.getDisplayName(),
@@ -263,10 +229,8 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("REQUIRED_ROLES descriptor should be optional")
         void requiredRolesShouldBeOptional() {
-            // Act
             PropertyDescriptor descriptor = AuthorizationRequirements.REQUIRED_ROLES;
 
-            // Assert
             assertNotNull(descriptor, "REQUIRED_ROLES should not be null");
             assertFalse(descriptor.isRequired(), "REQUIRED_ROLES should be optional");
         }
@@ -274,10 +238,8 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("REQUIRED_SCOPES descriptor should be optional")
         void requiredScopesShouldBeOptional() {
-            // Act
             PropertyDescriptor descriptor = AuthorizationRequirements.REQUIRED_SCOPES;
 
-            // Assert
             assertNotNull(descriptor, "REQUIRED_SCOPES should not be null");
             assertFalse(descriptor.isRequired(), "REQUIRED_SCOPES should be optional");
         }
@@ -285,10 +247,8 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("getPropertyDescriptors should include all three descriptors")
         void getPropertyDescriptorsShouldIncludeAllThree() {
-            // Act
             List<PropertyDescriptor> descriptors = AuthorizationRequirements.getPropertyDescriptors();
 
-            // Assert
             assertTrue(descriptors.contains(AuthorizationRequirements.REQUIRE_VALID_TOKEN),
                     "Should include REQUIRE_VALID_TOKEN");
             assertTrue(descriptors.contains(AuthorizationRequirements.REQUIRED_ROLES),
@@ -308,7 +268,6 @@ class AuthorizationRequirementsTest {
             // Arrange - simulating what parseCommaSeparated would do
             var requirements = new AuthorizationRequirements(true, Set.of("admin"), Set.of());
 
-            // Assert
             assertEquals(1, requirements.requiredRoles().size(), "Should have one role");
             assertTrue(requirements.requiredRoles().contains("admin"), "Should contain 'admin'");
         }
@@ -316,11 +275,9 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("Should parse multiple role values")
         void shouldParseMultipleRoles() {
-            // Arrange
             var requirements = new AuthorizationRequirements(
                     true, Set.of("admin", "user", "moderator"), Set.of());
 
-            // Assert
             assertEquals(3, requirements.requiredRoles().size(), "Should have three roles");
             assertTrue(requirements.requiredRoles().contains("admin"), "Should contain 'admin'");
             assertTrue(requirements.requiredRoles().contains("user"), "Should contain 'user'");
@@ -330,10 +287,8 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("Should handle empty set for empty input")
         void shouldHandleEmptyInput() {
-            // Arrange
             var requirements = new AuthorizationRequirements(true, Set.of(), Set.of());
 
-            // Assert
             assertTrue(requirements.requiredRoles().isEmpty(), "Roles should be empty");
             assertTrue(requirements.requiredScopes().isEmpty(), "Scopes should be empty");
         }
@@ -341,11 +296,9 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("Should parse scope values correctly")
         void shouldParseScopes() {
-            // Arrange
             var requirements = new AuthorizationRequirements(
                     true, Set.of(), Set.of("read", "write", "delete"));
 
-            // Assert
             assertEquals(3, requirements.requiredScopes().size(), "Should have three scopes");
             assertTrue(requirements.requiredScopes().contains("read"), "Should contain 'read'");
             assertTrue(requirements.requiredScopes().contains("write"), "Should contain 'write'");
@@ -355,13 +308,11 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("Should handle mixed roles and scopes")
         void shouldHandleMixedRolesAndScopes() {
-            // Arrange
             var requirements = new AuthorizationRequirements(
                     true,
                     Set.of("admin", "user"),
                     Set.of("read", "write"));
 
-            // Assert
             assertEquals(2, requirements.requiredRoles().size(), "Should have two roles");
             assertEquals(2, requirements.requiredScopes().size(), "Should have two scopes");
             assertTrue(requirements.hasAuthorizationRequirements(),
@@ -376,11 +327,9 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("Should be equal when all fields match")
         void shouldBeEqualWhenFieldsMatch() {
-            // Arrange
             var req1 = new AuthorizationRequirements(true, Set.of("admin"), Set.of("read"));
             var req2 = new AuthorizationRequirements(true, Set.of("admin"), Set.of("read"));
 
-            // Assert
             assertEquals(req1, req2, "Records with same values should be equal");
             assertEquals(req1.hashCode(), req2.hashCode(), "Hash codes should match");
         }
@@ -388,24 +337,19 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("Should not be equal when requireValidToken differs")
         void shouldNotBeEqualWhenRequireValidTokenDiffers() {
-            // Arrange
             var req1 = new AuthorizationRequirements(true, Set.of("admin"), Set.of("read"));
             var req2 = new AuthorizationRequirements(false, Set.of("admin"), Set.of("read"));
 
-            // Assert
             assertNotEquals(req1, req2, "Records should differ by requireValidToken");
         }
 
         @Test
         @DisplayName("Should have toString representation")
         void shouldHaveToStringRepresentation() {
-            // Arrange
             var requirements = new AuthorizationRequirements(true, Set.of("admin"), Set.of("read"));
 
-            // Act
             String toString = requirements.toString();
 
-            // Assert
             assertNotNull(toString, "toString should not be null");
             assertFalse(toString.isEmpty(), "toString should not be empty");
         }
@@ -418,17 +362,14 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("Should parse roles and scopes correctly from ProcessContext")
         void shouldParseRolesAndScopes() {
-            // Arrange
             TestRunner runner = TestRunners.newTestRunner(new TestProcessor());
             runner.setProperty(AuthorizationRequirements.REQUIRE_VALID_TOKEN, "true");
             runner.setProperty(AuthorizationRequirements.REQUIRED_ROLES, "admin, user");
             runner.setProperty(AuthorizationRequirements.REQUIRED_SCOPES, "read,write");
 
-            // Act
             AuthorizationRequirements requirements =
                     AuthorizationRequirements.from(runner.getProcessContext());
 
-            // Assert
             assertTrue(requirements.requireValidToken(), "Should require valid token");
             assertEquals(2, requirements.requiredRoles().size(), "Should have 2 roles");
             assertTrue(requirements.requiredRoles().contains("admin"), "Should contain 'admin' role");
@@ -441,16 +382,13 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("Should return empty sets when properties are not set")
         void shouldReturnEmptySetsWhenPropertiesNotSet() {
-            // Arrange
             TestRunner runner = TestRunners.newTestRunner(new TestProcessor());
             runner.setProperty(AuthorizationRequirements.REQUIRE_VALID_TOKEN, "true");
             // Don't set REQUIRED_ROLES or REQUIRED_SCOPES
 
-            // Act
             AuthorizationRequirements requirements =
                     AuthorizationRequirements.from(runner.getProcessContext());
 
-            // Assert
             assertTrue(requirements.requireValidToken(), "Should require valid token");
             assertTrue(requirements.requiredRoles().isEmpty(), "Roles should be empty");
             assertTrue(requirements.requiredScopes().isEmpty(), "Scopes should be empty");
@@ -461,16 +399,13 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("Should respect requireValidToken=false")
         void shouldRespectRequireValidTokenFalse() {
-            // Arrange
             TestRunner runner = TestRunners.newTestRunner(new TestProcessor());
             runner.setProperty(AuthorizationRequirements.REQUIRE_VALID_TOKEN, "false");
             runner.setProperty(AuthorizationRequirements.REQUIRED_ROLES, "admin");
 
-            // Act
             AuthorizationRequirements requirements =
                     AuthorizationRequirements.from(runner.getProcessContext());
 
-            // Assert
             assertFalse(requirements.requireValidToken(), "Should not require valid token");
             assertEquals(1, requirements.requiredRoles().size(), "Should still have roles");
             assertTrue(requirements.requiredRoles().contains("admin"), "Should contain 'admin' role");
@@ -479,17 +414,14 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("Should trim whitespace and filter empty strings")
         void shouldTrimWhitespaceAndFilterEmpty() {
-            // Arrange
             TestRunner runner = TestRunners.newTestRunner(new TestProcessor());
             runner.setProperty(AuthorizationRequirements.REQUIRE_VALID_TOKEN, "true");
             runner.setProperty(AuthorizationRequirements.REQUIRED_ROLES, " admin , user , ");
             runner.setProperty(AuthorizationRequirements.REQUIRED_SCOPES, "  read  ,  write  ,  ,  ");
 
-            // Act
             AuthorizationRequirements requirements =
                     AuthorizationRequirements.from(runner.getProcessContext());
 
-            // Assert
             assertEquals(2, requirements.requiredRoles().size(),
                     "Should have 2 roles (whitespace trimmed, empty filtered)");
             assertTrue(requirements.requiredRoles().contains("admin"), "Should contain trimmed 'admin'");
@@ -503,16 +435,13 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("Should handle single value without commas")
         void shouldHandleSingleValue() {
-            // Arrange
             TestRunner runner = TestRunners.newTestRunner(new TestProcessor());
             runner.setProperty(AuthorizationRequirements.REQUIRE_VALID_TOKEN, "true");
             runner.setProperty(AuthorizationRequirements.REQUIRED_ROLES, "admin");
 
-            // Act
             AuthorizationRequirements requirements =
                     AuthorizationRequirements.from(runner.getProcessContext());
 
-            // Assert
             assertEquals(1, requirements.requiredRoles().size(), "Should have 1 role");
             assertTrue(requirements.requiredRoles().contains("admin"), "Should contain 'admin'");
         }
@@ -520,32 +449,26 @@ class AuthorizationRequirementsTest {
         @Test
         @DisplayName("Should handle empty string as empty set")
         void shouldHandleEmptyStringAsEmptySet() {
-            // Arrange
             TestRunner runner = TestRunners.newTestRunner(new TestProcessor());
             runner.setProperty(AuthorizationRequirements.REQUIRE_VALID_TOKEN, "true");
             runner.setProperty(AuthorizationRequirements.REQUIRED_ROLES, "");
 
-            // Act
             AuthorizationRequirements requirements =
                     AuthorizationRequirements.from(runner.getProcessContext());
 
-            // Assert
             assertTrue(requirements.requiredRoles().isEmpty(), "Empty string should result in empty set");
         }
 
         @Test
         @DisplayName("Should handle whitespace-only string as empty set")
         void shouldHandleWhitespaceOnlyStringAsEmptySet() {
-            // Arrange
             TestRunner runner = TestRunners.newTestRunner(new TestProcessor());
             runner.setProperty(AuthorizationRequirements.REQUIRE_VALID_TOKEN, "true");
             runner.setProperty(AuthorizationRequirements.REQUIRED_ROLES, "   ");
 
-            // Act
             AuthorizationRequirements requirements =
                     AuthorizationRequirements.from(runner.getProcessContext());
 
-            // Assert
             assertTrue(requirements.requiredRoles().isEmpty(),
                     "Whitespace-only string should result in empty set");
         }

--- a/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/util/AuthorizationValidatorTest.java
+++ b/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/util/AuthorizationValidatorTest.java
@@ -40,11 +40,9 @@ class AuthorizationValidatorTest {
         @Test
         @DisplayName("Should throw NullPointerException when token is null")
         void shouldThrowWhenTokenIsNull() {
-            // Arrange
             AuthorizationRequirements requirements = new AuthorizationRequirements(
                     true, Set.of(), Set.of());
 
-            // Act & Assert
             assertThrows(NullPointerException.class,
                     () -> AuthorizationValidator.validate(null, requirements));
         }
@@ -52,11 +50,9 @@ class AuthorizationValidatorTest {
         @Test
         @DisplayName("Should throw NullPointerException when requirements is null")
         void shouldThrowWhenRequirementsIsNull() {
-            // Arrange
             TestTokenHolder tokenHolder = TestTokenGenerators.accessTokens().next();
             AccessTokenContent token = tokenHolder.asAccessTokenContent();
 
-            // Act & Assert
             assertThrows(NullPointerException.class,
                     () -> AuthorizationValidator.validate(token, null));
         }
@@ -69,16 +65,13 @@ class AuthorizationValidatorTest {
         @Test
         @DisplayName("Should authorize when no roles or scopes required")
         void shouldAuthorizeWhenNoRequirements() {
-            // Arrange
             TestTokenHolder tokenHolder = TestTokenGenerators.accessTokens().next();
             AccessTokenContent token = tokenHolder.asAccessTokenContent();
             AuthorizationRequirements requirements = new AuthorizationRequirements(
                     true, Set.of(), Set.of());
 
-            // Act
             AuthorizationResult result = AuthorizationValidator.validate(token, requirements);
 
-            // Assert
             assertTrue(result.authorized());
             assertNull(result.reason());
             assertTrue(result.missingScopes().isEmpty());
@@ -88,16 +81,13 @@ class AuthorizationValidatorTest {
         @Test
         @DisplayName("Should authorize when requirements has no authorization checks")
         void shouldAuthorizeWhenNoAuthorizationChecks() {
-            // Arrange
             TestTokenHolder tokenHolder = TestTokenGenerators.accessTokens().next();
             AccessTokenContent token = tokenHolder.asAccessTokenContent();
             AuthorizationRequirements requirements = new AuthorizationRequirements(
                     false, Set.of(), Set.of());
 
-            // Act
             AuthorizationResult result = AuthorizationValidator.validate(token, requirements);
 
-            // Assert
             assertTrue(result.authorized());
             assertNull(result.reason());
         }
@@ -110,7 +100,6 @@ class AuthorizationValidatorTest {
         @Test
         @DisplayName("Should authorize when token has all required roles")
         void shouldAuthorizeWhenTokenHasAllRoles() {
-            // Arrange
             TestTokenHolder tokenHolder = TestTokenGenerators.accessTokens().next();
             tokenHolder.withClaim("roles", ClaimValue.forList("admin,user",
                     List.of("admin", "user", "viewer")));
@@ -119,10 +108,8 @@ class AuthorizationValidatorTest {
             AuthorizationRequirements requirements = new AuthorizationRequirements(
                     true, Set.of("admin", "user"), Set.of());
 
-            // Act
             AuthorizationResult result = AuthorizationValidator.validate(token, requirements);
 
-            // Assert
             assertTrue(result.authorized());
             assertNull(result.reason());
             assertTrue(result.missingRoles().isEmpty());
@@ -131,7 +118,6 @@ class AuthorizationValidatorTest {
         @Test
         @DisplayName("Should not authorize when token missing required roles")
         void shouldNotAuthorizeWhenMissingRoles() {
-            // Arrange
             TestTokenHolder tokenHolder = TestTokenGenerators.accessTokens().next();
             tokenHolder.withClaim("roles", ClaimValue.forList("user",
                     List.of("user", "viewer")));
@@ -140,10 +126,8 @@ class AuthorizationValidatorTest {
             AuthorizationRequirements requirements = new AuthorizationRequirements(
                     true, Set.of("admin", "superuser"), Set.of());
 
-            // Act
             AuthorizationResult result = AuthorizationValidator.validate(token, requirements);
 
-            // Assert
             assertFalse(result.authorized());
             assertNotNull(result.reason());
             assertTrue(result.reason().contains("Missing roles"));
@@ -155,7 +139,6 @@ class AuthorizationValidatorTest {
         @Test
         @DisplayName("Should not authorize when token has only non-matching roles")
         void shouldNotAuthorizeWhenTokenHasNonMatchingRoles() {
-            // Arrange
             TestTokenHolder tokenHolder = TestTokenGenerators.accessTokens().next();
             tokenHolder.withClaim("roles", ClaimValue.forList("viewer",
                     List.of("viewer")));
@@ -164,10 +147,8 @@ class AuthorizationValidatorTest {
             AuthorizationRequirements requirements = new AuthorizationRequirements(
                     true, Set.of("admin"), Set.of());
 
-            // Act
             AuthorizationResult result = AuthorizationValidator.validate(token, requirements);
 
-            // Assert
             assertFalse(result.authorized());
             assertNotNull(result.reason());
             assertTrue(result.reason().contains("Missing roles"));
@@ -181,7 +162,6 @@ class AuthorizationValidatorTest {
         @Test
         @DisplayName("Should authorize when token has all required scopes")
         void shouldAuthorizeWhenTokenHasAllScopes() {
-            // Arrange
             TestTokenHolder tokenHolder = TestTokenGenerators.accessTokens().next();
             tokenHolder.withClaim("scope", ClaimValue.forList("read write delete",
                     List.of("read", "write", "delete")));
@@ -190,10 +170,8 @@ class AuthorizationValidatorTest {
             AuthorizationRequirements requirements = new AuthorizationRequirements(
                     true, Set.of(), Set.of("read", "write"));
 
-            // Act
             AuthorizationResult result = AuthorizationValidator.validate(token, requirements);
 
-            // Assert
             assertTrue(result.authorized());
             assertNull(result.reason());
             assertTrue(result.missingScopes().isEmpty());
@@ -202,7 +180,6 @@ class AuthorizationValidatorTest {
         @Test
         @DisplayName("Should not authorize when token missing required scopes")
         void shouldNotAuthorizeWhenMissingScopes() {
-            // Arrange
             TestTokenHolder tokenHolder = TestTokenGenerators.accessTokens().next();
             tokenHolder.withClaim("scope", ClaimValue.forList("read",
                     List.of("read")));
@@ -211,10 +188,8 @@ class AuthorizationValidatorTest {
             AuthorizationRequirements requirements = new AuthorizationRequirements(
                     true, Set.of(), Set.of("read", "write", "delete"));
 
-            // Act
             AuthorizationResult result = AuthorizationValidator.validate(token, requirements);
 
-            // Assert
             assertFalse(result.authorized());
             assertNotNull(result.reason());
             assertTrue(result.reason().contains("Missing scopes"));
@@ -226,17 +201,14 @@ class AuthorizationValidatorTest {
         @Test
         @DisplayName("Should not authorize when token has no scopes but scopes required")
         void shouldNotAuthorizeWhenTokenHasNoScopes() {
-            // Arrange
             TestTokenHolder tokenHolder = TestTokenGenerators.accessTokens().next();
             AccessTokenContent token = tokenHolder.asAccessTokenContent();
 
             AuthorizationRequirements requirements = new AuthorizationRequirements(
                     true, Set.of(), Set.of("read"));
 
-            // Act
             AuthorizationResult result = AuthorizationValidator.validate(token, requirements);
 
-            // Assert
             assertFalse(result.authorized());
             assertNotNull(result.reason());
             assertTrue(result.reason().contains("Missing scopes"));
@@ -250,7 +222,6 @@ class AuthorizationValidatorTest {
         @Test
         @DisplayName("Should authorize when token has both required roles and scopes")
         void shouldAuthorizeWhenBothRolesAndScopesSatisfied() {
-            // Arrange
             TestTokenHolder tokenHolder = TestTokenGenerators.accessTokens().next();
             tokenHolder.withClaim("roles", ClaimValue.forList("admin,user",
                     List.of("admin", "user")));
@@ -261,10 +232,8 @@ class AuthorizationValidatorTest {
             AuthorizationRequirements requirements = new AuthorizationRequirements(
                     true, Set.of("admin"), Set.of("read"));
 
-            // Act
             AuthorizationResult result = AuthorizationValidator.validate(token, requirements);
 
-            // Assert
             assertTrue(result.authorized());
             assertNull(result.reason());
             assertTrue(result.missingRoles().isEmpty());
@@ -274,7 +243,6 @@ class AuthorizationValidatorTest {
         @Test
         @DisplayName("Should not authorize when roles satisfied but scopes missing")
         void shouldNotAuthorizeWhenRolesOkButScopesMissing() {
-            // Arrange
             TestTokenHolder tokenHolder = TestTokenGenerators.accessTokens().next();
             tokenHolder.withClaim("roles", ClaimValue.forList("admin",
                     List.of("admin")));
@@ -285,10 +253,8 @@ class AuthorizationValidatorTest {
             AuthorizationRequirements requirements = new AuthorizationRequirements(
                     true, Set.of("admin"), Set.of("read", "write"));
 
-            // Act
             AuthorizationResult result = AuthorizationValidator.validate(token, requirements);
 
-            // Assert
             assertFalse(result.authorized());
             assertNotNull(result.reason());
             assertTrue(result.reason().contains("Missing scopes"));
@@ -299,7 +265,6 @@ class AuthorizationValidatorTest {
         @Test
         @DisplayName("Should not authorize when scopes satisfied but roles missing")
         void shouldNotAuthorizeWhenScopesOkButRolesMissing() {
-            // Arrange
             TestTokenHolder tokenHolder = TestTokenGenerators.accessTokens().next();
             tokenHolder.withClaim("roles", ClaimValue.forList("user",
                     List.of("user")));
@@ -310,10 +275,8 @@ class AuthorizationValidatorTest {
             AuthorizationRequirements requirements = new AuthorizationRequirements(
                     true, Set.of("admin"), Set.of("read"));
 
-            // Act
             AuthorizationResult result = AuthorizationValidator.validate(token, requirements);
 
-            // Assert
             assertFalse(result.authorized());
             assertNotNull(result.reason());
             assertTrue(result.reason().contains("Missing roles"));
@@ -324,7 +287,6 @@ class AuthorizationValidatorTest {
         @Test
         @DisplayName("Should not authorize when both roles and scopes missing")
         void shouldNotAuthorizeWhenBothRolesAndScopesMissing() {
-            // Arrange
             TestTokenHolder tokenHolder = TestTokenGenerators.accessTokens().next();
             tokenHolder.withClaim("roles", ClaimValue.forList("viewer",
                     List.of("viewer")));
@@ -335,10 +297,8 @@ class AuthorizationValidatorTest {
             AuthorizationRequirements requirements = new AuthorizationRequirements(
                     true, Set.of("admin"), Set.of("write"));
 
-            // Act
             AuthorizationResult result = AuthorizationValidator.validate(token, requirements);
 
-            // Assert
             assertFalse(result.authorized());
             assertNotNull(result.reason());
             assertTrue(result.reason().contains("Missing scopes"));
@@ -355,7 +315,6 @@ class AuthorizationValidatorTest {
         @Test
         @DisplayName("Should create result via builder with all fields")
         void shouldCreateResultViaBuilder() {
-            // Arrange & Act
             AuthorizationResult result = AuthorizationResult.builder()
                     .authorized(false)
                     .reason("Test failure reason")
@@ -363,7 +322,6 @@ class AuthorizationValidatorTest {
                     .missingRoles(Set.of("admin"))
                     .build();
 
-            // Assert
             assertFalse(result.authorized());
             assertEquals("Test failure reason", result.reason());
             assertEquals(Set.of("write", "delete"), result.missingScopes());
@@ -373,7 +331,6 @@ class AuthorizationValidatorTest {
         @Test
         @DisplayName("Should handle null reason in result")
         void shouldHandleNullReason() {
-            // Arrange & Act
             AuthorizationResult result = AuthorizationResult.builder()
                     .authorized(true)
                     .reason(null)
@@ -381,7 +338,6 @@ class AuthorizationValidatorTest {
                     .missingRoles(Set.of())
                     .build();
 
-            // Assert
             assertTrue(result.authorized());
             assertNull(result.reason());
         }
@@ -389,7 +345,6 @@ class AuthorizationValidatorTest {
         @Test
         @DisplayName("Should support equals and hashCode")
         void shouldSupportEqualsAndHashCode() {
-            // Arrange
             AuthorizationResult result1 = AuthorizationResult.builder()
                     .authorized(true)
                     .missingScopes(Set.of())
@@ -402,7 +357,6 @@ class AuthorizationValidatorTest {
                     .missingRoles(Set.of())
                     .build();
 
-            // Act & Assert
             assertEquals(result1, result2);
             assertEquals(result1.hashCode(), result2.hashCode());
         }

--- a/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/util/DynamicPropertyGroupParserTest.java
+++ b/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/util/DynamicPropertyGroupParserTest.java
@@ -35,16 +35,13 @@ class DynamicPropertyGroupParserTest {
         @Test
         @DisplayName("Should parse properties with a single group")
         void shouldParsePropertiesWithSingleGroup() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("restapi.health.path", "/api/health");
             properties.put("restapi.health.methods", "GET");
             properties.put("restapi.health.schema", "health-schema");
 
-            // Act
             Map<String, Map<String, String>> result = DynamicPropertyGroupParser.parse("restapi.", properties);
 
-            // Assert
             assertEquals(1, result.size());
             assertTrue(result.containsKey("health"));
             assertEquals("/api/health", result.get("health").get("path"));
@@ -55,17 +52,14 @@ class DynamicPropertyGroupParserTest {
         @Test
         @DisplayName("Should parse properties with multiple groups")
         void shouldParsePropertiesWithMultipleGroups() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("restapi.health.path", "/api/health");
             properties.put("restapi.health.methods", "GET");
             properties.put("restapi.users.path", "/api/users");
             properties.put("restapi.users.methods", "GET,POST");
 
-            // Act
             Map<String, Map<String, String>> result = DynamicPropertyGroupParser.parse("restapi.", properties);
 
-            // Assert
             assertEquals(2, result.size());
             assertEquals("/api/health", result.get("health").get("path"));
             assertEquals("GET", result.get("health").get("methods"));
@@ -76,16 +70,13 @@ class DynamicPropertyGroupParserTest {
         @Test
         @DisplayName("Should ignore properties without matching prefix")
         void shouldIgnorePropertiesWithoutPrefix() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("restapi.health.path", "/api/health");
             properties.put("other.setting", "value");
             properties.put("unrelated", "data");
 
-            // Act
             Map<String, Map<String, String>> result = DynamicPropertyGroupParser.parse("restapi.", properties);
 
-            // Assert
             assertEquals(1, result.size());
             assertTrue(result.containsKey("health"));
         }
@@ -93,15 +84,12 @@ class DynamicPropertyGroupParserTest {
         @Test
         @DisplayName("Should ignore properties without dot after group name")
         void shouldIgnorePropertiesWithoutDotAfterGroupName() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("restapi.health", "value-without-property");
             properties.put("restapi.health.path", "/api/health");
 
-            // Act
             Map<String, Map<String, String>> result = DynamicPropertyGroupParser.parse("restapi.", properties);
 
-            // Assert
             assertEquals(1, result.size());
             assertEquals(1, result.get("health").size());
             assertEquals("/api/health", result.get("health").get("path"));
@@ -110,10 +98,8 @@ class DynamicPropertyGroupParserTest {
         @Test
         @DisplayName("Should return empty map for empty input")
         void shouldReturnEmptyMapForEmptyInput() {
-            // Act
             Map<String, Map<String, String>> result = DynamicPropertyGroupParser.parse("restapi.", Map.of());
 
-            // Assert
             assertTrue(result.isEmpty());
         }
 
@@ -135,14 +121,11 @@ class DynamicPropertyGroupParserTest {
         @Test
         @DisplayName("Should handle dot in property name after group")
         void shouldHandleDotInPropertyName() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("restapi.users.some.nested.key", "nested-value");
 
-            // Act
             Map<String, Map<String, String>> result = DynamicPropertyGroupParser.parse("restapi.", properties);
 
-            // Assert
             assertEquals(1, result.size());
             assertEquals("nested-value", result.get("users").get("some.nested.key"));
         }
@@ -155,15 +138,12 @@ class DynamicPropertyGroupParserTest {
         @Test
         @DisplayName("Should strip prefix correctly")
         void shouldStripPrefixCorrectly() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("issuer.myIssuer.name", "TestIssuer");
             properties.put("issuer.myIssuer.jwks-url", "https://example.com/jwks");
 
-            // Act
             Map<String, Map<String, String>> result = DynamicPropertyGroupParser.parse("issuer.", properties);
 
-            // Assert
             assertEquals(1, result.size());
             assertTrue(result.containsKey("myIssuer"));
             assertEquals("TestIssuer", result.get("myIssuer").get("name"));
@@ -173,15 +153,12 @@ class DynamicPropertyGroupParserTest {
         @Test
         @DisplayName("Should work with different prefixes")
         void shouldWorkWithDifferentPrefixes() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("custom.prefix.group1.key", "value1");
             properties.put("custom.prefix.group2.key", "value2");
 
-            // Act
             Map<String, Map<String, String>> result = DynamicPropertyGroupParser.parse("custom.prefix.", properties);
 
-            // Assert
             assertEquals(2, result.size());
             assertEquals("value1", result.get("group1").get("key"));
             assertEquals("value2", result.get("group2").get("key"));

--- a/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/util/ErrorContextTest.java
+++ b/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/util/ErrorContextTest.java
@@ -34,7 +34,6 @@ class ErrorContextTest {
         @Test
         @DisplayName("Should create instance with all fields via builder")
         void shouldCreateWithAllFields() {
-            // Arrange & Act
             ErrorContext context = ErrorContext.builder()
                     .operation("tokenValidation")
                     .component("JwtProcessor")
@@ -42,7 +41,6 @@ class ErrorContextTest {
                     .cause(new RuntimeException("Test error"))
                     .build();
 
-            // Assert
             assertEquals("tokenValidation", context.getOperation());
             assertEquals("JwtProcessor", context.getComponent());
             assertEquals("AUTH_001", context.getErrorCode());
@@ -54,13 +52,11 @@ class ErrorContextTest {
         @Test
         @DisplayName("Should create instance with minimal fields")
         void shouldCreateWithMinimalFields() {
-            // Arrange & Act
             ErrorContext context = ErrorContext.builder()
                     .operation("processing")
                     .component("TestComponent")
                     .build();
 
-            // Assert
             assertEquals("processing", context.getOperation());
             assertEquals("TestComponent", context.getComponent());
             assertNull(context.getErrorCode());
@@ -76,12 +72,10 @@ class ErrorContextTest {
         @Test
         @DisplayName("Should create builder via forComponent")
         void shouldCreateBuilderViaForComponent() {
-            // Arrange & Act
             ErrorContext context = ErrorContext.forComponent("MyComponent")
                     .operation("myOperation")
                     .build();
 
-            // Assert
             assertEquals("MyComponent", context.getComponent());
             assertEquals("myOperation", context.getOperation());
         }
@@ -94,19 +88,16 @@ class ErrorContextTest {
         @Test
         @DisplayName("Should add valid key-value pairs to context")
         void shouldAddValidKeyValuePairs() {
-            // Arrange
             ErrorContext context = ErrorContext.builder()
                     .operation("test")
                     .component("test")
                     .build();
 
-            // Act
             context.with("key1", "value1")
                     .with("key_2", "value2")
                     .with("key-3", "value3")
                     .with("key.4", 123);
 
-            // Assert
             Map<String, Object> contextMap = context.getContext();
             assertEquals("value1", contextMap.get("key1"));
             assertEquals("value2", contextMap.get("key_2"));
@@ -117,68 +108,56 @@ class ErrorContextTest {
         @Test
         @DisplayName("Should ignore null keys")
         void shouldIgnoreNullKeys() {
-            // Arrange
             ErrorContext context = ErrorContext.builder()
                     .operation("test")
                     .component("test")
                     .build();
 
-            // Act
             context.with(null, "value");
 
-            // Assert
             assertTrue(context.getContext().isEmpty());
         }
 
         @Test
         @DisplayName("Should ignore null values")
         void shouldIgnoreNullValues() {
-            // Arrange
             ErrorContext context = ErrorContext.builder()
                     .operation("test")
                     .component("test")
                     .build();
 
-            // Act
             context.with("key", null);
 
-            // Assert
             assertTrue(context.getContext().isEmpty());
         }
 
         @Test
         @DisplayName("Should ignore keys with invalid format")
         void shouldIgnoreInvalidKeyFormat() {
-            // Arrange
             ErrorContext context = ErrorContext.builder()
                     .operation("test")
                     .component("test")
                     .build();
 
-            // Act
             context.with("invalid key", "value1")  // space not allowed
                     .with("key@test", "value2")      // @ not allowed
                     .with("key#test", "value3")      // # not allowed
                     .with("", "value4");             // empty not allowed
 
-            // Assert
             assertTrue(context.getContext().isEmpty());
         }
 
         @Test
         @DisplayName("Should return unmodifiable context map")
         void shouldReturnUnmodifiableContextMap() {
-            // Arrange
             ErrorContext context = ErrorContext.builder()
                     .operation("test")
                     .component("test")
                     .build();
             context.with("key1", "value1");
 
-            // Act
             Map<String, Object> contextMap = context.getContext();
 
-            // Assert
             assertThrows(UnsupportedOperationException.class,
                     () -> contextMap.put("key2", "value2"));
         }
@@ -186,17 +165,14 @@ class ErrorContextTest {
         @Test
         @DisplayName("Should allow method chaining with 'with'")
         void shouldAllowMethodChaining() {
-            // Arrange
             ErrorContext context = ErrorContext.builder()
                     .operation("test")
                     .component("test")
                     .build();
 
-            // Act
             ErrorContext result = context.with("key1", "value1")
                     .with("key2", "value2");
 
-            // Assert
             assertSame(context, result);
             assertEquals(2, context.getContext().size());
         }
@@ -209,7 +185,6 @@ class ErrorContextTest {
         @Test
         @DisplayName("Should build message with all components")
         void shouldBuildMessageWithAllComponents() {
-            // Arrange
             ErrorContext context = ErrorContext.builder()
                     .operation("tokenValidation")
                     .component("JwtProcessor")
@@ -217,10 +192,8 @@ class ErrorContextTest {
                     .build();
             context.with("issuer", "https://auth.example.com");
 
-            // Act
             String message = context.buildMessage("Token validation failed");
 
-            // Assert
             assertTrue(message.contains("Token validation failed"));
             assertTrue(message.contains("ErrorCode=AUTH_001"));
             assertTrue(message.contains("Component=JwtProcessor"));
@@ -231,16 +204,13 @@ class ErrorContextTest {
         @Test
         @DisplayName("Should build message without error code when null")
         void shouldBuildMessageWithoutErrorCode() {
-            // Arrange
             ErrorContext context = ErrorContext.builder()
                     .operation("processing")
                     .component("TestComponent")
                     .build();
 
-            // Act
             String message = context.buildMessage("Processing failed");
 
-            // Assert
             assertTrue(message.contains("Processing failed"));
             assertTrue(message.contains("Component=TestComponent"));
             assertTrue(message.contains("Operation=processing"));
@@ -250,7 +220,6 @@ class ErrorContextTest {
         @Test
         @DisplayName("Should truncate long context values at 100 characters")
         void shouldTruncateLongValues() {
-            // Arrange
             ErrorContext context = ErrorContext.builder()
                     .operation("test")
                     .component("test")
@@ -258,10 +227,8 @@ class ErrorContextTest {
             String longValue = "A".repeat(150);
             context.with("longKey", longValue);
 
-            // Act
             String message = context.buildMessage("Test");
 
-            // Assert
             assertTrue(message.contains("longKey=" + "A".repeat(97) + "..."));
             assertFalse(message.contains("A".repeat(100)));
         }
@@ -269,7 +236,6 @@ class ErrorContextTest {
         @Test
         @DisplayName("Should include cause information")
         void shouldIncludeCauseInformation() {
-            // Arrange
             Exception cause = new IllegalArgumentException("Invalid token format");
             ErrorContext context = ErrorContext.builder()
                     .operation("tokenParsing")
@@ -277,10 +243,8 @@ class ErrorContextTest {
                     .cause(cause)
                     .build();
 
-            // Act
             String message = context.buildMessage("Parsing failed");
 
-            // Assert
             assertTrue(message.contains("Caused by: IllegalArgumentException"));
             assertTrue(message.contains("Invalid token format"));
         }
@@ -288,7 +252,6 @@ class ErrorContextTest {
         @Test
         @DisplayName("Should include root cause when different from direct cause")
         void shouldIncludeRootCauseWhenDifferent() {
-            // Arrange
             Exception rootCause = new IllegalStateException("Connection lost");
             Exception middleCause = new RuntimeException("Processing error", rootCause);
             Exception topCause = new Exception("Operation failed", middleCause);
@@ -299,10 +262,8 @@ class ErrorContextTest {
                     .cause(topCause)
                     .build();
 
-            // Act
             String message = context.buildMessage("Failed");
 
-            // Assert
             assertTrue(message.contains("Caused by: Exception"));
             assertTrue(message.contains("Operation failed"));
             assertTrue(message.contains("Root cause: IllegalStateException"));
@@ -312,7 +273,6 @@ class ErrorContextTest {
         @Test
         @DisplayName("Should not duplicate root cause when same as direct cause")
         void shouldNotDuplicateRootCause() {
-            // Arrange
             Exception cause = new IllegalArgumentException("Invalid input");
             ErrorContext context = ErrorContext.builder()
                     .operation("validation")
@@ -320,10 +280,8 @@ class ErrorContextTest {
                     .cause(cause)
                     .build();
 
-            // Act
             String message = context.buildMessage("Validation failed");
 
-            // Assert
             assertTrue(message.contains("Caused by: IllegalArgumentException"));
             assertFalse(message.contains("Root cause:"));
         }
@@ -331,7 +289,6 @@ class ErrorContextTest {
         @Test
         @DisplayName("Should handle null context values")
         void shouldHandleNullContextValues() {
-            // Arrange
             ErrorContext context = ErrorContext.builder()
                     .operation("test")
                     .component("test")
@@ -354,7 +311,6 @@ class ErrorContextTest {
         @Test
         @DisplayName("Should return same throwable when no cause")
         void shouldReturnSelfWhenNoCause() {
-            // Arrange
             Exception exception = new RuntimeException("Test");
             ErrorContext context = ErrorContext.builder()
                     .operation("test")
@@ -373,7 +329,6 @@ class ErrorContextTest {
         @Test
         @DisplayName("Should traverse chain of 3 causes")
         void shouldTraverseThreeLevelCauseChain() {
-            // Arrange
             Exception level3 = new IllegalArgumentException("Root problem");
             Exception level2 = new RuntimeException("Middle problem", level3);
             Exception level1 = new Exception("Top problem", level2);
@@ -384,10 +339,8 @@ class ErrorContextTest {
                     .cause(level1)
                     .build();
 
-            // Act
             String message = context.buildMessage("Test");
 
-            // Assert
             assertTrue(message.contains("Caused by: Exception"));
             assertTrue(message.contains("Root cause: IllegalArgumentException"));
             assertTrue(message.contains("Root problem"));
@@ -396,7 +349,6 @@ class ErrorContextTest {
         @Test
         @DisplayName("Should handle circular cause reference")
         void shouldHandleCircularCauseReference() {
-            // Arrange
             Exception exception1 = new RuntimeException("Error 1");
             Exception exception2 = new RuntimeException("Error 2", exception1);
             // Create circular reference via reflection
@@ -449,7 +401,6 @@ class ErrorContextTest {
         @Test
         @DisplayName("Should have all error code constants accessible")
         void shouldHaveAllErrorCodes() {
-            // Assert
             assertEquals("CONFIG_ERROR", ErrorContext.ErrorCodes.CONFIGURATION_ERROR);
             assertEquals("VALIDATION_ERROR", ErrorContext.ErrorCodes.VALIDATION_ERROR);
             assertEquals("PROCESSING_ERROR", ErrorContext.ErrorCodes.PROCESSING_ERROR);
@@ -465,17 +416,14 @@ class ErrorContextTest {
         @Test
         @DisplayName("Should use error codes in context")
         void shouldUseErrorCodesInContext() {
-            // Arrange
             ErrorContext context = ErrorContext.builder()
                     .operation("authentication")
                     .component("AuthService")
                     .errorCode(ErrorContext.ErrorCodes.AUTHENTICATION_ERROR)
                     .build();
 
-            // Act
             String message = context.buildMessage("Auth failed");
 
-            // Assert
             assertTrue(message.contains("ErrorCode=AUTH_ERROR"));
         }
     }

--- a/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/util/ProcessingErrorTest.java
+++ b/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/util/ProcessingErrorTest.java
@@ -31,14 +31,12 @@ class ProcessingErrorTest {
         @Test
         @DisplayName("Should create instance with all fields via builder")
         void shouldCreateWithAllFields() {
-            // Arrange & Act
             ProcessingError error = ProcessingError.builder()
                     .errorCode("AUTH_001")
                     .errorReason("Invalid token signature")
                     .errorCategory("AUTHENTICATION")
                     .build();
 
-            // Assert
             assertEquals("AUTH_001", error.errorCode());
             assertEquals("Invalid token signature", error.errorReason());
             assertEquals("AUTHENTICATION", error.errorCategory());
@@ -47,14 +45,12 @@ class ProcessingErrorTest {
         @Test
         @DisplayName("Should create instance with null values")
         void shouldCreateWithNullValues() {
-            // Arrange & Act
             ProcessingError error = ProcessingError.builder()
                     .errorCode(null)
                     .errorReason(null)
                     .errorCategory(null)
                     .build();
 
-            // Assert
             assertNull(error.errorCode());
             assertNull(error.errorReason());
             assertNull(error.errorCategory());
@@ -63,13 +59,11 @@ class ProcessingErrorTest {
         @Test
         @DisplayName("Should create instance with partial fields")
         void shouldCreateWithPartialFields() {
-            // Arrange & Act
             ProcessingError error = ProcessingError.builder()
                     .errorCode("TOKEN_EXPIRED")
                     .errorReason("The access token has expired")
                     .build();
 
-            // Assert
             assertEquals("TOKEN_EXPIRED", error.errorCode());
             assertEquals("The access token has expired", error.errorReason());
             assertNull(error.errorCategory());
@@ -83,7 +77,6 @@ class ProcessingErrorTest {
         @Test
         @DisplayName("Should be equal when all fields match")
         void shouldBeEqualWhenFieldsMatch() {
-            // Arrange
             ProcessingError error1 = ProcessingError.builder()
                     .errorCode("ERR_001")
                     .errorReason("Test error")
@@ -96,7 +89,6 @@ class ProcessingErrorTest {
                     .errorCategory("TEST")
                     .build();
 
-            // Act & Assert
             assertEquals(error1, error2);
             assertEquals(error1.hashCode(), error2.hashCode());
         }
@@ -104,7 +96,6 @@ class ProcessingErrorTest {
         @Test
         @DisplayName("Should not be equal when errorCode differs")
         void shouldNotBeEqualWhenErrorCodeDiffers() {
-            // Arrange
             ProcessingError error1 = ProcessingError.builder()
                     .errorCode("ERR_001")
                     .errorReason("Test error")
@@ -117,14 +108,12 @@ class ProcessingErrorTest {
                     .errorCategory("TEST")
                     .build();
 
-            // Act & Assert
             assertNotEquals(error1, error2);
         }
 
         @Test
         @DisplayName("Should not be equal when errorReason differs")
         void shouldNotBeEqualWhenErrorReasonDiffers() {
-            // Arrange
             ProcessingError error1 = ProcessingError.builder()
                     .errorCode("ERR_001")
                     .errorReason("First error")
@@ -137,14 +126,12 @@ class ProcessingErrorTest {
                     .errorCategory("TEST")
                     .build();
 
-            // Act & Assert
             assertNotEquals(error1, error2);
         }
 
         @Test
         @DisplayName("Should not be equal when errorCategory differs")
         void shouldNotBeEqualWhenErrorCategoryDiffers() {
-            // Arrange
             ProcessingError error1 = ProcessingError.builder()
                     .errorCode("ERR_001")
                     .errorReason("Test error")
@@ -157,14 +144,12 @@ class ProcessingErrorTest {
                     .errorCategory("CATEGORY_B")
                     .build();
 
-            // Act & Assert
             assertNotEquals(error1, error2);
         }
 
         @Test
         @DisplayName("Should handle null values in equals")
         void shouldHandleNullsInEquals() {
-            // Arrange
             ProcessingError error1 = ProcessingError.builder()
                     .errorCode(null)
                     .errorReason(null)
@@ -177,7 +162,6 @@ class ProcessingErrorTest {
                     .errorCategory(null)
                     .build();
 
-            // Act & Assert
             assertEquals(error1, error2);
             assertEquals(error1.hashCode(), error2.hashCode());
         }
@@ -185,26 +169,22 @@ class ProcessingErrorTest {
         @Test
         @DisplayName("Should not be equal to null")
         void shouldNotBeEqualToNull() {
-            // Arrange
             ProcessingError error = ProcessingError.builder()
                     .errorCode("ERR_001")
                     .build();
 
-            // Act & Assert
             assertNotEquals(null, error);
         }
 
         @Test
         @DisplayName("Should be equal to itself")
         void shouldBeEqualToItself() {
-            // Arrange
             ProcessingError error = ProcessingError.builder()
                     .errorCode("ERR_001")
                     .errorReason("Test")
                     .errorCategory("TEST")
                     .build();
 
-            // Act & Assert
             assertEquals(error, error);
         }
     }
@@ -216,17 +196,14 @@ class ProcessingErrorTest {
         @Test
         @DisplayName("Should include all fields in toString")
         void shouldIncludeAllFieldsInToString() {
-            // Arrange
             ProcessingError error = ProcessingError.builder()
                     .errorCode("AUTH_FAILED")
                     .errorReason("Invalid credentials")
                     .errorCategory("SECURITY")
                     .build();
 
-            // Act
             String result = error.toString();
 
-            // Assert
             assertTrue(result.contains("AUTH_FAILED"));
             assertTrue(result.contains("Invalid credentials"));
             assertTrue(result.contains("SECURITY"));
@@ -240,36 +217,30 @@ class ProcessingErrorTest {
         @Test
         @DisplayName("Should return correct errorCode via getter")
         void shouldReturnCorrectErrorCode() {
-            // Arrange
             ProcessingError error = ProcessingError.builder()
                     .errorCode("TEST_CODE")
                     .build();
 
-            // Act & Assert
             assertEquals("TEST_CODE", error.errorCode());
         }
 
         @Test
         @DisplayName("Should return correct errorReason via getter")
         void shouldReturnCorrectErrorReason() {
-            // Arrange
             ProcessingError error = ProcessingError.builder()
                     .errorReason("Test reason message")
                     .build();
 
-            // Act & Assert
             assertEquals("Test reason message", error.errorReason());
         }
 
         @Test
         @DisplayName("Should return correct errorCategory via getter")
         void shouldReturnCorrectErrorCategory() {
-            // Arrange
             ProcessingError error = ProcessingError.builder()
                     .errorCategory("VALIDATION")
                     .build();
 
-            // Act & Assert
             assertEquals("VALIDATION", error.errorCategory());
         }
     }

--- a/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/util/TokenMaskingTest.java
+++ b/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/util/TokenMaskingTest.java
@@ -34,26 +34,20 @@ class TokenMaskingTest {
         @Test
         @DisplayName("Should return *** for null token")
         void shouldMaskNullToken() {
-            // Arrange
             String token = null;
 
-            // Act
             String result = TokenMasking.maskToken(token);
 
-            // Assert
             assertEquals("***", result);
         }
 
         @Test
         @DisplayName("Should return *** for empty string")
         void shouldMaskEmptyToken() {
-            // Arrange
             String token = "";
 
-            // Act
             String result = TokenMasking.maskToken(token);
 
-            // Assert
             assertEquals("***", result);
         }
     }
@@ -76,39 +70,30 @@ class TokenMaskingTest {
         @Test
         @DisplayName("Should mask 13 character token showing first 8 chars")
         void shouldMaskThirteenCharToken() {
-            // Arrange
             String token = "1234567890123";
 
-            // Act
             String result = TokenMasking.maskToken(token);
 
-            // Assert
             assertEquals("12345678...[13 chars]", result);
         }
 
         @Test
         @DisplayName("Should mask 20 character token showing first 8 chars")
         void shouldMaskTwentyCharToken() {
-            // Arrange
             String token = "12345678901234567890";
 
-            // Act
             String result = TokenMasking.maskToken(token);
 
-            // Assert
             assertEquals("12345678...[20 chars]", result);
         }
 
         @Test
         @DisplayName("Should mask realistic JWT token")
         void shouldMaskRealisticJwt() {
-            // Arrange
             String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
 
-            // Act
             String result = TokenMasking.maskToken(token);
 
-            // Assert
             assertTrue(result.startsWith("eyJhbGci..."),
                     "Should start with first 8 chars of JWT");
             assertTrue(result.contains("chars]"),
@@ -118,13 +103,10 @@ class TokenMaskingTest {
         @Test
         @DisplayName("Should mask very long token (1000+ chars)")
         void shouldMaskVeryLongToken() {
-            // Arrange
             String token = "A".repeat(1000);
 
-            // Act
             String result = TokenMasking.maskToken(token);
 
-            // Assert
             assertEquals("AAAAAAAA...[1000 chars]", result);
         }
     }

--- a/nifi-cuioss-processors/src/test/java/de/cuioss/nifi/processors/auth/MultiIssuerJWTTokenAuthenticatorExtendedTest.java
+++ b/nifi-cuioss-processors/src/test/java/de/cuioss/nifi/processors/auth/MultiIssuerJWTTokenAuthenticatorExtendedTest.java
@@ -55,6 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
  * and authorization logic with representative token content.
  */
 @EnableTestLogger
+@DisplayName("Extended Tests for MultiIssuerJWTTokenAuthenticator")
 class MultiIssuerJWTTokenAuthenticatorExtendedTest {
 
     private static final String CS_ID = "jwt-config";
@@ -75,12 +76,11 @@ class MultiIssuerJWTTokenAuthenticatorExtendedTest {
         testRunner.setProperty(Properties.JWT_ISSUER_CONFIG_SERVICE, CS_ID);
     }
 
-    private MockFlowFile enqueueWithToken(String token) {
+    private void enqueueWithToken(String token) {
         Map<String, String> attributes = new HashMap<>();
         attributes.put(TOKEN_ATTR, token);
         testRunner.enqueue("test data", attributes);
         testRunner.run();
-        return null; // Caller retrieves from relationship
     }
 
     @Nested

--- a/nifi-cuioss-processors/src/test/java/de/cuioss/nifi/processors/auth/MultiIssuerJWTTokenAuthenticatorI18nTest.java
+++ b/nifi-cuioss-processors/src/test/java/de/cuioss/nifi/processors/auth/MultiIssuerJWTTokenAuthenticatorI18nTest.java
@@ -23,6 +23,7 @@ import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -30,7 +31,9 @@ import java.util.Map;
 
 import static de.cuioss.nifi.processors.auth.JwtProcessorConstants.Properties;
 import static de.cuioss.nifi.processors.auth.JwtProcessorConstants.Relationships;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test class for internationalization aspects of {@link MultiIssuerJWTTokenAuthenticator}.
@@ -59,69 +62,64 @@ class MultiIssuerJWTTokenAuthenticatorI18nTest {
                         "Token validation failed"));
     }
 
-    @Test
-    @DisplayName("Test internationalized error message for missing token")
-    void internationalizedErrorMessageForMissingToken() {
-        testRunner.enqueue("test data");
-
+    private MockFlowFile runAndGetFailedFlowFile() {
         testRunner.run();
 
         testRunner.assertTransferCount(Relationships.AUTHENTICATION_FAILED, 1);
-
-        MockFlowFile flowFile = testRunner.getFlowFilesForRelationship(
-                Relationships.AUTHENTICATION_FAILED).getFirst();
-
-        String errorReason = flowFile.getAttribute(JwtAttributes.Error.REASON);
-        assertNotNull(errorReason, "Error reason should not be null");
-        assertTrue(errorReason.contains("jwt.token") || errorReason.contains("Token") ||
-                errorReason.contains("token") || errorReason.contains("Kein"),
-                "Error message should reference the token attribute or mention token");
+        return testRunner.getFlowFilesForRelationship(Relationships.AUTHENTICATION_FAILED).getFirst();
     }
 
-    @Test
-    @DisplayName("Test internationalized error message for token size limit")
-    void internationalizedErrorMessageForTokenSizeLimit() {
-        Map<String, String> attributes = new HashMap<>();
-        attributes.put(TOKEN_ATTR, "X".repeat(20000));
-        testRunner.enqueue("test data", attributes);
+    @Nested
+    @DisplayName("Internationalized Error Messages")
+    class InternationalizedErrorMessageTests {
 
-        testRunner.run();
+        @Test
+        @DisplayName("Should reference the token attribute when no token is present")
+        void shouldReferenceTokenAttributeWhenMissingToken() {
+            testRunner.enqueue("test data");
 
-        testRunner.assertTransferCount(Relationships.AUTHENTICATION_FAILED, 1);
+            MockFlowFile flowFile = runAndGetFailedFlowFile();
 
-        MockFlowFile flowFile = testRunner.getFlowFilesForRelationship(
-                Relationships.AUTHENTICATION_FAILED).getFirst();
+            String errorReason = flowFile.getAttribute(JwtAttributes.Error.REASON);
+            assertNotNull(errorReason, "Error reason should be present");
+            assertTrue(errorReason.contains("jwt.token") || errorReason.contains("Token")
+                            || errorReason.contains("token") || errorReason.contains("Kein"),
+                    "Error message should reference the token attribute or mention token");
+        }
 
-        String errorReason = flowFile.getAttribute(JwtAttributes.Error.REASON);
-        String errorCode = flowFile.getAttribute(JwtAttributes.Error.CODE);
+        @Test
+        @DisplayName("Should report the size limit when token exceeds maximum size")
+        void shouldReportSizeLimitWhenTokenTooLarge() {
+            Map<String, String> attributes = new HashMap<>();
+            attributes.put(TOKEN_ATTR, "X".repeat(20000));
+            testRunner.enqueue("test data", attributes);
 
-        assertNotNull(errorReason, "Error reason should not be null");
-        assertEquals("AUTH-003", errorCode, "Error code should be AUTH-003");
-        // Check for size limit - could be formatted as "16384" or "16.384" depending on locale
-        assertTrue(errorReason.contains("16384") || errorReason.contains("16.384"),
-                "Error message should contain the size limit");
-    }
+            MockFlowFile flowFile = runAndGetFailedFlowFile();
 
-    @Test
-    @DisplayName("Test internationalized error message for malformed token")
-    void internationalizedErrorMessageForMalformedToken() {
-        // BeforeEach already configures validation failure — "malformedtoken" will
-        // pass through to TokenValidator which throws TokenValidationException
-        Map<String, String> attributes = new HashMap<>();
-        attributes.put(TOKEN_ATTR, "malformedtoken");
-        testRunner.enqueue("test data", attributes);
+            String errorReason = flowFile.getAttribute(JwtAttributes.Error.REASON);
+            String errorCode = flowFile.getAttribute(JwtAttributes.Error.CODE);
+            assertEquals("AUTH-003", errorCode, "Error code should signal oversized token");
+            assertNotNull(errorReason, "Error reason should be present");
+            // Size limit may be formatted as "16384" or "16.384" depending on locale
+            assertTrue(errorReason.contains("16384") || errorReason.contains("16.384"),
+                    "Error message should contain the size limit");
+        }
 
-        testRunner.run();
+        @Test
+        @DisplayName("Should populate error reason and code for a malformed token")
+        void shouldPopulateErrorForMalformedToken() {
+            // BeforeEach already configures validation failure — "malformedtoken" passes
+            // through to TokenValidator which throws TokenValidationException
+            Map<String, String> attributes = new HashMap<>();
+            attributes.put(TOKEN_ATTR, "malformedtoken");
+            testRunner.enqueue("test data", attributes);
 
-        testRunner.assertTransferCount(Relationships.AUTHENTICATION_FAILED, 1);
+            MockFlowFile flowFile = runAndGetFailedFlowFile();
 
-        MockFlowFile flowFile = testRunner.getFlowFilesForRelationship(
-                Relationships.AUTHENTICATION_FAILED).getFirst();
-
-        String errorReason = flowFile.getAttribute(JwtAttributes.Error.REASON);
-        String errorCode = flowFile.getAttribute(JwtAttributes.Error.CODE);
-
-        assertNotNull(errorReason, "Error reason should not be null");
-        assertNotNull(errorCode, "Error code should not be null");
+            String errorReason = flowFile.getAttribute(JwtAttributes.Error.REASON);
+            String errorCode = flowFile.getAttribute(JwtAttributes.Error.CODE);
+            assertNotNull(errorReason, "Error reason should be present");
+            assertNotNull(errorCode, "Error code should be present");
+        }
     }
 }

--- a/nifi-cuioss-processors/src/test/java/de/cuioss/nifi/processors/auth/MultiIssuerJWTTokenAuthenticatorTest.java
+++ b/nifi-cuioss-processors/src/test/java/de/cuioss/nifi/processors/auth/MultiIssuerJWTTokenAuthenticatorTest.java
@@ -40,13 +40,16 @@ import java.util.Map;
 
 import static de.cuioss.nifi.processors.auth.JwtProcessorConstants.Properties;
 import static de.cuioss.nifi.processors.auth.JwtProcessorConstants.Relationships;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Test class for {@link MultiIssuerJWTTokenAuthenticator}.
  * Tests processor behavior with a mock {@link de.cuioss.nifi.jwt.config.JwtIssuerConfigService}.
  */
 @EnableTestLogger
+@DisplayName("Tests for MultiIssuerJWTTokenAuthenticator")
 class MultiIssuerJWTTokenAuthenticatorTest {
 
     private static final String CS_ID = "jwt-config";

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/RestApiAttributesTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/RestApiAttributesTest.java
@@ -42,13 +42,22 @@ class RestApiAttributesTest {
     @Test
     @DisplayName("Should follow naming convention")
     void shouldFollowNamingConvention() {
-        assertTrue(RestApiAttributes.ROUTE_NAME.startsWith("rest."));
-        assertTrue(RestApiAttributes.ROUTE_PATH.startsWith("rest."));
-        assertTrue(RestApiAttributes.HTTP_METHOD.startsWith("http."));
-        assertTrue(RestApiAttributes.HTTP_REQUEST_URI.startsWith("http."));
-        assertTrue(RestApiAttributes.HTTP_REMOTE_HOST.startsWith("http."));
-        assertTrue(RestApiAttributes.CONTENT_TYPE.startsWith("mime."));
-        assertTrue(RestApiAttributes.QUERY_PARAM_PREFIX.startsWith("http."));
-        assertTrue(RestApiAttributes.HEADER_PREFIX.startsWith("http."));
+        assertAll("Attribute naming convention",
+                () -> assertTrue(RestApiAttributes.ROUTE_NAME.startsWith("rest."),
+                        "ROUTE_NAME should start with 'rest.'"),
+                () -> assertTrue(RestApiAttributes.ROUTE_PATH.startsWith("rest."),
+                        "ROUTE_PATH should start with 'rest.'"),
+                () -> assertTrue(RestApiAttributes.HTTP_METHOD.startsWith("http."),
+                        "HTTP_METHOD should start with 'http.'"),
+                () -> assertTrue(RestApiAttributes.HTTP_REQUEST_URI.startsWith("http."),
+                        "HTTP_REQUEST_URI should start with 'http.'"),
+                () -> assertTrue(RestApiAttributes.HTTP_REMOTE_HOST.startsWith("http."),
+                        "HTTP_REMOTE_HOST should start with 'http.'"),
+                () -> assertTrue(RestApiAttributes.CONTENT_TYPE.startsWith("mime."),
+                        "CONTENT_TYPE should start with 'mime.'"),
+                () -> assertTrue(RestApiAttributes.QUERY_PARAM_PREFIX.startsWith("http."),
+                        "QUERY_PARAM_PREFIX should start with 'http.'"),
+                () -> assertTrue(RestApiAttributes.HEADER_PREFIX.startsWith("http."),
+                        "HEADER_PREFIX should start with 'http.'"));
     }
 }

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/config/RouteConfigurationParserTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/config/RouteConfigurationParserTest.java
@@ -41,14 +41,11 @@ class RouteConfigurationParserTest {
         @Test
         @DisplayName("Should parse single route")
         void shouldParseSingleRoute() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("restapi.health.path", "/api/health");
 
-            // Act
             List<RouteConfiguration> routes = RouteConfigurationParser.parse(properties);
 
-            // Assert
             assertEquals(1, routes.size());
             RouteConfiguration route = routes.getFirst();
             assertEquals("health", route.name());
@@ -58,7 +55,6 @@ class RouteConfigurationParserTest {
         @Test
         @DisplayName("Should parse multiple routes")
         void shouldParseMultipleRoutes() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("restapi.health.path", "/api/health");
             properties.put("restapi.health.methods", "GET");
@@ -66,55 +62,44 @@ class RouteConfigurationParserTest {
             properties.put("restapi.users.methods", "GET,POST,PUT,DELETE");
             properties.put("restapi.orders.path", "/api/orders");
 
-            // Act
             List<RouteConfiguration> routes = RouteConfigurationParser.parse(properties);
 
-            // Assert
             assertEquals(3, routes.size());
         }
 
         @Test
         @DisplayName("Should apply default methods when not specified")
         void shouldApplyDefaultMethods() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("restapi.health.path", "/api/health");
 
-            // Act
             List<RouteConfiguration> routes = RouteConfigurationParser.parse(properties);
 
-            // Assert
             assertEquals(RouteConfiguration.DEFAULT_METHODS, routes.getFirst().methods());
         }
 
         @Test
         @DisplayName("Should parse custom methods")
         void shouldParseCustomMethods() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("restapi.health.path", "/api/health");
             properties.put("restapi.health.methods", "GET");
 
-            // Act
             List<RouteConfiguration> routes = RouteConfigurationParser.parse(properties);
 
-            // Assert
             assertEquals(Set.of("GET"), routes.getFirst().methods());
         }
 
         @Test
         @DisplayName("Should parse roles and scopes")
         void shouldParseRolesAndScopes() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("restapi.users.path", "/api/users");
             properties.put("restapi.users.required-roles", "admin,user");
             properties.put("restapi.users.required-scopes", "read,write");
 
-            // Act
             List<RouteConfiguration> routes = RouteConfigurationParser.parse(properties);
 
-            // Assert
             RouteConfiguration route = routes.getFirst();
             assertEquals(Set.of("admin", "user"), route.requiredRoles());
             assertEquals(Set.of("read", "write"), route.requiredScopes());
@@ -123,59 +108,47 @@ class RouteConfigurationParserTest {
         @Test
         @DisplayName("Should default enabled to true when absent")
         void shouldDefaultEnabledToTrue() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("restapi.health.path", "/api/health");
 
-            // Act
             List<RouteConfiguration> routes = RouteConfigurationParser.parse(properties);
 
-            // Assert
             assertTrue(routes.getFirst().enabled());
         }
 
         @Test
         @DisplayName("Should parse enabled=false")
         void shouldParseEnabledFalse() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("restapi.health.path", "/api/health");
             properties.put("restapi.health.enabled", "false");
 
-            // Act
             List<RouteConfiguration> routes = RouteConfigurationParser.parse(properties);
 
-            // Assert
             assertFalse(routes.getFirst().enabled());
         }
 
         @Test
         @DisplayName("Should parse enabled=true explicitly")
         void shouldParseEnabledTrue() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("restapi.health.path", "/api/health");
             properties.put("restapi.health.enabled", "true");
 
-            // Act
             List<RouteConfiguration> routes = RouteConfigurationParser.parse(properties);
 
-            // Assert
             assertTrue(routes.getFirst().enabled());
         }
 
         @Test
         @DisplayName("Should handle schema property as file path")
         void shouldHandleSchemaProperty() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("restapi.users.path", "/api/users");
             properties.put("restapi.users.schema", "./conf/schemas/user-schema.json");
 
-            // Act
             List<RouteConfiguration> routes = RouteConfigurationParser.parse(properties);
 
-            // Assert
             assertEquals("./conf/schemas/user-schema.json", routes.getFirst().schemaPath());
         }
     }
@@ -352,14 +325,11 @@ class RouteConfigurationParserTest {
         @Test
         @DisplayName("Should reject route without path")
         void shouldRejectRouteWithoutPath() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("restapi.health.methods", "GET");
 
-            // Act
             List<RouteConfiguration> routes = RouteConfigurationParser.parse(properties);
 
-            // Assert
             assertTrue(routes.isEmpty());
             LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, "no path");
         }
@@ -367,28 +337,22 @@ class RouteConfigurationParserTest {
         @Test
         @DisplayName("Should accept route with path only")
         void shouldAcceptRouteWithPathOnly() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("restapi.health.path", "/api/health");
 
-            // Act
             List<RouteConfiguration> routes = RouteConfigurationParser.parse(properties);
 
-            // Assert
             assertEquals(1, routes.size());
         }
 
         @Test
         @DisplayName("Should log warning for invalid route")
         void shouldLogWarningForInvalidRoute() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("restapi.health.methods", "GET"); // no path
 
-            // Act
             RouteConfigurationParser.parse(properties);
 
-            // Assert
             LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, "health");
         }
     }
@@ -400,42 +364,33 @@ class RouteConfigurationParserTest {
         @Test
         @DisplayName("Should return empty list for no route properties")
         void shouldReturnEmptyListForNoRouteProperties() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("some.other.property", "value");
 
-            // Act
             List<RouteConfiguration> routes = RouteConfigurationParser.parse(properties);
 
-            // Assert
             assertTrue(routes.isEmpty());
         }
 
         @Test
         @DisplayName("Should handle empty values")
         void shouldHandleEmptyValues() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("restapi.health.path", "  ");
 
-            // Act
             List<RouteConfiguration> routes = RouteConfigurationParser.parse(properties);
 
-            // Assert
             assertTrue(routes.isEmpty());
         }
 
         @Test
         @DisplayName("Should return unmodifiable list")
         void shouldReturnUnmodifiableList() {
-            // Arrange
             Map<String, String> properties = new HashMap<>();
             properties.put("restapi.health.path", "/api/health");
 
-            // Act
             List<RouteConfiguration> routes = RouteConfigurationParser.parse(properties);
 
-            // Assert
             var newRoute = RouteConfiguration.builder().name("x").path("/x").build();
             assertThrows(UnsupportedOperationException.class, () -> routes.add(newRoute));
         }

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/config/RouteConfigurationTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/config/RouteConfigurationTest.java
@@ -34,7 +34,6 @@ class RouteConfigurationTest {
         @Test
         @DisplayName("Should create with all fields")
         void shouldCreateWithAllFields() {
-            // Arrange & Act
             var route = RouteConfiguration.builder()
                     .name("users").path("/api/users")
                     .method("GET").method("POST")
@@ -43,7 +42,6 @@ class RouteConfigurationTest {
                     .schemaPath("./conf/schemas/user-schema.json")
                     .build();
 
-            // Assert
             assertEquals("users", route.name());
             assertEquals("/api/users", route.path());
             assertTrue(route.enabled());

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/GatewayRequestHandlerTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/GatewayRequestHandlerTest.java
@@ -197,7 +197,6 @@ class GatewayRequestHandlerTest {
                                 .GET().build(),
                         HttpResponse.BodyHandlers.ofString());
 
-                // Assert
                 assertEquals(404, response.statusCode());
             } finally {
                 disabledServer.stop();

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/HttpRequestContainerTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/HttpRequestContainerTest.java
@@ -36,17 +36,14 @@ class HttpRequestContainerTest {
         @Test
         @DisplayName("Should create with all fields")
         void shouldCreateWithAllFields() {
-            // Arrange
             var token = TestTokenGenerators.accessTokens().next().asAccessTokenContent();
             byte[] body = "request body".getBytes(StandardCharsets.UTF_8);
 
-            // Act
             var container = new HttpRequestContainer(
                     "users", "POST", "/api/users",
                     Map.of("page", "1"), Map.of("Authorization", "Bearer token"),
                     "127.0.0.1", body, "application/json", token, null, null, Map.of("id", "42"));
 
-            // Assert
             assertEquals("users", container.routeName());
             assertEquals("POST", container.method());
             assertEquals("/api/users", container.requestUri());
@@ -62,29 +59,24 @@ class HttpRequestContainerTest {
         @Test
         @DisplayName("Should have empty body for GET requests")
         void shouldHaveEmptyBodyForGetRequests() {
-            // Arrange
             var token = TestTokenGenerators.accessTokens().next().asAccessTokenContent();
 
-            // Act
             var container = new HttpRequestContainer(
                     "health", "GET", "/api/health",
                     Map.of(), Map.of(), "127.0.0.1", new byte[0], null, token, null, null, Map.of());
 
-            // Assert
             assertEquals(0, container.body().length);
         }
 
         @Test
         @DisplayName("Should have immutable maps")
         void shouldHaveImmutableMaps() {
-            // Arrange
             var token = TestTokenGenerators.accessTokens().next().asAccessTokenContent();
             var container = new HttpRequestContainer(
                     "health", "GET", "/api/health",
                     Map.of("key", "value"), Map.of("Header", "value"),
                     "127.0.0.1", null, null, token, null, null, Map.of("id", "1"));
 
-            // Assert
             var queryParams = container.queryParameters();
             var headers = container.headers();
             var pathParams = container.pathParameters();
@@ -99,30 +91,24 @@ class HttpRequestContainerTest {
         @Test
         @DisplayName("Should store token reference")
         void shouldStoreTokenReference() {
-            // Arrange
             var token = TestTokenGenerators.accessTokens().next().asAccessTokenContent();
 
-            // Act
             var container = new HttpRequestContainer(
                     "health", "GET", "/api/health",
                     Map.of(), Map.of(), "127.0.0.1", null, null, token, null, null, Map.of());
 
-            // Assert
             assertSame(token, container.token());
         }
 
         @Test
         @DisplayName("Should handle null body gracefully")
         void shouldHandleNullBody() {
-            // Arrange
             var token = TestTokenGenerators.accessTokens().next().asAccessTokenContent();
 
-            // Act
             var container = new HttpRequestContainer(
                     "health", "GET", "/api/health",
                     null, null, "127.0.0.1", null, null, token, null, null, null);
 
-            // Assert
             assertEquals(0, container.body().length);
             assertTrue(container.queryParameters().isEmpty());
             assertTrue(container.headers().isEmpty());
@@ -136,15 +122,12 @@ class HttpRequestContainerTest {
         @Test
         @DisplayName("Should default to empty map when null")
         void shouldDefaultToEmptyMapWhenNull() {
-            // Arrange
             var token = TestTokenGenerators.accessTokens().next().asAccessTokenContent();
 
-            // Act
             var container = new HttpRequestContainer(
                     "users", "GET", "/api/users/42",
                     Map.of(), Map.of(), "127.0.0.1", null, null, token, null, null, null);
 
-            // Assert
             assertNotNull(container.pathParameters(), "Path parameters should never be null");
             assertTrue(container.pathParameters().isEmpty(), "Path parameters should default to empty");
         }
@@ -152,16 +135,13 @@ class HttpRequestContainerTest {
         @Test
         @DisplayName("Should carry path parameters from a pattern-matched route")
         void shouldCarryPathParameters() {
-            // Arrange
             var token = TestTokenGenerators.accessTokens().next().asAccessTokenContent();
 
-            // Act
             var container = new HttpRequestContainer(
                     "users", "GET", "/api/users/42/orders/7",
                     Map.of(), Map.of(), "127.0.0.1", null, null, token, null, null,
                     Map.of("userId", "42", "orderId", "7"));
 
-            // Assert
             assertAll("Path parameters",
                     () -> assertEquals("42", container.pathParameters().get("userId"), "userId should match"),
                     () -> assertEquals("7", container.pathParameters().get("orderId"), "orderId should match"),
@@ -171,18 +151,15 @@ class HttpRequestContainerTest {
         @Test
         @DisplayName("Should defensively copy the supplied path parameters")
         void shouldDefensivelyCopyPathParameters() {
-            // Arrange
             var token = TestTokenGenerators.accessTokens().next().asAccessTokenContent();
             var mutable = new java.util.HashMap<String, String>();
             mutable.put("id", "1");
 
-            // Act
             var container = new HttpRequestContainer(
                     "users", "GET", "/api/users/1",
                     Map.of(), Map.of(), "127.0.0.1", null, null, token, null, null, mutable);
             mutable.put("id", "mutated");
 
-            // Assert
             assertEquals("1", container.pathParameters().get("id"), "Container should hold an independent copy");
         }
     }

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/RequestStatusEntryTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/RequestStatusEntryTest.java
@@ -37,13 +37,10 @@ class RequestStatusEntryTest {
         @Test
         @DisplayName("Should create ACCEPTED entry with traceId")
         void shouldCreateAcceptedEntry() {
-            // Arrange
             String traceId = UUID.randomUUID().toString();
 
-            // Act
             var entry = RequestStatusEntry.accepted(traceId, null);
 
-            // Assert
             assertEquals(traceId, entry.traceId());
             assertEquals(RequestStatus.ACCEPTED, entry.status());
             assertNotNull(entry.acceptedAt());
@@ -56,27 +53,21 @@ class RequestStatusEntryTest {
         @Test
         @DisplayName("Should create ACCEPTED entry with parentTraceId")
         void shouldCreateAcceptedEntryWithParent() {
-            // Arrange
             String traceId = UUID.randomUUID().toString();
             String parentTraceId = UUID.randomUUID().toString();
 
-            // Act
             var entry = RequestStatusEntry.accepted(traceId, parentTraceId);
 
-            // Assert
             assertEquals(parentTraceId, entry.parentTraceId());
         }
 
         @Test
         @DisplayName("Should create COLLECTING_ATTACHMENTS entry")
         void shouldCreateCollectingAttachmentsEntry() {
-            // Arrange
             String traceId = UUID.randomUUID().toString();
 
-            // Act
             var entry = RequestStatusEntry.collectingAttachments(traceId, null, "upload", 5, 2);
 
-            // Assert
             assertEquals(traceId, entry.traceId());
             assertEquals(RequestStatus.COLLECTING_ATTACHMENTS, entry.status());
             assertEquals("upload", entry.routeName());
@@ -94,15 +85,12 @@ class RequestStatusEntryTest {
         @Test
         @DisplayName("Should serialize and deserialize round-trip")
         void shouldSerializeDeserializeRoundTrip() {
-            // Arrange
             String traceId = UUID.randomUUID().toString();
             var entry = RequestStatusEntry.accepted(traceId, null);
 
-            // Act
             String json = entry.toJson();
             var deserialized = RequestStatusEntry.fromJson(json);
 
-            // Assert
             assertEquals(entry.traceId(), deserialized.traceId());
             assertEquals(entry.status(), deserialized.status());
             assertEquals(entry.acceptedAt(), deserialized.acceptedAt());
@@ -114,7 +102,6 @@ class RequestStatusEntryTest {
         @Test
         @DisplayName("Should serialize and deserialize with all optional fields")
         void shouldSerializeDeserializeWithOptionalFields() {
-            // Arrange
             String traceId = UUID.randomUUID().toString();
             String parentTraceId = UUID.randomUUID().toString();
             Instant now = Instant.now();
@@ -122,11 +109,9 @@ class RequestStatusEntryTest {
                     traceId, RequestStatus.REJECTED, now, now,
                     parentTraceId, "Validation failed", 0, 0, null);
 
-            // Act
             String json = entry.toJson();
             var deserialized = RequestStatusEntry.fromJson(json);
 
-            // Assert
             assertEquals(traceId, deserialized.traceId());
             assertEquals(RequestStatus.REJECTED, deserialized.status());
             assertEquals(parentTraceId, deserialized.parentTraceId());
@@ -137,31 +122,25 @@ class RequestStatusEntryTest {
         @EnumSource(RequestStatus.class)
         @DisplayName("Should serialize all status values")
         void shouldSerializeAllStatusValues(RequestStatus status) {
-            // Arrange
             Instant now = Instant.now();
             var entry = new RequestStatusEntry(
                     UUID.randomUUID().toString(), status, now, now, null, null, 0, 0, null);
 
-            // Act
             String json = entry.toJson();
             var deserialized = RequestStatusEntry.fromJson(json);
 
-            // Assert
             assertEquals(status, deserialized.status());
         }
 
         @Test
         @DisplayName("Should serialize and deserialize COLLECTING_ATTACHMENTS round-trip")
         void shouldSerializeDeserializeCollectingAttachments() {
-            // Arrange
             String traceId = UUID.randomUUID().toString();
             var entry = RequestStatusEntry.collectingAttachments(traceId, null, "upload", 3, 1);
 
-            // Act
             String json = entry.toJson();
             var deserialized = RequestStatusEntry.fromJson(json);
 
-            // Assert
             assertEquals(RequestStatus.COLLECTING_ATTACHMENTS, deserialized.status());
             assertEquals("upload", deserialized.routeName());
             assertEquals(3, deserialized.attachmentsMaxCount());
@@ -176,10 +155,8 @@ class RequestStatusEntryTest {
                     + "\"acceptedAt\":\"2026-01-01T00:00:00Z\",\"updatedAt\":\"2026-01-01T00:00:00Z\","
                     + "\"attachmentsMaxCount\":5}";
 
-            // Act
             var deserialized = RequestStatusEntry.fromJson(json);
 
-            // Assert
             assertEquals(0, deserialized.attachmentsMinCount());
             assertEquals(5, deserialized.attachmentsMaxCount());
         }
@@ -187,13 +164,10 @@ class RequestStatusEntryTest {
         @Test
         @DisplayName("Should produce valid JSON")
         void shouldProduceValidJson() {
-            // Arrange
             var entry = RequestStatusEntry.accepted(UUID.randomUUID().toString(), null);
 
-            // Act
             String json = entry.toJson();
 
-            // Assert
             assertTrue(json.contains("\"traceId\""));
             assertTrue(json.contains("\"status\":\"ACCEPTED\""));
             assertTrue(json.contains("\"acceptedAt\""));

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/RequestStatusStoreTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/RequestStatusStoreTest.java
@@ -53,14 +53,11 @@ class RequestStatusStoreTest {
         @Test
         @DisplayName("Should store and retrieve ACCEPTED entry")
         void shouldStoreAndRetrieveAcceptedEntry() throws Exception {
-            // Arrange
             String traceId = UUID.randomUUID().toString();
 
-            // Act
             store.accept(traceId, null);
             var result = store.getStatus(traceId);
 
-            // Assert
             assertTrue(result.isPresent());
             assertEquals(traceId, result.get().traceId());
             assertEquals(RequestStatus.ACCEPTED, result.get().status());
@@ -70,15 +67,12 @@ class RequestStatusStoreTest {
         @Test
         @DisplayName("Should store with parentTraceId")
         void shouldStoreWithParentTraceId() throws Exception {
-            // Arrange
             String traceId = UUID.randomUUID().toString();
             String parentTraceId = UUID.randomUUID().toString();
 
-            // Act
             store.accept(traceId, parentTraceId);
             var result = store.getStatus(traceId);
 
-            // Assert
             assertTrue(result.isPresent());
             assertEquals(parentTraceId, result.get().parentTraceId());
         }
@@ -86,24 +80,19 @@ class RequestStatusStoreTest {
         @Test
         @DisplayName("Should return empty for unknown traceId")
         void shouldReturnEmptyForUnknownTraceId() throws Exception {
-            // Act
             var result = store.getStatus(UUID.randomUUID().toString());
 
-            // Assert
             assertTrue(result.isEmpty());
         }
 
         @Test
         @DisplayName("Should store COLLECTING_ATTACHMENTS entry")
         void shouldStoreCollectingAttachmentsEntry() throws Exception {
-            // Arrange
             String traceId = UUID.randomUUID().toString();
 
-            // Act
             store.collectingAttachments(traceId, null, "upload", 5, 1);
             var result = store.getStatus(traceId);
 
-            // Assert
             assertTrue(result.isPresent());
             assertEquals(RequestStatus.COLLECTING_ATTACHMENTS, result.get().status());
             assertEquals("upload", result.get().routeName());
@@ -113,15 +102,12 @@ class RequestStatusStoreTest {
         @Test
         @DisplayName("Should update status preserving other fields")
         void shouldUpdateStatusPreservingOtherFields() throws Exception {
-            // Arrange
             String traceId = UUID.randomUUID().toString();
             store.collectingAttachments(traceId, null, "upload", 5, 1);
 
-            // Act
             store.updateStatus(traceId, RequestStatus.PROCESSING);
             var result = store.getStatus(traceId);
 
-            // Assert
             assertTrue(result.isPresent());
             assertEquals(RequestStatus.PROCESSING, result.get().status());
             assertEquals("upload", result.get().routeName());
@@ -145,29 +131,23 @@ class RequestStatusStoreTest {
         @Test
         @DisplayName("Should serialize string key correctly")
         void shouldSerializeStringKey() throws Exception {
-            // Arrange
             String key = "test-key";
             var out = new ByteArrayOutputStream();
 
-            // Act
             RequestStatusStore.STRING_SERIALIZER.serialize(key, out);
 
-            // Assert
             assertEquals(key, out.toString(StandardCharsets.UTF_8));
         }
 
         @Test
         @DisplayName("Should serialize and deserialize entry round-trip")
         void shouldSerializeDeserializeEntryRoundTrip() throws Exception {
-            // Arrange
             var entry = RequestStatusEntry.accepted(UUID.randomUUID().toString(), null);
             var out = new ByteArrayOutputStream();
 
-            // Act
             RequestStatusStore.ENTRY_SERIALIZER.serialize(entry, out);
             var deserialized = RequestStatusStore.ENTRY_DESERIALIZER.deserialize(out.toByteArray());
 
-            // Assert
             assertNotNull(deserialized);
             assertEquals(entry.traceId(), deserialized.traceId());
             assertEquals(entry.status(), deserialized.status());
@@ -176,20 +156,16 @@ class RequestStatusStoreTest {
         @Test
         @DisplayName("Should return null for empty byte array")
         void shouldReturnNullForEmptyBytes() throws Exception {
-            // Act
             var result = RequestStatusStore.ENTRY_DESERIALIZER.deserialize(new byte[0]);
 
-            // Assert
             assertNull(result);
         }
 
         @Test
         @DisplayName("Should return null for null byte array")
         void shouldReturnNullForNullBytes() throws Exception {
-            // Act
             var result = RequestStatusStore.ENTRY_DESERIALIZER.deserialize(null);
 
-            // Assert
             assertNull(result);
         }
     }

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/StatusEndpointHandlerTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/StatusEndpointHandlerTest.java
@@ -130,12 +130,10 @@ class StatusEndpointHandlerTest {
             String traceId = UUID.randomUUID().toString();
             statusStore.accept(traceId, null);
 
-            // Act
             var response = httpClient.send(
                     HttpRequest.newBuilder(uri("/status/" + traceId)).GET().build(),
                     HttpResponse.BodyHandlers.ofString());
 
-            // Assert
             assertEquals(200, response.statusCode());
             assertTrue(response.headers().firstValue("Content-Type")
                     .orElse("").contains("application/json"));
@@ -150,17 +148,14 @@ class StatusEndpointHandlerTest {
         @Test
         @DisplayName("Should return parentTraceId when present")
         void shouldReturnParentTraceId() throws Exception {
-            // Arrange
             String traceId = UUID.randomUUID().toString();
             String parentTraceId = UUID.randomUUID().toString();
             statusStore.accept(traceId, parentTraceId);
 
-            // Act
             var response = httpClient.send(
                     HttpRequest.newBuilder(uri("/status/" + traceId)).GET().build(),
                     HttpResponse.BodyHandlers.ofString());
 
-            // Assert
             assertEquals(200, response.statusCode());
             JsonObject json = Json.createReader(new StringReader(response.body())).readObject();
             assertEquals(parentTraceId, json.getString("parentTraceId"));
@@ -169,12 +164,10 @@ class StatusEndpointHandlerTest {
         @Test
         @DisplayName("Should return 404 for unknown traceId")
         void shouldReturn404ForUnknownTraceId() throws Exception {
-            // Act
             var response = httpClient.send(
                     HttpRequest.newBuilder(uri("/status/" + UUID.randomUUID())).GET().build(),
                     HttpResponse.BodyHandlers.ofString());
 
-            // Assert
             assertEquals(404, response.statusCode());
             assertTrue(response.body().contains("Not Found"));
         }
@@ -182,12 +175,10 @@ class StatusEndpointHandlerTest {
         @Test
         @DisplayName("Should return 400 for invalid UUID format")
         void shouldReturn400ForInvalidUuid() throws Exception {
-            // Act
             var response = httpClient.send(
                     HttpRequest.newBuilder(uri("/status/not-a-uuid")).GET().build(),
                     HttpResponse.BodyHandlers.ofString());
 
-            // Assert
             assertEquals(400, response.statusCode());
             assertTrue(response.body().contains("Invalid traceId format"));
         }
@@ -213,7 +204,6 @@ class StatusEndpointHandlerTest {
         @Test
         @DisplayName("Should return 202 with traceId and Location for tracked POST")
         void shouldReturnTrackedResponseForPost() throws Exception {
-            // Act
             var response = httpClient.send(
                     HttpRequest.newBuilder(uri("/api/orders"))
                             .header("Authorization", "Bearer " + tokenHolder.getRawToken())
@@ -222,7 +212,6 @@ class StatusEndpointHandlerTest {
                             .build(),
                     HttpResponse.BodyHandlers.ofString());
 
-            // Assert
             assertEquals(202, response.statusCode());
 
             // Verify Location header
@@ -282,10 +271,8 @@ class StatusEndpointHandlerTest {
         @Test
         @DisplayName("Should pass X-Parent-Trace-Id to status entry")
         void shouldPassParentTraceId() throws Exception {
-            // Arrange
             String parentTraceId = UUID.randomUUID().toString();
 
-            // Act
             var response = httpClient.send(
                     HttpRequest.newBuilder(uri("/api/orders"))
                             .header("Authorization", "Bearer " + tokenHolder.getRawToken())

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/server/JettyServerManagerTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/server/JettyServerManagerTest.java
@@ -23,7 +23,11 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/validation/JsonSchemaValidatorTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/validation/JsonSchemaValidatorTest.java
@@ -62,41 +62,34 @@ class JsonSchemaValidatorTest {
         @Test
         @DisplayName("Should return empty list for valid object with all fields")
         void shouldReturnEmptyForValidObject() throws Exception {
-            // Arrange
             Path schemaFile = writeSchema(USER_SCHEMA);
             var validator = new JsonSchemaValidator(Map.of("users", schemaFile.toString()));
 
-            // Act
             List<SchemaViolation> violations = validator.validate("users",
                     """
                             {"name": "Alice", "age": 30}
                             """.getBytes(StandardCharsets.UTF_8));
 
-            // Assert
             assertTrue(violations.isEmpty());
         }
 
         @Test
         @DisplayName("Should return empty list for valid object with required field only")
         void shouldReturnEmptyForRequiredFieldOnly() throws Exception {
-            // Arrange
             Path schemaFile = writeSchema(USER_SCHEMA);
             var validator = new JsonSchemaValidator(Map.of("users", schemaFile.toString()));
 
-            // Act
             List<SchemaViolation> violations = validator.validate("users",
                     """
                             {"name": "Bob"}
                             """.getBytes(StandardCharsets.UTF_8));
 
-            // Assert
             assertTrue(violations.isEmpty());
         }
 
         @Test
         @DisplayName("Should return empty list for route without schema")
         void shouldReturnEmptyForRouteWithoutSchema() throws Exception {
-            // Arrange
             Path schemaFile = writeSchema(USER_SCHEMA);
             var validator = new JsonSchemaValidator(Map.of("users", schemaFile.toString()));
 
@@ -104,7 +97,6 @@ class JsonSchemaValidatorTest {
             List<SchemaViolation> violations = validator.validate("health",
                     "anything".getBytes(StandardCharsets.UTF_8));
 
-            // Assert
             assertTrue(violations.isEmpty());
         }
     }
@@ -116,17 +108,14 @@ class JsonSchemaValidatorTest {
         @Test
         @DisplayName("Should return violations for missing required field")
         void shouldReturnViolationsForMissingRequiredField() throws Exception {
-            // Arrange
             Path schemaFile = writeSchema(USER_SCHEMA);
             var validator = new JsonSchemaValidator(Map.of("users", schemaFile.toString()));
 
-            // Act
             List<SchemaViolation> violations = validator.validate("users",
                     """
                             {"age": 25}
                             """.getBytes(StandardCharsets.UTF_8));
 
-            // Assert
             assertFalse(violations.isEmpty());
             assertTrue(violations.stream().anyMatch(v -> v.message().contains("name")),
                     "Expected violation mentioning 'name', got: " + violations);
@@ -135,17 +124,14 @@ class JsonSchemaValidatorTest {
         @Test
         @DisplayName("Should return violations for wrong type")
         void shouldReturnViolationsForWrongType() throws Exception {
-            // Arrange
             Path schemaFile = writeSchema(USER_SCHEMA);
             var validator = new JsonSchemaValidator(Map.of("users", schemaFile.toString()));
 
-            // Act
             List<SchemaViolation> violations = validator.validate("users",
                     """
                             {"name": "Alice", "age": "not-a-number"}
                             """.getBytes(StandardCharsets.UTF_8));
 
-            // Assert
             assertFalse(violations.isEmpty());
             assertTrue(violations.stream().anyMatch(v ->
                             v.message().toLowerCase().contains("integer")
@@ -156,24 +142,20 @@ class JsonSchemaValidatorTest {
         @Test
         @DisplayName("Should return violations for additional properties")
         void shouldReturnViolationsForAdditionalProperties() throws Exception {
-            // Arrange
             Path schemaFile = writeSchema(USER_SCHEMA);
             var validator = new JsonSchemaValidator(Map.of("users", schemaFile.toString()));
 
-            // Act
             List<SchemaViolation> violations = validator.validate("users",
                     """
                             {"name": "Alice", "extra": true}
                             """.getBytes(StandardCharsets.UTF_8));
 
-            // Assert
             assertFalse(violations.isEmpty());
         }
 
         @Test
         @DisplayName("Should return multiple violations")
         void shouldReturnMultipleViolations() throws Exception {
-            // Arrange
             Path schemaFile = writeSchema(USER_SCHEMA);
             var validator = new JsonSchemaValidator(Map.of("users", schemaFile.toString()));
 
@@ -183,7 +165,6 @@ class JsonSchemaValidatorTest {
                             {"age": "not-a-number", "extra": true}
                             """.getBytes(StandardCharsets.UTF_8));
 
-            // Assert
             assertTrue(violations.size() >= 2,
                     "Expected at least 2 violations, got: " + violations.size());
         }
@@ -196,15 +177,12 @@ class JsonSchemaValidatorTest {
         @Test
         @DisplayName("Should return violation for unparseable JSON")
         void shouldReturnViolationForUnparseableJson() throws Exception {
-            // Arrange
             Path schemaFile = writeSchema(USER_SCHEMA);
             var validator = new JsonSchemaValidator(Map.of("users", schemaFile.toString()));
 
-            // Act
             List<SchemaViolation> violations = validator.validate("users",
                     "not-json{{{".getBytes(StandardCharsets.UTF_8));
 
-            // Assert
             assertFalse(violations.isEmpty());
             assertTrue(violations.getFirst().message().startsWith("Invalid JSON"),
                     "Expected 'Invalid JSON' message, got: " + violations.getFirst().message());
@@ -248,7 +226,6 @@ class JsonSchemaValidatorTest {
         @Test
         @DisplayName("Should support multiple route schemas")
         void shouldSupportMultipleRouteSchemas() throws Exception {
-            // Arrange
             Path userSchema = writeSchema(USER_SCHEMA);
             Path orderSchema = tempDir.resolve("order-schema.json");
             Files.writeString(orderSchema, """
@@ -281,11 +258,9 @@ class JsonSchemaValidatorTest {
         @Test
         @DisplayName("Should report hasSchema correctly")
         void shouldReportHasSchemaCorrectly() throws Exception {
-            // Arrange
             Path schemaFile = writeSchema(USER_SCHEMA);
             var validator = new JsonSchemaValidator(Map.of("users", schemaFile.toString()));
 
-            // Assert
             assertTrue(validator.hasSchema("users"));
             assertFalse(validator.hasSchema("health"));
         }
@@ -298,32 +273,26 @@ class JsonSchemaValidatorTest {
         @Test
         @DisplayName("Should validate successfully with inline JSON schema")
         void shouldValidateWithInlineSchema() {
-            // Arrange
             var validator = new JsonSchemaValidator(Map.of("users", USER_SCHEMA));
 
-            // Act
             List<SchemaViolation> violations = validator.validate("users",
                     """
                             {"name": "Alice", "age": 30}
                             """.getBytes(StandardCharsets.UTF_8));
 
-            // Assert
             assertTrue(violations.isEmpty());
         }
 
         @Test
         @DisplayName("Should return violations for invalid body with inline schema")
         void shouldReturnViolationsForInvalidBodyWithInlineSchema() {
-            // Arrange
             var validator = new JsonSchemaValidator(Map.of("users", USER_SCHEMA));
 
-            // Act
             List<SchemaViolation> violations = validator.validate("users",
                     """
                             {"age": 25}
                             """.getBytes(StandardCharsets.UTF_8));
 
-            // Assert
             assertFalse(violations.isEmpty());
             assertTrue(violations.stream().anyMatch(v -> v.message().contains("name")),
                     "Expected violation mentioning 'name', got: " + violations);
@@ -335,13 +304,11 @@ class JsonSchemaValidatorTest {
             // Arrange — leading spaces and newline before the JSON object
             var validator = new JsonSchemaValidator(Map.of("users", "  \n" + USER_SCHEMA));
 
-            // Act
             List<SchemaViolation> violations = validator.validate("users",
                     """
                             {"name": "Bob"}
                             """.getBytes(StandardCharsets.UTF_8));
 
-            // Assert
             assertTrue(violations.isEmpty());
         }
     }

--- a/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/service/JwtValidationServiceTest.java
+++ b/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/service/JwtValidationServiceTest.java
@@ -65,16 +65,13 @@ class JwtValidationServiceTest {
         @Test
         @DisplayName("Should create successful result with token content")
         void shouldCreateSuccessfulResult() {
-            // Arrange
             var tokenHolder = new TestTokenHolder(TokenType.ACCESS_TOKEN,
                     ClaimControlParameter.defaultForTokenType(TokenType.ACCESS_TOKEN));
             AccessTokenContent tokenContent = tokenHolder.asAccessTokenContent();
 
-            // Act
             JwtValidationService.TokenValidationResult result =
                     JwtValidationService.TokenValidationResult.success(tokenContent);
 
-            // Assert
             assertTrue(result.isValid(), "Result should be valid");
             assertNull(result.getError(), "Error should be null for successful result");
             assertEquals(tokenContent, result.getTokenContent(),
@@ -84,14 +81,11 @@ class JwtValidationServiceTest {
         @Test
         @DisplayName("Should create failure result with error message")
         void shouldCreateFailureResult() {
-            // Arrange
             String errorMessage = strings().next();
 
-            // Act
             JwtValidationService.TokenValidationResult result =
                     JwtValidationService.TokenValidationResult.failure(errorMessage);
 
-            // Assert
             assertFalse(result.isValid(), "Result should be invalid");
             assertEquals(errorMessage, result.getError(),
                     "Error message should match provided message");
@@ -101,22 +95,18 @@ class JwtValidationServiceTest {
         @Test
         @DisplayName("Should get issuer from field when set")
         void shouldGetIssuerFromField() {
-            // Arrange
             JwtValidationService.TokenValidationResult result =
                     JwtValidationService.TokenValidationResult.success(null);
             String issuer = strings().next();
 
-            // Act
             result.setIssuer(issuer);
 
-            // Assert
             assertEquals(issuer, result.getIssuer(), "Issuer should match set value");
         }
 
         @Test
         @DisplayName("Should get issuer from token content when field not set")
         void shouldGetIssuerFromTokenContent() {
-            // Arrange
             var tokenHolder = new TestTokenHolder(TokenType.ACCESS_TOKEN,
                     ClaimControlParameter.defaultForTokenType(TokenType.ACCESS_TOKEN));
             AccessTokenContent tokenContent = tokenHolder.asAccessTokenContent();
@@ -124,10 +114,8 @@ class JwtValidationServiceTest {
             JwtValidationService.TokenValidationResult result =
                     JwtValidationService.TokenValidationResult.success(tokenContent);
 
-            // Act
             String actualIssuer = result.getIssuer();
 
-            // Assert
             assertEquals(TestTokenHolder.TEST_ISSUER, actualIssuer,
                     "Issuer should be retrieved from token content");
         }
@@ -135,50 +123,40 @@ class JwtValidationServiceTest {
         @Test
         @DisplayName("Should return null issuer when neither field nor token content available")
         void shouldReturnNullIssuerWhenNotAvailable() {
-            // Arrange
             JwtValidationService.TokenValidationResult result =
                     JwtValidationService.TokenValidationResult.failure("error");
 
-            // Act
             String issuer = result.getIssuer();
 
-            // Assert
             assertNull(issuer, "Issuer should be null when not available");
         }
 
         @Test
         @DisplayName("Should set and get authorized flag")
         void shouldSetAndGetAuthorized() {
-            // Arrange
             JwtValidationService.TokenValidationResult result =
                     JwtValidationService.TokenValidationResult.success(null);
 
-            // Act
             result.setAuthorized(true);
 
-            // Assert
             assertTrue(result.isAuthorized(), "Authorized flag should be true");
         }
 
         @Test
         @DisplayName("Should set and get scopes from field")
         void shouldSetAndGetScopesFromField() {
-            // Arrange
             JwtValidationService.TokenValidationResult result =
                     JwtValidationService.TokenValidationResult.success(null);
             List<String> scopes = Arrays.asList("read", "write");
 
-            // Act
             result.setScopes(scopes);
 
-            // Assert
             assertEquals(scopes, result.getScopes(), "Scopes should match set value");
         }
 
         @Test
         @DisplayName("Should get scopes from token content when field not set")
         void shouldGetScopesFromTokenContent() {
-            // Arrange
             var tokenHolder = new TestTokenHolder(TokenType.ACCESS_TOKEN,
                     ClaimControlParameter.defaultForTokenType(TokenType.ACCESS_TOKEN));
             AccessTokenContent tokenContent = tokenHolder.asAccessTokenContent();
@@ -186,10 +164,8 @@ class JwtValidationServiceTest {
             JwtValidationService.TokenValidationResult result =
                     JwtValidationService.TokenValidationResult.success(tokenContent);
 
-            // Act
             List<String> actualScopes = result.getScopes();
 
-            // Assert
             assertNotNull(actualScopes, "Scopes should be retrieved from token content");
             assertFalse(actualScopes.isEmpty(), "Scopes should not be empty");
         }
@@ -197,22 +173,18 @@ class JwtValidationServiceTest {
         @Test
         @DisplayName("Should set and get roles from field")
         void shouldSetAndGetRolesFromField() {
-            // Arrange
             JwtValidationService.TokenValidationResult result =
                     JwtValidationService.TokenValidationResult.success(null);
             List<String> roles = Arrays.asList("admin", "user");
 
-            // Act
             result.setRoles(roles);
 
-            // Assert
             assertEquals(roles, result.getRoles(), "Roles should match set value");
         }
 
         @Test
         @DisplayName("Should get roles from token content when field not set")
         void shouldGetRolesFromTokenContent() {
-            // Arrange
             var tokenHolder = new TestTokenHolder(TokenType.ACCESS_TOKEN,
                     ClaimControlParameter.defaultForTokenType(TokenType.ACCESS_TOKEN));
             AccessTokenContent tokenContent = tokenHolder.asAccessTokenContent();
@@ -220,10 +192,8 @@ class JwtValidationServiceTest {
             JwtValidationService.TokenValidationResult result =
                     JwtValidationService.TokenValidationResult.success(tokenContent);
 
-            // Act
             List<String> actualRoles = result.getRoles();
 
-            // Assert
             assertNotNull(actualRoles, "Roles should be retrieved from token content");
             assertFalse(actualRoles.isEmpty(), "Roles should not be empty");
         }
@@ -231,7 +201,6 @@ class JwtValidationServiceTest {
         @Test
         @DisplayName("Should build claims map from token content")
         void shouldBuildClaimsMapFromTokenContent() {
-            // Arrange
             var tokenHolder = new TestTokenHolder(TokenType.ACCESS_TOKEN,
                     ClaimControlParameter.defaultForTokenType(TokenType.ACCESS_TOKEN));
             AccessTokenContent tokenContent = tokenHolder.asAccessTokenContent();
@@ -239,10 +208,8 @@ class JwtValidationServiceTest {
             JwtValidationService.TokenValidationResult result =
                     JwtValidationService.TokenValidationResult.success(tokenContent);
 
-            // Act
             Map<String, Object> claims = result.getClaims();
 
-            // Assert
             assertNotNull(claims, "Claims should not be null");
             assertEquals(tokenContent.getSubject().orElse(""), claims.get("sub"), "Subject should match");
             assertEquals(tokenContent.getIssuer(), claims.get("iss"), "Issuer should match");
@@ -267,10 +234,8 @@ class JwtValidationServiceTest {
             JwtValidationService.TokenValidationResult result =
                     JwtValidationService.TokenValidationResult.success(tokenContent);
 
-            // Act
             Map<String, Object> claims = result.getClaims();
 
-            // Assert
             assertNotNull(claims, "Claims should not be null");
             assertEquals("", claims.get("sub"), "Empty subject should be empty string");
             assertFalse(claims.containsKey("roles"), "Roles should not be present when empty");
@@ -296,14 +261,11 @@ class JwtValidationServiceTest {
         @Test
         @DisplayName("Should return empty map when token content is null")
         void shouldReturnEmptyMapWhenTokenContentIsNull() {
-            // Arrange
             JwtValidationService.TokenValidationResult result =
                     JwtValidationService.TokenValidationResult.failure("error");
 
-            // Act
             Map<String, Object> claims = result.getClaims();
 
-            // Assert
             assertNotNull(claims, "Claims should not be null");
             assertTrue(claims.isEmpty(), "Claims should be empty when token content is null");
         }
@@ -335,13 +297,11 @@ class JwtValidationServiceTest {
         @Test
         @DisplayName("Should reject null processor ID")
         void shouldRejectNullProcessorId() {
-            // Arrange
             NiFiWebConfigurationContext mockContext = createMock(NiFiWebConfigurationContext.class);
             JwtValidationService service = new JwtValidationService(mockContext);
             HttpServletRequest mockRequest = createNiceMock(HttpServletRequest.class);
             replay(mockRequest);
 
-            // Act & Assert
             assertThrows(NullPointerException.class,
                     () -> service.verifyToken("some-token", null, mockRequest),
                     "Should throw NullPointerException for null processorId");
@@ -368,7 +328,6 @@ class JwtValidationServiceTest {
         @Test
         @DisplayName("Should throw IllegalArgumentException when component not found")
         void shouldThrowWhenComponentNotFound() {
-            // Arrange
             String processorId = UUID.randomUUID().toString();
             expect(mockConfigContext.getComponentDetails(anyObject(NiFiWebRequestContext.class)))
                     .andThrow(new ResourceNotFoundException("Processor not found"));
@@ -376,7 +335,6 @@ class JwtValidationServiceTest {
                     .andThrow(new ResourceNotFoundException("CS not found"));
             replay(mockConfigContext);
 
-            // Act & Assert
             IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
                     () -> service.verifyToken("some-token", processorId, mockRequest));
             assertTrue(exception.getMessage().contains("Component not found"));
@@ -398,7 +356,6 @@ class JwtValidationServiceTest {
                     .andReturn(details);
             replay(mockConfigContext);
 
-            // Act & Assert
             IllegalStateException exception = assertThrows(IllegalStateException.class,
                     () -> service.verifyToken("some-token", processorId, mockRequest));
             assertTrue(exception.getMessage().contains("No issuer configurations found"));
@@ -494,7 +451,6 @@ class JwtValidationServiceTest {
         @Test
         @DisplayName("Should reject null processor ID")
         void shouldRejectNullProcessorId() {
-            // Arrange & Act & Assert
             assertThrows(NullPointerException.class,
                     () -> service.verifyToken("some-token", null, mockRequest),
                     "Should throw NullPointerException for null processorId");

--- a/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/JwksValidationServletTest.java
+++ b/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/JwksValidationServletTest.java
@@ -296,26 +296,21 @@ class JwksValidationServletTest {
         @Test
         @DisplayName("Should block private address by default (allowPrivateAddresses=false)")
         void defaultBlocksPrivateAddress() {
-            // Arrange
             JwksValidationServlet servlet = new JwksValidationServlet();
 
             // Act — default is false, so private addresses should be blocked
             InetAddress result = servlet.resolveAndValidateAddress("127.0.0.1", false);
 
-            // Assert
             assertNull(result, "Private address should be blocked when allowPrivateAddresses=false");
         }
 
         @Test
         @DisplayName("Should allow loopback address when allowPrivateAddresses=true")
         void allowsLoopbackWhenEnabled() {
-            // Arrange
             JwksValidationServlet servlet = new JwksValidationServlet();
 
-            // Act
             InetAddress result = servlet.resolveAndValidateAddress("127.0.0.1", true);
 
-            // Assert
             assertNotNull(result, "Loopback address should be allowed when allowPrivateAddresses=true");
             assertTrue(result.isLoopbackAddress());
         }
@@ -323,10 +318,8 @@ class JwksValidationServletTest {
         @Test
         @DisplayName("Should return null for empty host regardless of allowPrivateAddresses")
         void returnsNullForEmptyHost() {
-            // Arrange
             JwksValidationServlet servlet = new JwksValidationServlet();
 
-            // Act & Assert
             assertNull(servlet.resolveAndValidateAddress("", true));
             assertNull(servlet.resolveAndValidateAddress(null, true));
             assertNull(servlet.resolveAndValidateAddress("", false));
@@ -336,10 +329,8 @@ class JwksValidationServletTest {
         @Test
         @DisplayName("Should return null for unresolvable host regardless of allowPrivateAddresses")
         void returnsNullForUnresolvableHost() {
-            // Arrange
             JwksValidationServlet servlet = new JwksValidationServlet();
 
-            // Act & Assert
             assertNull(servlet.resolveAndValidateAddress(
                     "this.host.definitely.does.not.exist.invalid", true));
             assertNull(servlet.resolveAndValidateAddress(
@@ -555,7 +546,6 @@ class JwksValidationServletTest {
         @Test
         @DisplayName("Should return processor properties when no CS keys present")
         void shouldReturnProcessorPropertiesWhenNoCsKeysPresent() {
-            // Arrange
             Map<String, String> processorProps = Map.of("some.key", "some-value");
             NiFiWebConfigurationContext mockCtx = createNiceMock(NiFiWebConfigurationContext.class);
             replay(mockCtx);
@@ -563,7 +553,6 @@ class JwksValidationServletTest {
             HttpServletRequest mockReq = createNiceMock(HttpServletRequest.class);
             replay(mockReq);
 
-            // Act
             Map<String, String> result = JwksValidationServlet.resolveControllerServiceProperties(
                     processorProps, reader, mockReq);
 
@@ -574,7 +563,6 @@ class JwksValidationServletTest {
         @Test
         @DisplayName("Should resolve CS properties when CS reference key present")
         void shouldResolveCsPropertiesWhenCsReferencePresent() {
-            // Arrange
             String csId = UUID.randomUUID().toString();
             Map<String, String> processorProps = new HashMap<>();
             processorProps.put("jwt.issuer.config.service", csId);
@@ -598,7 +586,6 @@ class JwksValidationServletTest {
             HttpServletRequest mockReq = createNiceMock(HttpServletRequest.class);
             replay(mockReq);
 
-            // Act
             Map<String, String> result = JwksValidationServlet.resolveControllerServiceProperties(
                     processorProps, reader, mockReq);
 
@@ -610,7 +597,6 @@ class JwksValidationServletTest {
         @Test
         @DisplayName("Should return processor properties when CS lookup fails")
         void shouldReturnProcessorPropertiesWhenCsLookupFails() {
-            // Arrange
             String csId = UUID.randomUUID().toString();
             Map<String, String> processorProps = new HashMap<>();
             processorProps.put("jwt.issuer.config.service", csId);
@@ -636,7 +622,6 @@ class JwksValidationServletTest {
         @Test
         @DisplayName("Should skip blank CS reference values")
         void shouldSkipBlankCsReferenceValues() {
-            // Arrange
             Map<String, String> processorProps = new HashMap<>();
             processorProps.put("jwt.issuer.config.service", "   ");
             NiFiWebConfigurationContext mockCtx = createNiceMock(NiFiWebConfigurationContext.class);
@@ -645,7 +630,6 @@ class JwksValidationServletTest {
             HttpServletRequest mockReq = createNiceMock(HttpServletRequest.class);
             replay(mockReq);
 
-            // Act
             Map<String, String> result = JwksValidationServlet.resolveControllerServiceProperties(
                     processorProps, reader, mockReq);
 
@@ -687,10 +671,8 @@ class JwksValidationServletTest {
             JwksValidationServlet servlet = new JwksValidationServlet();
             String url = mockServer.url("/jwks").toString();
 
-            // Act
             HttpResult<String> result = servlet.fetchJwksContentByOriginalUrl(url);
 
-            // Assert
             assertFalse(result.isSuccess());
             assertTrue(result.getErrorMessage().isPresent());
             assertTrue(result.getErrorMessage().get().contains("exceeds maximum size limit"));
@@ -710,10 +692,8 @@ class JwksValidationServletTest {
             JwksValidationServlet servlet = new JwksValidationServlet();
             String url = mockServer.url("/jwks").toString();
 
-            // Act
             HttpResult<String> result = servlet.fetchJwksContentByOriginalUrl(url);
 
-            // Assert
             assertTrue(result.isSuccess());
             assertTrue(result.getContent().isPresent());
             assertEquals(validJwks, result.getContent().get());
@@ -722,7 +702,6 @@ class JwksValidationServletTest {
         @Test
         @DisplayName("Should return failure for non-200 HTTP status")
         void shouldReturnFailureForNon200Status() throws Exception {
-            // Arrange
             mockServer.enqueue(new MockResponse.Builder()
                     .code(404)
                     .body("Not Found")
@@ -731,10 +710,8 @@ class JwksValidationServletTest {
             JwksValidationServlet servlet = new JwksValidationServlet();
             String url = mockServer.url("/jwks").toString();
 
-            // Act
             HttpResult<String> result = servlet.fetchJwksContentByOriginalUrl(url);
 
-            // Assert
             assertFalse(result.isSuccess());
             assertTrue(result.getErrorMessage().isPresent());
             assertTrue(result.getErrorMessage().get().contains("status 404"));
@@ -743,7 +720,6 @@ class JwksValidationServletTest {
         @Test
         @DisplayName("Should accept response via resolved address within size limit")
         void shouldAcceptResponseViaResolvedAddress() throws Exception {
-            // Arrange
             String validJwks = InMemoryKeyMaterialHandler.createDefaultJwks();
             mockServer.enqueue(new MockResponse.Builder()
                     .code(200)
@@ -755,11 +731,9 @@ class JwksValidationServletTest {
             URI uri = URI.create(mockServer.url("/jwks").toString());
             InetAddress resolved = InetAddress.getByName(uri.getHost());
 
-            // Act
             HttpResult<String> result = servlet.fetchJwksContentByResolvedAddress(
                     uri.toString(), uri, resolved);
 
-            // Assert
             assertTrue(result.isSuccess());
             assertTrue(result.getContent().isPresent());
             assertEquals(validJwks, result.getContent().get());
@@ -768,7 +742,6 @@ class JwksValidationServletTest {
         @Test
         @DisplayName("Should reject oversized response via resolved address")
         void shouldRejectOversizedResponseViaResolvedAddress() throws Exception {
-            // Arrange
             String oversizedBody = "x".repeat(1024 * 1024 + 1);
             mockServer.enqueue(new MockResponse.Builder()
                     .code(200)
@@ -780,11 +753,9 @@ class JwksValidationServletTest {
             URI uri = URI.create(mockServer.url("/jwks").toString());
             InetAddress resolved = InetAddress.getByName(uri.getHost());
 
-            // Act
             HttpResult<String> result = servlet.fetchJwksContentByResolvedAddress(
                     uri.toString(), uri, resolved);
 
-            // Assert
             assertFalse(result.isSuccess());
             assertTrue(result.getErrorMessage().isPresent());
             assertTrue(result.getErrorMessage().get().contains("exceeds maximum size limit"));
@@ -793,7 +764,6 @@ class JwksValidationServletTest {
         @Test
         @DisplayName("Should return failure for non-200 status via resolved address")
         void shouldReturnFailureForNon200ViaResolvedAddress() throws Exception {
-            // Arrange
             mockServer.enqueue(new MockResponse.Builder()
                     .code(503)
                     .body("Service Unavailable")
@@ -803,11 +773,9 @@ class JwksValidationServletTest {
             URI uri = URI.create(mockServer.url("/jwks").toString());
             InetAddress resolved = InetAddress.getByName(uri.getHost());
 
-            // Act
             HttpResult<String> result = servlet.fetchJwksContentByResolvedAddress(
                     uri.toString(), uri, resolved);
 
-            // Assert
             assertFalse(result.isSuccess());
             assertTrue(result.getErrorMessage().isPresent());
             assertTrue(result.getErrorMessage().get().contains("status 503"));
@@ -893,7 +861,6 @@ class JwksValidationServletTest {
                              new JwksValidationServlet());
                      ctx.addServlet(holder, URL_ENDPOINT);
                  })) {
-                // Act
                 serverHandle.spec()
                         .contentType("application/json")
                         .header("X-Processor-Id", processorId)

--- a/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/util/ComponentConfigReaderTest.java
+++ b/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/util/ComponentConfigReaderTest.java
@@ -119,7 +119,6 @@ class ComponentConfigReaderTest {
         @Test
         @DisplayName("Should return processor config when processor found on first try")
         void shouldReturnProcessorConfig() {
-            // Arrange
             String processorId = UUID.randomUUID().toString();
             Map<String, String> properties = Map.of(
                     "rest.gateway.listening.port", "9443",
@@ -135,11 +134,9 @@ class ComponentConfigReaderTest {
                     .andReturn(details);
             replay(mockConfigContext);
 
-            // Act
             ComponentConfigReader.ComponentConfig config =
                     reader.getComponentConfig(processorId, mockRequest);
 
-            // Assert
             assertEquals(ComponentConfigReader.ComponentType.PROCESSOR, config.type());
             assertEquals("de.cuioss.nifi.rest.RestApiGatewayProcessor", config.componentClass());
             assertEquals("9443", config.properties().get("rest.gateway.listening.port"));
@@ -151,7 +148,6 @@ class ComponentConfigReaderTest {
         @Test
         @DisplayName("Should fall back to controller service when processor not found")
         void shouldFallbackToControllerService() {
-            // Arrange
             String componentId = UUID.randomUUID().toString();
             Map<String, String> properties = Map.of(
                     "jwt.issuer.url", "https://keycloak.example.com/realms/test");
@@ -170,11 +166,9 @@ class ComponentConfigReaderTest {
                     .andReturn(csDetails);
             replay(mockConfigContext);
 
-            // Act
             ComponentConfigReader.ComponentConfig config =
                     reader.getComponentConfig(componentId, mockRequest);
 
-            // Assert
             assertEquals(ComponentConfigReader.ComponentType.CONTROLLER_SERVICE, config.type());
             assertEquals("de.cuioss.nifi.jwt.StandardJwtIssuerConfigService", config.componentClass());
             assertEquals("https://keycloak.example.com/realms/test",
@@ -185,7 +179,6 @@ class ComponentConfigReaderTest {
         @Test
         @DisplayName("Should throw IllegalArgumentException when both APIs fail")
         void shouldThrowWhenBothNotFound() {
-            // Arrange
             String componentId = UUID.randomUUID().toString();
             expect(mockConfigContext.getComponentDetails(anyObject(NiFiWebRequestContext.class)))
                     .andThrow(new ResourceNotFoundException("Processor not found"));
@@ -193,7 +186,6 @@ class ComponentConfigReaderTest {
                     .andThrow(new ResourceNotFoundException("CS not found"));
             replay(mockConfigContext);
 
-            // Act & Assert
             IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
                     () -> reader.getComponentConfig(componentId, mockRequest));
             assertTrue(exception.getMessage().contains("Component not found"));
@@ -204,7 +196,6 @@ class ComponentConfigReaderTest {
         @Test
         @DisplayName("Should handle null properties from ComponentDetails")
         void shouldHandleNullProperties() {
-            // Arrange
             String processorId = UUID.randomUUID().toString();
             ComponentDetails details = new ComponentDetails.Builder()
                     .id(processorId)
@@ -215,11 +206,9 @@ class ComponentConfigReaderTest {
                     .andReturn(details);
             replay(mockConfigContext);
 
-            // Act
             ComponentConfigReader.ComponentConfig config =
                     reader.getComponentConfig(processorId, mockRequest);
 
-            // Assert
             assertNotNull(config.properties());
             assertTrue(config.properties().isEmpty());
             verify(mockConfigContext);
@@ -228,7 +217,6 @@ class ComponentConfigReaderTest {
         @Test
         @DisplayName("Should handle empty properties from ComponentDetails")
         void shouldHandleEmptyProperties() {
-            // Arrange
             String processorId = UUID.randomUUID().toString();
             ComponentDetails details = new ComponentDetails.Builder()
                     .id(processorId)
@@ -240,11 +228,9 @@ class ComponentConfigReaderTest {
                     .andReturn(details);
             replay(mockConfigContext);
 
-            // Act
             ComponentConfigReader.ComponentConfig config =
                     reader.getComponentConfig(processorId, mockRequest);
 
-            // Assert
             assertNotNull(config.properties());
             assertTrue(config.properties().isEmpty());
             verify(mockConfigContext);
@@ -258,7 +244,6 @@ class ComponentConfigReaderTest {
         @Test
         @DisplayName("Should return properties map from component config")
         void shouldReturnPropertiesMap() {
-            // Arrange
             String processorId = UUID.randomUUID().toString();
             Map<String, String> expectedProperties = Map.of(
                     "issuer.1.name", "test-issuer",
@@ -274,10 +259,8 @@ class ComponentConfigReaderTest {
                     .andReturn(details);
             replay(mockConfigContext);
 
-            // Act
             Map<String, String> properties = reader.getProcessorProperties(processorId, mockRequest);
 
-            // Assert
             assertEquals(2, properties.size());
             assertEquals("test-issuer", properties.get("issuer.1.name"));
             assertEquals("https://example.com/jwks", properties.get("issuer.1.jwks-url"));


### PR DESCRIPTION
## Summary

Refactors test classes across all modules to align with the project's active coding-profile standards for module testing. The changes apply the `refactor-to-profile-standards` recipe to 31 test files spanning 5 modules, enforcing AAA test structure, `@DisplayName`, `@Nested` grouping, parameterized tests for 3+ similar variants, and CUI test utility usage conventions.

## Changes

**nifi-cuioss-processors** — 3 test files
- `de.cuioss.nifi.processors.auth`: `MultiIssuerJWTTokenAuthenticatorTest`, `MultiIssuerJWTTokenAuthenticatorExtendedTest`, `MultiIssuerJWTTokenAuthenticatorI18nTest`

**nifi-cuioss-common** — 12 test files
- `de.cuioss.nifi.jwt`: `JwtLogMessagesTest`
- `de.cuioss.nifi.jwt.test`: `DynamicPropertyTestHelper`, `TestJwtIssuerConfigService`
- `de.cuioss.nifi.jwt.util`: `AuthorizationRequirementsTest`, `AuthorizationValidatorTest`, `DynamicPropertyGroupParserTest`, `ErrorContextTest`, `ProcessingErrorTest`, `TokenMaskingTest`
- `de.cuioss.nifi.jwt.config`: `ConfigurationManagerTest`, `IssuerConfigurationParserTest`, `JwtAuthenticationConfigTest`, `StandardJwtIssuerConfigServiceTest`
- `de.cuioss.nifi.jwt.i18n`: `NiFiI18nResolverTest`

**nifi-cuioss-rest-processors** — 9 test files
- `de.cuioss.nifi.rest`: `RestApiAttributesTest`
- `de.cuioss.nifi.rest.config`: `RouteConfigurationParserTest`, `RouteConfigurationTest`
- `de.cuioss.nifi.rest.handler`: `GatewayRequestHandlerTest`, `HttpRequestContainerTest`, `RequestStatusEntryTest`, `RequestStatusStoreTest`, `StatusEndpointHandlerTest`
- `de.cuioss.nifi.rest.server`: `JettyServerManagerTest`
- `de.cuioss.nifi.rest.validation`: `JsonSchemaValidatorTest`

**nifi-cuioss-ui** — 6 test files
- `de.cuioss.nifi.ui.util`: `ComponentConfigReaderTest`
- `de.cuioss.nifi.ui.service`: `JwtValidationServiceTest`
- `de.cuioss.nifi.ui.servlets`: `JwksValidationServletTest`

**integration-testing** — 1 test file
- `de.cuioss.nifi.integration`: `NiFiFlowPipelineIT`

## Test Plan

- [ ] Verification command passed (`./mvnw verify`)
- [ ] Manual testing completed (if applicable)

## Related Issues

No related issues.
