### PR TITLE
feat: add integration-test mode to deploy skill

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -70,7 +70,6 @@ Runs the `integration-testing` module's Java Failsafe ITs (e.g. `RestApiGatewayI
 
 - `-pl integration-testing -am` is **mandatory** — the `-am` (also-make) is required because the `integration-testing` test sources depend on the `nifi-cuioss-common` test-jar, which is only built when the reactor is also-made.
 - The `integration-tests` profile **manages its own container lifecycle**: `deploy-and-start.sh` auto-stops the same-project `docker` stack (`docker compose down -v`) before building and starting fresh NiFi+Keycloak containers, and `cleanup-containers` tears them down on completion. **No explicit pre-flight stop is needed here** — the profile already reuses the existing Docker primitives.
-- The only residual hazard is concurrent invocation: do **NOT** run `/deploy` and a Maven IT run at the same time (both bind the same host ports — Keycloak `9085`/`9086`, NiFi `9095`).
 
 #### stop
 ```bash

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -17,6 +17,7 @@ Optional argument selects the workflow:
 - `/deploy redeploy` — Redeploy after code changes (rebuild NAR + restart NiFi only)
 - `/deploy test` — Run E2E Playwright tests (containers must be running)
 - `/deploy test <file>` — Run specific E2E test file
+- `/deploy integration-test` (alias `/deploy it`) — Run the integration-testing module's Java Failsafe ITs (Maven manages container lifecycle)
 - `/deploy stop` — Stop all containers
 - `/deploy full` — Full CI workflow: stop → build → start → test → stop
 - `/deploy troubleshoot` — Diagnose common issues
@@ -25,7 +26,7 @@ Optional argument selects the workflow:
 
 ### Step 1: Determine Action
 
-Parse the argument to determine which workflow to execute. Default (no args) = show status.
+Parse the argument to determine which workflow to execute. Default (no args) = show status. `integration-test` and `it` both route to the [integration-test [it]](#integration-test-it) subsection.
 
 ### Step 2: Execute Action
 
@@ -60,6 +61,16 @@ Verify: `./integration-testing/src/main/docker/check-status.sh`
 cd e-2-e-playwright && npm run playwright:test [-- tests/<file>.spec.js]
 ```
 Containers MUST be running. Use `/deploy start` first if needed.
+
+#### integration-test [it]
+```bash
+python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Pintegration-tests -pl integration-testing -am"
+```
+Runs the `integration-testing` module's Java Failsafe ITs (e.g. `RestApiGatewayIT`) via the canonical plan-marshall Maven executor. Use a 10-minute (600000 ms) Bash timeout and analyze the build's TOON result (`status`, `errors[]`, `log_file`) rather than scanning raw stdout.
+
+- `-pl integration-testing -am` is **mandatory** — the `-am` (also-make) is required because the `integration-testing` test sources depend on the `nifi-cuioss-common` test-jar, which is only built when the reactor is also-made.
+- The `integration-tests` profile **manages its own container lifecycle**: `deploy-and-start.sh` auto-stops the same-project `docker` stack (`docker compose down -v`) before building and starting fresh NiFi+Keycloak containers, and `cleanup-containers` tears them down on completion. **No explicit pre-flight stop is needed here** — the profile already reuses the existing Docker primitives.
+- The only residual hazard is concurrent invocation: do **NOT** run `/deploy` and a Maven IT run at the same time (both bind the same host ports — Keycloak `9085`/`9086`, NiFi `9095`).
 
 #### stop
 ```bash
@@ -113,6 +124,7 @@ The `tabs_context_mcp` call frequently returns "Browser extension is not connect
 ## Critical Rules
 
 - Maven E2E (`./mvnw verify -Pintegration-tests`) automatically stops existing containers before starting fresh ones (via fixed `deploy-and-start.sh`)
+- The `integration-tests` profile's `deploy-and-start.sh` already stops the same-project `docker` dev stack before starting, so `/deploy integration-test` (`it`) needs no competing explicit stop step
 - After `./mvnw clean install`, the NAR in `target/nifi-deploy/` is stale — must run `/deploy redeploy` to update running containers
 - NiFi loads NARs only at startup — code changes require container restart, not just file copy
 - The `target/nifi-deploy/` directory is volume-mounted into the NiFi container

--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -198,7 +198,8 @@
     "active_profiles": [
       "implementation",
       "module_testing",
-      "quality"
+      "quality",
+      "integration_testing"
     ]
   },
   "system": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Custom Apache NiFi processors for JWT authentication and validation with a web-b
 - **Compile:** `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "compile"`
 - **Quality gate:** `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Psonar"`
 - **Full verify:** `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify"`
-- **Integration tests:** `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Pintegration-tests -pl integration-testing -am"` — stop any running Docker containers first; see [Running Maven integration tests](#running-maven-integration-tests--pintegration-tests)
+- **Integration tests:** `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Pintegration-tests -pl integration-testing -am"` — runbook (container lifecycle, mandatory `-pl integration-testing -am`, concurrency rule) lives in the `/deploy it` skill mode
 - **Coverage:** `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Pcoverage"`
 - **Module tests (e-2-e-playwright-npm):** `python3 .plan/execute-script.py plan-marshall:build-npm:npm run --command-args "run test --prefix=e-2-e-playwright"` — only on e-2-e-playwright-npm
 - **Module tests (nifi-cuioss-ui-npm):** `python3 .plan/execute-script.py plan-marshall:build-npm:npm run --command-args "run test --prefix=nifi-cuioss-ui"` — only on nifi-cuioss-ui-npm
@@ -34,16 +34,7 @@ Use `/deploy` skill for full runbook. Quick reference:
 
 ### Running Maven integration tests (`-Pintegration-tests`)
 
-The Maven `integration-tests` profile **manages its own container lifecycle** (`deploy-and-start.sh` starts NiFi+Keycloak and waits for readiness; `cleanup-containers` stops them afterward). Because it binds the same host ports the standalone dev stack uses (Keycloak `9085`/`9086`, NiFi `9095`), any already-running containers cause a port conflict and the IT run fails. Follow this pre-flight every time:
-
-1. **Check for running containers:** `docker ps`
-2. **If the integration-testing stack is up** (compose project `docker`, e.g. `docker-keycloak-1` / `docker-nifi-1`), stop it:
-   `docker compose -f integration-testing/src/main/docker/docker-compose.yml down -v`
-   (Unnamed containers without a `keycloak`/`nifi` compose label do not bind the IT ports and can be left running.)
-3. **Run the IT** via the canonical executor with `-pl integration-testing -am` (the `-am` is mandatory — `integration-testing` test sources depend on the `nifi-cuioss-common` test-jar, which is only built when the reactor is also-made):
-   `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Pintegration-tests -pl integration-testing -am"`
-
-The profile tears its own containers down on completion. Do NOT run `/deploy` and a Maven IT run at the same time.
+To run the integration-testing module's Java Failsafe ITs, use the `/deploy it` skill mode — the runbook (self-managed container lifecycle, mandatory `-pl integration-testing -am`, and the concurrency rule) lives there.
 
 ## Conventions
 

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/RestApiGatewayProcessorTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/RestApiGatewayProcessorTest.java
@@ -149,7 +149,7 @@ class RestApiGatewayProcessorTest {
 
             // Send HTTP request
             var response = httpClient.send(
-                    HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/api/health"))
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/api/health"))
                             .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                             .GET().build(),
                     HttpResponse.BodyHandlers.ofString());
@@ -181,7 +181,7 @@ class RestApiGatewayProcessorTest {
             int port = getServerPort();
 
             var response = httpClient.send(
-                    HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/api/users"))
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/api/users"))
                             .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                             .header("Content-Type", "application/json")
                             .POST(HttpRequest.BodyPublishers.ofString("{\"name\":\"test\"}"))
@@ -210,14 +210,14 @@ class RestApiGatewayProcessorTest {
 
             // Send to health
             httpClient.send(
-                    HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/api/health"))
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/api/health"))
                             .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                             .GET().build(),
                     HttpResponse.BodyHandlers.ofString());
 
             // Send to users
             httpClient.send(
-                    HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/api/users"))
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/api/users"))
                             .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                             .GET().build(),
                     HttpResponse.BodyHandlers.ofString());
@@ -241,7 +241,7 @@ class RestApiGatewayProcessorTest {
             int port = getServerPort();
 
             var response = httpClient.send(
-                    HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/api/health"))
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/api/health"))
                             .GET().build(), // No Authorization header
                     HttpResponse.BodyHandlers.ofString());
 
@@ -264,7 +264,7 @@ class RestApiGatewayProcessorTest {
             int port = getServerPort();
 
             httpClient.send(
-                    HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/api/health"))
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/api/health"))
                             .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                             .GET().build(),
                     HttpResponse.BodyHandlers.ofString());
@@ -283,7 +283,7 @@ class RestApiGatewayProcessorTest {
             int port = getServerPort();
 
             httpClient.send(
-                    HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/api/health?page=1&limit=10"))
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/api/health?page=1&limit=10"))
                             .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                             .GET().build(),
                     HttpResponse.BodyHandlers.ofString());
@@ -302,7 +302,7 @@ class RestApiGatewayProcessorTest {
             int port = getServerPort();
 
             httpClient.send(
-                    HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/api/users/42/orders/7"))
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/api/users/42/orders/7"))
                             .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                             .GET().build(),
                     HttpResponse.BodyHandlers.ofString());
@@ -321,7 +321,7 @@ class RestApiGatewayProcessorTest {
             int port = getServerPort();
 
             httpClient.send(
-                    HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/api/health"))
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/api/health"))
                             .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                             .GET().build(),
                     HttpResponse.BodyHandlers.ofString());
@@ -369,7 +369,7 @@ class RestApiGatewayProcessorTest {
                 int port = processor.serverManager.getPort();
 
                 var response = httpClient.send(
-                        HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/api/external"))
+                        HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/api/external"))
                                 .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                                 .GET().build(),
                         HttpResponse.BodyHandlers.ofString());
@@ -409,14 +409,14 @@ class RestApiGatewayProcessorTest {
 
                 // Both routes should work
                 var externalResponse = httpClient.send(
-                        HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/api/external"))
+                        HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/api/external"))
                                 .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                                 .GET().build(),
                         HttpResponse.BodyHandlers.ofString());
                 assertEquals(200, externalResponse.statusCode());
 
                 var nifiResponse = httpClient.send(
-                        HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/api/nifi-route"))
+                        HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/api/nifi-route"))
                                 .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                                 .GET().build(),
                         HttpResponse.BodyHandlers.ofString());
@@ -455,7 +455,7 @@ class RestApiGatewayProcessorTest {
 
                 // GET should NOT work (NiFi override says POST only)
                 var getResponse = httpClient.send(
-                        HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/api/myroute"))
+                        HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/api/myroute"))
                                 .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                                 .GET().build(),
                         HttpResponse.BodyHandlers.ofString());
@@ -463,7 +463,7 @@ class RestApiGatewayProcessorTest {
 
                 // POST should work
                 var postResponse = httpClient.send(
-                        HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/api/myroute"))
+                        HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/api/myroute"))
                                 .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                                 .header("Content-Type", "application/json")
                                 .POST(HttpRequest.BodyPublishers.ofString("{}"))
@@ -497,7 +497,7 @@ class RestApiGatewayProcessorTest {
                 int port = processor.serverManager.getPort();
 
                 var response = httpClient.send(
-                        HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/api/nifionly"))
+                        HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/api/nifionly"))
                                 .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                                 .GET().build(),
                         HttpResponse.BodyHandlers.ofString());

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/AttachmentsEndpointHandlerTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/AttachmentsEndpointHandlerTest.java
@@ -135,7 +135,7 @@ class AttachmentsEndpointHandlerTest {
     private String createParentEntry(String routePath) throws Exception {
         var response = httpClient.send(
                 HttpRequest.newBuilder()
-                        .uri(URI.create("http://localhost:%d%s".formatted(port, routePath)))
+                        .uri(URI.create("http://127.0.0.1:%d%s".formatted(port, routePath)))
                         .POST(HttpRequest.BodyPublishers.ofString("{\"test\":true}"))
                         .header("Content-Type", "application/json")
                         .build(),
@@ -155,7 +155,7 @@ class AttachmentsEndpointHandlerTest {
 
         var response = httpClient.send(
                 HttpRequest.newBuilder()
-                        .uri(URI.create("http://localhost:%d/attachments/%s".formatted(port, parentTraceId)))
+                        .uri(URI.create("http://127.0.0.1:%d/attachments/%s".formatted(port, parentTraceId)))
                         .POST(HttpRequest.BodyPublishers.ofString("attachment data"))
                         .header("Content-Type", "application/octet-stream")
                         .build(),
@@ -179,7 +179,7 @@ class AttachmentsEndpointHandlerTest {
 
         var response = httpClient.send(
                 HttpRequest.newBuilder()
-                        .uri(URI.create("http://localhost:%d/attachments/%s".formatted(port, unknownTraceId)))
+                        .uri(URI.create("http://127.0.0.1:%d/attachments/%s".formatted(port, unknownTraceId)))
                         .POST(HttpRequest.BodyPublishers.ofString("data"))
                         .header("Content-Type", "application/octet-stream")
                         .build(),
@@ -193,7 +193,7 @@ class AttachmentsEndpointHandlerTest {
     void shouldReturn400ForInvalidUuid() throws Exception {
         var response = httpClient.send(
                 HttpRequest.newBuilder()
-                        .uri(URI.create("http://localhost:%d/attachments/not-a-uuid".formatted(port)))
+                        .uri(URI.create("http://127.0.0.1:%d/attachments/not-a-uuid".formatted(port)))
                         .POST(HttpRequest.BodyPublishers.ofString("data"))
                         .header("Content-Type", "application/octet-stream")
                         .build(),
@@ -207,7 +207,7 @@ class AttachmentsEndpointHandlerTest {
     void shouldReturn400ForMissingParentTraceId() throws Exception {
         var response = httpClient.send(
                 HttpRequest.newBuilder()
-                        .uri(URI.create("http://localhost:%d/attachments/".formatted(port)))
+                        .uri(URI.create("http://127.0.0.1:%d/attachments/".formatted(port)))
                         .POST(HttpRequest.BodyPublishers.ofString("data"))
                         .header("Content-Type", "application/octet-stream")
                         .build(),
@@ -224,7 +224,7 @@ class AttachmentsEndpointHandlerTest {
 
         var response = httpClient.send(
                 HttpRequest.newBuilder()
-                        .uri(URI.create("http://localhost:%d/attachments/%s".formatted(port, parentTraceId)))
+                        .uri(URI.create("http://127.0.0.1:%d/attachments/%s".formatted(port, parentTraceId)))
                         .GET()
                         .build(),
                 HttpResponse.BodyHandlers.ofString());
@@ -239,7 +239,7 @@ class AttachmentsEndpointHandlerTest {
 
         var response = httpClient.send(
                 HttpRequest.newBuilder()
-                        .uri(URI.create("http://localhost:%d/attachments/%s".formatted(port, parentTraceId)))
+                        .uri(URI.create("http://127.0.0.1:%d/attachments/%s".formatted(port, parentTraceId)))
                         .POST(HttpRequest.BodyPublishers.ofString("data"))
                         .header("Content-Type", "application/octet-stream")
                         .build(),
@@ -257,7 +257,7 @@ class AttachmentsEndpointHandlerTest {
         for (int i = 0; i < 3; i++) {
             var response = httpClient.send(
                     HttpRequest.newBuilder()
-                            .uri(URI.create("http://localhost:%d/attachments/%s".formatted(port, parentTraceId)))
+                            .uri(URI.create("http://127.0.0.1:%d/attachments/%s".formatted(port, parentTraceId)))
                             .POST(HttpRequest.BodyPublishers.ofString("attachment " + i))
                             .header("Content-Type", "application/octet-stream")
                             .build(),
@@ -268,7 +268,7 @@ class AttachmentsEndpointHandlerTest {
         // 4th should fail
         var response = httpClient.send(
                 HttpRequest.newBuilder()
-                        .uri(URI.create("http://localhost:%d/attachments/%s".formatted(port, parentTraceId)))
+                        .uri(URI.create("http://127.0.0.1:%d/attachments/%s".formatted(port, parentTraceId)))
                         .POST(HttpRequest.BodyPublishers.ofString("attachment 4"))
                         .header("Content-Type", "application/octet-stream")
                         .build(),
@@ -285,7 +285,7 @@ class AttachmentsEndpointHandlerTest {
 
         var response = httpClient.send(
                 HttpRequest.newBuilder()
-                        .uri(URI.create("http://localhost:%d/attachments/%s".formatted(port, parentTraceId)))
+                        .uri(URI.create("http://127.0.0.1:%d/attachments/%s".formatted(port, parentTraceId)))
                         .POST(HttpRequest.BodyPublishers.ofString("attachment data"))
                         .header("Content-Type", "application/octet-stream")
                         .build(),
@@ -315,7 +315,7 @@ class AttachmentsEndpointHandlerTest {
 
         var response = httpClient.send(
                 HttpRequest.newBuilder()
-                        .uri(URI.create("http://localhost:%d/attachments/%s".formatted(port, parentTraceId)))
+                        .uri(URI.create("http://127.0.0.1:%d/attachments/%s".formatted(port, parentTraceId)))
                         .POST(HttpRequest.BodyPublishers.ofString("data"))
                         .header("Content-Type", "application/octet-stream")
                         .build(),
@@ -334,7 +334,7 @@ class AttachmentsEndpointHandlerTest {
 
         var response = httpClient.send(
                 HttpRequest.newBuilder()
-                        .uri(URI.create("http://localhost:%d/attachments/%s".formatted(port, parentTraceId)))
+                        .uri(URI.create("http://127.0.0.1:%d/attachments/%s".formatted(port, parentTraceId)))
                         .POST(HttpRequest.BodyPublishers.ofString("attachment data"))
                         .header("Content-Type", "application/octet-stream")
                         .build(),
@@ -358,7 +358,7 @@ class AttachmentsEndpointHandlerTest {
         // Submit one attachment (meets min count of 1)
         var response = httpClient.send(
                 HttpRequest.newBuilder()
-                        .uri(URI.create("http://localhost:%d/attachments/%s".formatted(port, parentTraceId)))
+                        .uri(URI.create("http://127.0.0.1:%d/attachments/%s".formatted(port, parentTraceId)))
                         .POST(HttpRequest.BodyPublishers.ofString("attachment data"))
                         .header("Content-Type", "application/octet-stream")
                         .build(),
@@ -378,7 +378,7 @@ class AttachmentsEndpointHandlerTest {
 
         var response = httpClient.send(
                 HttpRequest.newBuilder()
-                        .uri(URI.create("http://localhost:%d/attachments/%s".formatted(port, parentTraceId)))
+                        .uri(URI.create("http://127.0.0.1:%d/attachments/%s".formatted(port, parentTraceId)))
                         .POST(HttpRequest.BodyPublishers.ofString("attachment"))
                         .header("Content-Type", "application/octet-stream")
                         .build(),
@@ -394,7 +394,7 @@ class AttachmentsEndpointHandlerTest {
         // Query status of the attachment
         var statusResponse = httpClient.send(
                 HttpRequest.newBuilder()
-                        .uri(URI.create("http://localhost:%d/status/%s".formatted(port, attachmentTraceId)))
+                        .uri(URI.create("http://127.0.0.1:%d/status/%s".formatted(port, attachmentTraceId)))
                         .GET()
                         .build(),
                 HttpResponse.BodyHandlers.ofString());

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/GatewayRequestHandlerTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/GatewayRequestHandlerTest.java
@@ -119,7 +119,7 @@ class GatewayRequestHandlerTest {
     }
 
     private URI uri(String path) {
-        return URI.create("http://localhost:" + port + path);
+        return URI.create("http://127.0.0.1:" + port + path);
     }
 
     private HttpRequest.Builder requestBuilder(String path) {
@@ -192,7 +192,7 @@ class GatewayRequestHandlerTest {
             try {
                 int disabledPort = connector.getLocalPort();
                 var response = httpClient.send(
-                        HttpRequest.newBuilder(URI.create("http://localhost:" + disabledPort + "/api/disabled"))
+                        HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + disabledPort + "/api/disabled"))
                                 .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                                 .GET().build(),
                         HttpResponse.BodyHandlers.ofString());
@@ -234,7 +234,7 @@ class GatewayRequestHandlerTest {
 
         private HttpResponse<String> get(String path) throws Exception {
             return httpClient.send(
-                    HttpRequest.newBuilder(URI.create("http://localhost:" + patternPort + path))
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + patternPort + path))
                             .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                             .GET().build(),
                     HttpResponse.BodyHandlers.ofString());
@@ -346,7 +346,7 @@ class GatewayRequestHandlerTest {
             int smallPort = connector.getLocalPort();
             try {
                 var response = httpClient.send(
-                        HttpRequest.newBuilder(URI.create("http://localhost:" + smallPort + "/api/data"))
+                        HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + smallPort + "/api/data"))
                                 .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                                 .header("Content-Type", "application/json")
                                 .POST(HttpRequest.BodyPublishers.ofString("a]".repeat(100)))
@@ -528,14 +528,14 @@ class GatewayRequestHandlerTest {
             try {
                 // Fill the queue
                 httpClient.send(
-                        HttpRequest.newBuilder(URI.create("http://localhost:" + tinyPort + "/api/health"))
+                        HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + tinyPort + "/api/health"))
                                 .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                                 .GET().build(),
                         HttpResponse.BodyHandlers.ofString());
 
                 // This one should get 503
                 var response = httpClient.send(
-                        HttpRequest.newBuilder(URI.create("http://localhost:" + tinyPort + "/api/health"))
+                        HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + tinyPort + "/api/health"))
                                 .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                                 .GET().build(),
                         HttpResponse.BodyHandlers.ofString());
@@ -573,7 +573,7 @@ class GatewayRequestHandlerTest {
 
             try {
                 var response = httpClient.send(
-                        HttpRequest.newBuilder(URI.create("http://localhost:" + noFlowFilePort + "/api/health"))
+                        HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + noFlowFilePort + "/api/health"))
                                 .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                                 .GET().build(),
                         HttpResponse.BodyHandlers.ofString());
@@ -693,7 +693,7 @@ class GatewayRequestHandlerTest {
      * as a successful rejection.
      */
     private void assertAttackRejected(AttackTestCase testCase) throws Exception {
-        String attackUrl = "http://localhost:" + port + "/api/health" + testCase.attackString();
+        String attackUrl = "http://127.0.0.1:" + port + "/api/health" + testCase.attackString();
         try {
             var request = HttpRequest.newBuilder(URI.create(attackUrl))
                     .header("Authorization", "Bearer " + tokenHolder.getRawToken())
@@ -768,7 +768,7 @@ class GatewayRequestHandlerTest {
         @DisplayName("Should return 422 for invalid body")
         void shouldReturn422ForInvalidBody() throws Exception {
             var response = httpClient.send(
-                    HttpRequest.newBuilder(URI.create("http://localhost:" + schemaPort + "/api/validated"))
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + schemaPort + "/api/validated"))
                             .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                             .header("Content-Type", "application/json")
                             .POST(HttpRequest.BodyPublishers.ofString("""
@@ -789,7 +789,7 @@ class GatewayRequestHandlerTest {
         @DisplayName("Should return 422 with violations array in response")
         void shouldReturn422WithViolationsArray() throws Exception {
             var response = httpClient.send(
-                    HttpRequest.newBuilder(URI.create("http://localhost:" + schemaPort + "/api/validated"))
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + schemaPort + "/api/validated"))
                             .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                             .header("Content-Type", "application/json")
                             .POST(HttpRequest.BodyPublishers.ofString("""
@@ -808,7 +808,7 @@ class GatewayRequestHandlerTest {
         @DisplayName("Should return 202 for valid body")
         void shouldReturn202ForValidBody() throws Exception {
             var response = httpClient.send(
-                    HttpRequest.newBuilder(URI.create("http://localhost:" + schemaPort + "/api/validated"))
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + schemaPort + "/api/validated"))
                             .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                             .header("Content-Type", "application/json")
                             .POST(HttpRequest.BodyPublishers.ofString("""
@@ -824,7 +824,7 @@ class GatewayRequestHandlerTest {
         @DisplayName("Should skip validation when no schema configured")
         void shouldSkipValidationWhenNoSchema() throws Exception {
             var response = httpClient.send(
-                    HttpRequest.newBuilder(URI.create("http://localhost:" + schemaPort + "/api/noschema"))
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + schemaPort + "/api/noschema"))
                             .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                             .header("Content-Type", "application/json")
                             .POST(HttpRequest.BodyPublishers.ofString("any invalid json content"))
@@ -839,7 +839,7 @@ class GatewayRequestHandlerTest {
         void shouldRejectEmptyBody() throws Exception {
             // POST with empty body should fail schema validation
             var response = httpClient.send(
-                    HttpRequest.newBuilder(URI.create("http://localhost:" + schemaPort + "/api/validated"))
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + schemaPort + "/api/validated"))
                             .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                             .header("Content-Type", "application/json")
                             .POST(HttpRequest.BodyPublishers.noBody())
@@ -887,7 +887,7 @@ class GatewayRequestHandlerTest {
             try {
                 // Valid body
                 var validResponse = httpClient.send(
-                        HttpRequest.newBuilder(URI.create("http://localhost:" + inlinePort + "/api/inline"))
+                        HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + inlinePort + "/api/inline"))
                                 .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                                 .header("Content-Type", "application/json")
                                 .POST(HttpRequest.BodyPublishers.ofString("{\"title\": \"Hello\"}"))
@@ -897,7 +897,7 @@ class GatewayRequestHandlerTest {
 
                 // Invalid body — missing required field
                 var invalidResponse = httpClient.send(
-                        HttpRequest.newBuilder(URI.create("http://localhost:" + inlinePort + "/api/inline"))
+                        HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + inlinePort + "/api/inline"))
                                 .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                                 .header("Content-Type", "application/json")
                                 .POST(HttpRequest.BodyPublishers.ofString("{\"other\": 1}"))
@@ -935,7 +935,7 @@ class GatewayRequestHandlerTest {
 
             try {
                 var response = httpClient.send(
-                        HttpRequest.newBuilder(URI.create("http://localhost:" + testPort + testCase.legitimatePattern()))
+                        HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + testPort + testCase.legitimatePattern()))
                                 .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                                 .GET().build(),
                         HttpResponse.BodyHandlers.ofString());

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/ManagementEndpointHandlerTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/ManagementEndpointHandlerTest.java
@@ -117,7 +117,12 @@ class ManagementEndpointHandlerTest {
     }
 
     private URI uri(String path) {
-        return URI.create("http://localhost:" + port + path);
+        // Use 127.0.0.1 (not "localhost"): the Jetty connector binds 0.0.0.0 (IPv4),
+        // but "localhost" can resolve to ::1 (IPv6) first on some platforms, letting the
+        // client reach a foreign service holding the same ephemeral IPv6 port instead of
+        // Jetty — an intermittent "Invalid status line" flake. Forcing IPv4 also matches
+        // the 127.0.0.1 address the loopback-bypass logic expects.
+        return URI.create("http://127.0.0.1:" + port + path);
     }
 
     @Nested
@@ -163,7 +168,7 @@ class ManagementEndpointHandlerTest {
         @Test
         @DisplayName("Should allow loopback requests without auth")
         void shouldAllowLoopbackRequestsWithoutAuth() throws Exception {
-            // Test connects via localhost — loopback bypass applies
+            // Test connects via 127.0.0.1 — loopback bypass applies
             var response = httpClient.send(
                     HttpRequest.newBuilder(uri("/metrics")).GET().build(),
                     HttpResponse.BodyHandlers.ofString());
@@ -326,7 +331,7 @@ class ManagementEndpointHandlerTest {
         @Test
         @DisplayName("Loopback requests work without any auth header")
         void loopbackRequestsWorkWithoutAuthHeader() throws Exception {
-            // Tests connect via localhost — loopback bypass applies
+            // Tests connect via 127.0.0.1 — loopback bypass applies
             var response = httpClient.send(
                     HttpRequest.newBuilder(uri("/metrics")).GET().build(),
                     HttpResponse.BodyHandlers.ofString());
@@ -343,7 +348,7 @@ class ManagementEndpointHandlerTest {
                             de.cuioss.sheriff.oauth.core.security.SecurityEventCounter.EventType.TOKEN_EXPIRED,
                             "Token expired"));
 
-            // Even though the request comes via loopback (localhost), it should
+            // Even though the request comes via loopback (127.0.0.1), it should
             // succeed because loopback bypass is checked first.
             var response = httpClient.send(
                     HttpRequest.newBuilder(uri("/metrics")).GET().build(),
@@ -391,7 +396,7 @@ class ManagementEndpointHandlerTest {
         @DisplayName("Should allow loopback access without auth")
         void shouldAllowLoopbackWithoutAuth() throws Exception {
             var response = httpClient.send(
-                    HttpRequest.newBuilder(URI.create("http://localhost:" + localOnlyPort + "/health"))
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + localOnlyPort + "/health"))
                             .GET().build(),
                     HttpResponse.BodyHandlers.ofString());
 
@@ -404,7 +409,7 @@ class ManagementEndpointHandlerTest {
             localOnlyHandler.loopbackBypassEnabled = false;
 
             var response = httpClient.send(
-                    HttpRequest.newBuilder(URI.create("http://localhost:" + localOnlyPort + "/health"))
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + localOnlyPort + "/health"))
                             .GET().build(),
                     HttpResponse.BodyHandlers.ofString());
 

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/StatusEndpointHandlerTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/StatusEndpointHandlerTest.java
@@ -116,7 +116,7 @@ class StatusEndpointHandlerTest {
     }
 
     private URI uri(String path) {
-        return URI.create("http://localhost:" + port + path);
+        return URI.create("http://127.0.0.1:" + port + path);
     }
 
     @Nested

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/server/JettyServerManagerTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/server/JettyServerManagerTest.java
@@ -137,7 +137,7 @@ class JettyServerManagerTest {
 
             HttpClient client = HttpClient.newHttpClient();
             var response = client.send(
-                    HttpRequest.newBuilder(URI.create("http://localhost:" + manager.getPort() + "/test"))
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + manager.getPort() + "/test"))
                             .GET().build(),
                     HttpResponse.BodyHandlers.ofString());
 
@@ -176,7 +176,7 @@ class JettyServerManagerTest {
 
             HttpClient client = HttpClient.newHttpClient();
             var response = client.send(
-                    HttpRequest.newBuilder(URI.create("http://localhost:" + manager.getPort() + "/test"))
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + manager.getPort() + "/test"))
                             .GET().build(),
                     HttpResponse.BodyHandlers.ofString());
 
@@ -220,7 +220,7 @@ class JettyServerManagerTest {
             HttpClient client = HttpClient.newHttpClient();
 
             assertThrows(Exception.class, () -> client.send(
-                    HttpRequest.newBuilder(URI.create("http://localhost:" + manager.getPort() + "/test"))
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + manager.getPort() + "/test"))
                             .GET().build(),
                     HttpResponse.BodyHandlers.ofString()));
         }


### PR DESCRIPTION
## Summary

Adds a new `/deploy integration-test` (alias `/deploy it`) mode to the project-level `/deploy` skill that runs the `integration-testing` module's Java Failsafe ITs via the canonical plan-marshall Maven executor, collapses the duplicated runbook prose in `CLAUDE.md` to a single pointer at the new mode, and activates the `integration_testing` plan-marshall profile so the capability is first-class in the planning system.

While finalizing, a pre-existing flaky test was discovered and fixed (see "Test hardening" below).

## Changes

### Deliverables

1. **`/deploy integration-test` mode** (`.claude/skills/deploy/SKILL.md`) — new parameter row, Step 1 routing, and a `#### integration-test [it]` Step 2 subsection invoking `verify -Pintegration-tests -pl integration-testing -am` via the canonical Maven executor (with the mandatory `-am` rationale), plus a Critical Rules note. The mode relies on `deploy-and-start.sh`'s built-in `docker compose down -v` auto-stop (it tears down the same-project dev stack before starting), so it adds **no** redundant explicit stop — only the concurrent-invocation rule.

2. **Collapse `CLAUDE.md` runbook → pointer** (`CLAUDE.md`) — the `### Running Maven integration tests` multi-step runbook is replaced by a one-line pointer at `/deploy it`; the runbook now lives in exactly one cohesive place (the skill).

3. **Activate `integration_testing` plan-marshall profile** (`.plan/marshal.json`) — adds `integration_testing` to `skill_domains.active_profiles` (now `implementation, module_testing, quality, integration_testing`), making integration-test deliverables first-class in plan-marshall's architecture enrichment / skill resolution. Does not force integration tests to run on every build/verify.

### Test hardening (flake fix)

The finalize quality sweep surfaced an intermittent failure in `nifi-cuioss-rest-processors` (`ManagementEndpointHandlerTest.shouldReturn405ForPost`, "Invalid status line"). Root cause: tests connect to `http://localhost:<ephemeral-port>` while the Jetty connector binds `0.0.0.0` (IPv4); `localhost` can resolve to IPv6 `::1` first, so when a foreign service holds that `::1` ephemeral port the client reaches it instead of Jetty (the garbled status line decoded to a foreign binary handshake that misread the request's "POST" bytes as a version field).

Fix: connect to `127.0.0.1` instead of `localhost` in all HTTP test URIs across the REST handler tests (`ManagementEndpointHandlerTest`, `RestApiGatewayProcessorTest`, `StatusEndpointHandlerTest`, `GatewayRequestHandlerTest`, `AttachmentsEndpointHandlerTest`, `JettyServerManagerTest`), forcing IPv4 to match Jetty's bind and the loopback-bypass logic. The single `https://localhost` (self-signed cert SAN) in `JettyServerManagerTest` is left unchanged.

## Verification

- `test -pl nifi-cuioss-rest-processors -am` — passes (exit 0); the previously-flaky test is now deterministic.
- Documentation/config deliverables are project-level skill + plan-marshall config (no automated Maven gate).
