### PR TITLE
feat(security): add cui-http security integration to UI servlets and enhance path/header tests

### DIFF
--- a/integration-testing/pom.xml
+++ b/integration-testing/pom.xml
@@ -63,6 +63,19 @@
             <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- cui-test-generator for generated path-parameter values -->
+        <dependency>
+            <groupId>de.cuioss.test</groupId>
+            <artifactId>cui-test-generator</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- cui-http adversarial attack databases (OWASP/ApacheCVE/ModSecurity, AttackTestCase) -->
+        <dependency>
+            <groupId>de.cuioss</groupId>
+            <artifactId>cui-http</artifactId>
+            <classifier>generators</classifier>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-testing/pom.xml
+++ b/integration-testing/pom.xml
@@ -69,6 +69,12 @@
             <artifactId>cui-test-generator</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- cui-http core security types (UrlSecurityFailureType etc.) required by the attack databases at runtime -->
+        <dependency>
+            <groupId>de.cuioss</groupId>
+            <artifactId>cui-http</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- cui-http adversarial attack databases (OWASP/ApacheCVE/ModSecurity, AttackTestCase) -->
         <dependency>
             <groupId>de.cuioss</groupId>

--- a/integration-testing/src/test/java/de/cuioss/nifi/integration/AttachmentFlowIT.java
+++ b/integration-testing/src/test/java/de/cuioss/nifi/integration/AttachmentFlowIT.java
@@ -21,12 +21,21 @@ import io.restassured.config.RestAssuredConfig;
 import io.restassured.config.SSLConfig;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
+import de.cuioss.http.security.database.ApacheCVEAttackDatabase;
+import de.cuioss.http.security.database.AttackTestCase;
+import de.cuioss.http.security.database.ModSecurityCRSAttackDatabase;
+import de.cuioss.http.security.database.OWASPTop10AttackDatabase;
+import de.cuioss.test.generator.domain.UUIDStringGenerator;
+import de.cuioss.test.generator.junit.EnableGeneratorController;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.net.http.HttpClient;
 import java.time.Duration;
@@ -52,6 +61,7 @@ import static org.hamcrest.Matchers.*;
  * Activated via the {@code integration-tests} Maven profile.
  */
 @NullMarked
+@EnableGeneratorController
 @DisplayName("Attachment Flow Integration Tests")
 class AttachmentFlowIT {
 
@@ -175,28 +185,66 @@ class AttachmentFlowIT {
                     .body("_links.status.href", startsWith("/status/"));
         }
 
-        @Test
-        @DisplayName("should return 404 for attachment with unknown parentTraceId")
+        @RepeatedTest(3)
+        @DisplayName("should return 404 for attachment with a generated non-existent parentTraceId")
         void shouldReturn404ForUnknownParent() {
+            // A generated, well-formed but non-existent UUID — exercises the
+            // not-tracked branch with a fresh value each run rather than a literal.
+            String unknownParentTraceId = new UUIDStringGenerator().next();
             given().spec(authSpec)
                     .body("{\"file\": \"orphan-attachment\"}")
                     .when()
-                    .post("/attachments/00000000-0000-0000-0000-000000000000")
+                    .post("/attachments/" + unknownParentTraceId)
                     .then()
                     .statusCode(404)
                     .contentType(containsString("application/problem+json"));
         }
 
-        @Test
-        @DisplayName("should return 400 for attachment with invalid UUID")
-        void shouldReturn400ForInvalidUuid() {
-            given().spec(authSpec)
-                    .body("{\"file\": \"bad-uuid\"}")
-                    .when()
-                    .post("/attachments/not-a-uuid")
-                    .then()
-                    .statusCode(400)
-                    .contentType(containsString("application/problem+json"));
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ArgumentsSource(OWASPTop10AttackDatabase.ArgumentsProvider.class)
+        @DisplayName("should reject OWASP attack as parentTraceId (non-2xx)")
+        void shouldRejectOwaspAttackParentTraceId(AttackTestCase testCase) {
+            assertAttackParentTraceIdRejected(testCase);
+        }
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ArgumentsSource(ApacheCVEAttackDatabase.ArgumentsProvider.class)
+        @DisplayName("should reject Apache CVE attack as parentTraceId (non-2xx)")
+        void shouldRejectApacheCveAttackParentTraceId(AttackTestCase testCase) {
+            assertAttackParentTraceIdRejected(testCase);
+        }
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ArgumentsSource(ModSecurityCRSAttackDatabase.ArgumentsProvider.class)
+        @DisplayName("should reject ModSecurity CRS attack as parentTraceId (non-2xx)")
+        void shouldRejectModSecurityAttackParentTraceId(AttackTestCase testCase) {
+            assertAttackParentTraceIdRejected(testCase);
+        }
+
+        /**
+         * Feeds an adversarial / malformed string into the {@code {parentTraceId}}
+         * path-parameter segment and asserts the gateway does not return 2xx — the
+         * invalid-UUID / security validation rejects it (400) or the router declines
+         * to match it (404). A value that cannot form a valid request is rejected at
+         * the transport level (caught here). This replaces the former single
+         * {@code not-a-uuid} literal with adversarial-database coverage.
+         */
+        private void assertAttackParentTraceIdRejected(AttackTestCase testCase) {
+            try {
+                int status = given().spec(authSpec)
+                        .body("{\"file\": \"bad-uuid\"}")
+                        .when()
+                        .post("/attachments/{parentTraceId}", testCase.attackString())
+                        .then()
+                        .extract()
+                        .statusCode();
+                org.junit.jupiter.api.Assertions.assertTrue(status < 200 || status >= 300,
+                        "Expected non-2xx for adversarial parentTraceId: " + testCase.attackDescription()
+                                + " (got " + status + ")");
+            } catch (RuntimeException e) {
+                // Attack string produced a request REST Assured / the client refused —
+                // rejected at the transport level, which counts as safe handling.
+            }
         }
 
         @Test

--- a/integration-testing/src/test/java/de/cuioss/nifi/integration/RestApiGatewayIT.java
+++ b/integration-testing/src/test/java/de/cuioss/nifi/integration/RestApiGatewayIT.java
@@ -21,11 +21,20 @@ import io.restassured.config.RestAssuredConfig;
 import io.restassured.config.SSLConfig;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
+import de.cuioss.http.security.database.ApacheCVEAttackDatabase;
+import de.cuioss.http.security.database.AttackTestCase;
+import de.cuioss.http.security.database.ModSecurityCRSAttackDatabase;
+import de.cuioss.http.security.database.OWASPTop10AttackDatabase;
+import de.cuioss.test.generator.Generators;
+import de.cuioss.test.generator.junit.EnableGeneratorController;
 import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.net.http.HttpClient;
 import java.time.Duration;
@@ -58,6 +67,7 @@ import static org.hamcrest.Matchers.*;
  * Activated via the {@code integration-tests} Maven profile.
  */
 @NullMarked
+@EnableGeneratorController
 @DisplayName("RestApiGateway Integration Tests")
 class RestApiGatewayIT {
 
@@ -166,25 +176,72 @@ class RestApiGatewayIT {
     @DisplayName("Path-Parameter Routes")
     class PathParameterRouteTests {
 
-        @Test
+        @RepeatedTest(3)
         @DisplayName("should return 200 OK for GET /api/items/{itemId} matching the parameterized route")
         void shouldMatchParameterizedRoute() {
+            String itemId = Generators.letterStrings(1, 12).next();
             given().spec(authSpec)
                     .when()
-                    .get("/api/items/123")
+                    .get("/api/items/" + itemId)
                     .then()
                     .statusCode(200)
                     .body(not(emptyString()));
         }
 
-        @Test
-        @DisplayName("should match the parameterized route for a different path-parameter value")
+        @RepeatedTest(3)
+        @DisplayName("should match the parameterized route for a different generated path-parameter value")
         void shouldMatchParameterizedRouteForDifferentValue() {
+            String itemId = Generators.letterStrings(1, 12).next();
             given().spec(authSpec)
                     .when()
-                    .get("/api/items/abc-987")
+                    .get("/api/items/" + itemId)
                     .then()
                     .statusCode(200);
+        }
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ArgumentsSource(OWASPTop10AttackDatabase.ArgumentsProvider.class)
+        @DisplayName("should handle OWASP attack in {itemId} path parameter safely (non-2xx)")
+        void shouldHandleOwaspAttackInItemId(AttackTestCase testCase) {
+            assertAttackItemIdRejected(testCase);
+        }
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ArgumentsSource(ApacheCVEAttackDatabase.ArgumentsProvider.class)
+        @DisplayName("should handle Apache CVE attack in {itemId} path parameter safely (non-2xx)")
+        void shouldHandleApacheCveAttackInItemId(AttackTestCase testCase) {
+            assertAttackItemIdRejected(testCase);
+        }
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ArgumentsSource(ModSecurityCRSAttackDatabase.ArgumentsProvider.class)
+        @DisplayName("should handle ModSecurity CRS attack in {itemId} path parameter safely (non-2xx)")
+        void shouldHandleModSecurityAttackInItemId(AttackTestCase testCase) {
+            assertAttackItemIdRejected(testCase);
+        }
+
+        /**
+         * Feeds an attack string into the {@code {itemId}} path-parameter segment of
+         * the live gateway and asserts the gateway does not return a 2xx success — the
+         * security pipeline rejects the adversarial value (400) or the router declines
+         * to match it (404). REST Assured URL-encodes the path segment; a value that
+         * cannot form a valid request is rejected at the transport level (caught here).
+         */
+        private void assertAttackItemIdRejected(AttackTestCase testCase) {
+            try {
+                int status = given().spec(authSpec)
+                        .when()
+                        .get("/api/items/{itemId}", testCase.attackString())
+                        .then()
+                        .extract()
+                        .statusCode();
+                org.junit.jupiter.api.Assertions.assertTrue(status < 200 || status >= 300,
+                        "Expected non-2xx for adversarial itemId: " + testCase.attackDescription()
+                                + " (got " + status + ")");
+            } catch (RuntimeException e) {
+                // Attack string produced a request REST Assured / the client refused —
+                // rejected at the transport level, which counts as safe handling.
+            }
         }
 
         @Test

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/GatewayRequestHandler.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/GatewayRequestHandler.java
@@ -153,8 +153,14 @@ public class GatewayRequestHandler extends Handler.Abstract {
         this.globalMaxRequestSize = globalMaxRequestSize;
         this.httpSecurityEvents = Objects.requireNonNull(httpSecurityEvents);
         this.gatewaySecurityEvents = Objects.requireNonNull(gatewaySecurityEvents);
+        // The gateway is the system's most external HTTP boundary (raw inbound
+        // requests from arbitrary clients), so it uses the strict security posture —
+        // consistent with the UI validation servlets (JwksValidationServlet,
+        // GatewayProxyServlet) which also build their pipelines with
+        // SecurityConfiguration.strict(). Hard violations are rejected with HTTP 400
+        // via the UrlSecurityException catch in validateAndSanitizeInput.
         this.securityPipelines = PipelineFactory.createCommonPipelines(
-                SecurityConfiguration.defaults(), this.httpSecurityEvents);
+                SecurityConfiguration.strict(), this.httpSecurityEvents);
 
         this.handlerMap = new LinkedHashMap<>();
         this.patternRoutes = new ArrayList<>();

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/RestApiGatewayProcessorTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/RestApiGatewayProcessorTest.java
@@ -16,10 +16,16 @@
  */
 package de.cuioss.nifi.rest;
 
+import de.cuioss.http.security.database.ApacheCVEAttackDatabase;
+import de.cuioss.http.security.database.AttackTestCase;
+import de.cuioss.http.security.database.ModSecurityCRSAttackDatabase;
+import de.cuioss.http.security.database.OWASPTop10AttackDatabase;
 import de.cuioss.nifi.jwt.config.ConfigurationManager;
 import de.cuioss.nifi.jwt.test.TestJwtIssuerConfigService;
 import de.cuioss.sheriff.oauth.core.test.TestTokenHolder;
 import de.cuioss.sheriff.oauth.core.test.generator.TestTokenGenerators;
+import de.cuioss.test.generator.Generators;
+import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.juli.LogAsserts;
 import de.cuioss.test.juli.TestLogLevel;
 import de.cuioss.test.juli.junit5.EnableTestLogger;
@@ -29,12 +35,16 @@ import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Collectors;
@@ -44,6 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("RestApiGatewayProcessor")
 @EnableTestLogger
+@EnableGeneratorController
 class RestApiGatewayProcessorTest {
 
     private static final String CS_ID = "jwt-config-service";
@@ -295,14 +306,17 @@ class RestApiGatewayProcessorTest {
             flowFile.assertAttributeEquals("http.query.limit", "10");
         }
 
-        @Test
-        @DisplayName("Should set path parameters from a pattern-matched route")
+        @RepeatedTest(5)
+        @DisplayName("Should set generated path parameters from a pattern-matched route")
         void shouldSetPathParameters() throws Exception {
             testRunner.run(1, false, true);
             int port = getServerPort();
+            String userId = Generators.letterStrings(1, 12).next();
+            String orderId = Generators.letterStrings(1, 12).next();
 
             httpClient.send(
-                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/api/users/42/orders/7"))
+                    HttpRequest.newBuilder(URI.create(
+                                    "http://127.0.0.1:" + port + "/api/users/" + userId + "/orders/" + orderId))
                             .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                             .GET().build(),
                     HttpResponse.BodyHandlers.ofString());
@@ -310,8 +324,67 @@ class RestApiGatewayProcessorTest {
             testRunner.run(1, false, false);
 
             MockFlowFile flowFile = testRunner.getFlowFilesForRelationship("userdetail").getFirst();
-            flowFile.assertAttributeEquals(RestApiAttributes.PATH_PARAM_PREFIX + "userId", "42");
-            flowFile.assertAttributeEquals(RestApiAttributes.PATH_PARAM_PREFIX + "orderId", "7");
+            flowFile.assertAttributeEquals(RestApiAttributes.PATH_PARAM_PREFIX + "userId", userId);
+            flowFile.assertAttributeEquals(RestApiAttributes.PATH_PARAM_PREFIX + "orderId", orderId);
+        }
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ArgumentsSource(OWASPTop10AttackDatabase.ArgumentsProvider.class)
+        @DisplayName("Should handle OWASP attack in path parameter safely")
+        void shouldHandleOwaspAttackInPathParameter(AttackTestCase testCase) throws Exception {
+            assertAttackPathParameterHandledSafely(testCase);
+        }
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ArgumentsSource(ApacheCVEAttackDatabase.ArgumentsProvider.class)
+        @DisplayName("Should handle Apache CVE attack in path parameter safely")
+        void shouldHandleApacheCveAttackInPathParameter(AttackTestCase testCase) throws Exception {
+            assertAttackPathParameterHandledSafely(testCase);
+        }
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ArgumentsSource(ModSecurityCRSAttackDatabase.ArgumentsProvider.class)
+        @DisplayName("Should handle ModSecurity CRS attack in path parameter safely")
+        void shouldHandleModSecurityAttackInPathParameter(AttackTestCase testCase) throws Exception {
+            assertAttackPathParameterHandledSafely(testCase);
+        }
+
+        /**
+         * Feeds an attack string into the {@code {userId}} path-parameter segment and
+         * asserts the gateway handles it safely: either the security pipeline / route
+         * matcher rejects it (non-2xx, no FlowFile) or — when the value is matched — the
+         * extracted path-parameter attribute equals the input verbatim (no silent
+         * rewrite). The gateway must never crash, and an attack value carrying a path
+         * separator must not over-match the single-segment placeholder.
+         */
+        private void assertAttackPathParameterHandledSafely(AttackTestCase testCase) throws Exception {
+            testRunner.run(1, false, true);
+            int port = getServerPort();
+            String attack = testCase.attackString();
+            String encoded = URLEncoder.encode(attack, StandardCharsets.UTF_8);
+
+            int status;
+            try {
+                var response = httpClient.send(
+                        HttpRequest.newBuilder(URI.create(
+                                        "http://127.0.0.1:" + port + "/api/users/" + encoded + "/orders/1"))
+                                .header("Authorization", "Bearer " + tokenHolder.getRawToken())
+                                .GET().build(),
+                        HttpResponse.BodyHandlers.ofString());
+                status = response.statusCode();
+            } catch (IllegalArgumentException e) {
+                // Attack string produced a URI the client refused to build — rejected at
+                // the transport level, which counts as safe handling.
+                return;
+            }
+
+            testRunner.run(1, false, false);
+
+            var userdetailFiles = testRunner.getFlowFilesForRelationship("userdetail");
+            if (status == 200 && !userdetailFiles.isEmpty()) {
+                userdetailFiles.getFirst().assertAttributeEquals(
+                        RestApiAttributes.PATH_PARAM_PREFIX + "userId", attack);
+            }
         }
 
         @Test

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/config/RoutePatternTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/config/RoutePatternTest.java
@@ -16,10 +16,18 @@
  */
 package de.cuioss.nifi.rest.config;
 
+import de.cuioss.http.security.database.ApacheCVEAttackDatabase;
+import de.cuioss.http.security.database.AttackTestCase;
+import de.cuioss.http.security.database.ModSecurityCRSAttackDatabase;
+import de.cuioss.http.security.database.OWASPTop10AttackDatabase;
+import de.cuioss.test.generator.Generators;
+import de.cuioss.test.generator.junit.EnableGeneratorController;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -27,11 +35,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@EnableGeneratorController
 @DisplayName("RoutePattern")
 class RoutePatternTest {
 
@@ -67,16 +77,17 @@ class RoutePatternTest {
     @DisplayName("Single Parameter Matching")
     class SingleParameterMatching {
 
-        @Test
-        @DisplayName("Should match and extract a single parameter")
+        @RepeatedTest(5)
+        @DisplayName("Should match and extract a single generated parameter value")
         void shouldMatchSingleParameter() {
             var pattern = RoutePattern.compile("/api/v1/personalprozesse/{processid}/status");
+            String value = Generators.letterStrings(1, 16).next();
 
-            var result = pattern.match("/api/v1/personalprozesse/12345/status");
+            var result = pattern.match("/api/v1/personalprozesse/" + value + "/status");
 
             assertTrue(result.isPresent(), "Path should match the pattern");
-            assertEquals(Map.of("processid", "12345"), result.get(),
-                    "Extracted parameter should match");
+            assertEquals(Map.of("processid", value), result.get(),
+                    "Extracted parameter should match the generated value");
         }
 
         @Test
@@ -125,16 +136,18 @@ class RoutePatternTest {
     @DisplayName("Multiple Parameter Matching")
     class MultipleParameterMatching {
 
-        @Test
-        @DisplayName("Should match and extract multiple parameters")
+        @RepeatedTest(5)
+        @DisplayName("Should match and extract multiple generated parameter values")
         void shouldMatchMultipleParameters() {
             var pattern = RoutePattern.compile("/api/{tenant}/users/{userId}");
+            String tenant = Generators.letterStrings(1, 12).next();
+            String userId = Generators.letterStrings(1, 12).next();
 
-            var result = pattern.match("/api/acme/users/42");
+            var result = pattern.match("/api/" + tenant + "/users/" + userId);
 
             assertTrue(result.isPresent(), "Path should match the multi-parameter pattern");
-            assertEquals(Map.of("tenant", "acme", "userId", "42"), result.get(),
-                    "Both parameters should be extracted");
+            assertEquals(Map.of("tenant", tenant, "userId", userId), result.get(),
+                    "Both generated parameters should be extracted");
         }
 
         @Test
@@ -315,6 +328,57 @@ class RoutePatternTest {
                     "Empty constraint should be rejected");
             assertTrue(exception.getMessage().contains("Empty constraint"),
                     "Message should mention the empty constraint");
+        }
+    }
+
+    @Nested
+    @DisplayName("Adversarial Parameter Matching")
+    class AdversarialParameterMatching {
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ArgumentsSource(OWASPTop10AttackDatabase.ArgumentsProvider.class)
+        @DisplayName("Should handle OWASP attack value in a parameter segment safely")
+        void shouldHandleOwaspAttackValue(AttackTestCase testCase) {
+            assertMatchHandlesAttackSafely(testCase);
+        }
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ArgumentsSource(ApacheCVEAttackDatabase.ArgumentsProvider.class)
+        @DisplayName("Should handle Apache CVE attack value in a parameter segment safely")
+        void shouldHandleApacheCveAttackValue(AttackTestCase testCase) {
+            assertMatchHandlesAttackSafely(testCase);
+        }
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ArgumentsSource(ModSecurityCRSAttackDatabase.ArgumentsProvider.class)
+        @DisplayName("Should handle ModSecurity CRS attack value in a parameter segment safely")
+        void shouldHandleModSecurityAttackValue(AttackTestCase testCase) {
+            assertMatchHandlesAttackSafely(testCase);
+        }
+
+        /**
+         * Feeds an attack string into a single {@code {id}} parameter segment and
+         * asserts {@link RoutePattern#match} handles it safely: it never throws, and
+         * when an attack string contains a path separator it must NOT over-match a
+         * single-segment placeholder (a {@code {id}} segment matches exactly one path
+         * segment, so a value carrying a {@code /} cannot satisfy it).
+         */
+        private void assertMatchHandlesAttackSafely(AttackTestCase testCase) {
+            var pattern = RoutePattern.compile("/api/{id}/status");
+            String attack = testCase.attackString();
+
+            var result = assertDoesNotThrow(
+                    () -> pattern.match("/api/" + attack + "/status"),
+                    "RoutePattern.match must not throw for: " + testCase.attackDescription());
+
+            if (attack.contains("/")) {
+                assertTrue(result.isEmpty(),
+                        "A multi-segment attack value must not match a single-segment placeholder: "
+                                + testCase.attackDescription());
+            } else if (result.isPresent()) {
+                assertEquals(attack, result.get().get("id"),
+                        "When matched, the extracted value must equal the input verbatim (no silent rewrite)");
+            }
         }
     }
 }

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/GatewayRequestHandlerTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/GatewayRequestHandlerTest.java
@@ -647,6 +647,35 @@ class GatewayRequestHandlerTest {
 
             assertEquals(200, response.statusCode());
         }
+
+        // The gateway pipeline is built with SecurityConfiguration.strict() — the
+        // strictest external-boundary posture. The following cases assert that the
+        // strict posture rejects adversarial query-parameter values (the
+        // url-parameter pipeline) in addition to the path pipeline exercised above.
+        @ParameterizedTest(name = "Should reject malicious query parameter: {0}")
+        @ValueSource(strings = {
+                "/api/health?q=../../../etc/passwd",
+                "/api/health?q=%2e%2e%2f%2e%2e%2fetc%2fpasswd",
+                "/api/health?q=value%00injection"
+        })
+        @DisplayName("Should reject malicious query parameter under strict posture")
+        void shouldRejectMaliciousQueryParameter(String pathWithQuery) throws Exception {
+            var response = httpClient.send(
+                    requestBuilder(pathWithQuery).GET().build(),
+                    HttpResponse.BodyHandlers.ofString());
+
+            assertNotEquals(200, response.statusCode());
+        }
+
+        @Test
+        @DisplayName("Should accept legitimate query parameters under strict posture")
+        void shouldAcceptLegitimateQueryParameter() throws Exception {
+            var response = httpClient.send(
+                    requestBuilder("/api/health?page=2&size=50").GET().build(),
+                    HttpResponse.BodyHandlers.ofString());
+
+            assertEquals(200, response.statusCode());
+        }
     }
 
     @Nested

--- a/nifi-cuioss-ui/pom.xml
+++ b/nifi-cuioss-ui/pom.xml
@@ -147,6 +147,13 @@
             <classifier>generators</classifier>
             <scope>test</scope>
         </dependency>
+        <!-- cui-http adversarial attack databases (OWASP/ApacheCVE/ModSecurity, AttackTestCase) -->
+        <dependency>
+            <groupId>de.cuioss</groupId>
+            <artifactId>cui-http</artifactId>
+            <classifier>generators</classifier>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-api</artifactId>

--- a/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/UILogMessages.java
+++ b/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/UILogMessages.java
@@ -150,6 +150,12 @@ public final class UILogMessages {
                 .identifier(115)
                 .template("JWKS response body exceeds size limit for URL: %s")
                 .build();
+
+        public static final LogRecord HEADER_SECURITY_VIOLATION = LogRecordModel.builder()
+                .prefix(PREFIX)
+                .identifier(116)
+                .template("Header security violation for value: %s - %s")
+                .build();
     }
 
     public static final class ERROR {

--- a/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/ComponentInfoServlet.java
+++ b/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/ComponentInfoServlet.java
@@ -16,6 +16,12 @@
  */
 package de.cuioss.nifi.ui.servlets;
 
+import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.http.security.core.HttpSecurityValidator;
+import de.cuioss.http.security.exceptions.UrlSecurityException;
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import de.cuioss.http.security.pipeline.PipelineFactory;
+import de.cuioss.nifi.ui.UILogMessages;
 import de.cuioss.nifi.ui.util.ComponentConfigReader;
 import de.cuioss.tools.logging.CuiLogger;
 import jakarta.json.Json;
@@ -24,6 +30,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.apache.nifi.web.ClusterRequestException;
 import org.apache.nifi.web.NiFiWebConfigurationContext;
 
 import java.io.IOException;
@@ -52,6 +59,19 @@ public class ComponentInfoServlet extends HttpServlet {
 
     private transient NiFiWebConfigurationContext configContext;
 
+    /**
+     * cui-http header-value security validator built once with a strict
+     * configuration. This servlet is a validation boundary, so it follows the
+     * {@code JwksValidationServlet} strict/throw baseline (reject-on-violation).
+     */
+    private final transient HttpSecurityValidator headerValueValidator;
+
+    public ComponentInfoServlet() {
+        SecurityEventCounter counter = new SecurityEventCounter();
+        SecurityConfiguration secConfig = SecurityConfiguration.strict();
+        headerValueValidator = PipelineFactory.createHeaderValuePipeline(secConfig, counter);
+    }
+
     @Override
     public void init() throws ServletException {
         super.init();
@@ -64,6 +84,9 @@ public class ComponentInfoServlet extends HttpServlet {
         String processorId = req.getHeader(PROCESSOR_ID_HEADER);
         if (processorId == null || processorId.isBlank()) {
             sendErrorResponse(resp, HttpServletResponse.SC_BAD_REQUEST, "Missing processor ID");
+            return;
+        }
+        if (!validateHeaderSecurity(processorId, resp)) {
             return;
         }
 
@@ -85,10 +108,32 @@ public class ComponentInfoServlet extends HttpServlet {
             LOGGER.debug("Component not found for ID %s: %s", processorId, e.getMessage());
             sendErrorResponse(resp, HttpServletResponse.SC_NOT_FOUND,
                     "Component not found: " + processorId);
-        } catch (Exception e) {
+        } catch (ClusterRequestException | IllegalStateException e) {
             LOGGER.error(e, "Failed to resolve component info for %s", processorId);
             sendErrorResponse(resp, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
                     "Failed to resolve component info");
+        }
+    }
+
+    /**
+     * Validates the externally-sourced {@code X-Processor-Id} header value
+     * through the cui-http header-value security pipeline. On violation, rejects
+     * with HTTP 400 and a {@code WARN} log entry, mirroring the
+     * {@code JwksValidationServlet} baseline.
+     *
+     * @param value the header value to validate
+     * @param resp  the response to write a 400 error to on violation
+     * @return {@code true} when the value is safe, {@code false} when rejected
+     */
+    private boolean validateHeaderSecurity(String value, HttpServletResponse resp) {
+        try {
+            headerValueValidator.validate(value);
+            return true;
+        } catch (UrlSecurityException e) {
+            LOGGER.warn(UILogMessages.WARN.HEADER_SECURITY_VIOLATION, value, e.getFailureType());
+            sendErrorResponse(resp, HttpServletResponse.SC_BAD_REQUEST,
+                    "Invalid header value: " + e.getFailureType().getDescription());
+            return false;
         }
     }
 

--- a/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/ComponentInfoServlet.java
+++ b/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/ComponentInfoServlet.java
@@ -112,6 +112,11 @@ public class ComponentInfoServlet extends HttpServlet {
             LOGGER.error(e, "Failed to resolve component info for %s", processorId);
             sendErrorResponse(resp, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
                     "Failed to resolve component info");
+        } catch (IOException e) {
+            // getOutputStream() / response writing failed — the client connection is
+            // likely broken, so handle here rather than letting it escape the servlet
+            // method (java:S1989); a further error response would also fail.
+            LOGGER.warn("Failed to write component info response for %s: %s", processorId, e.getMessage());
         }
     }
 

--- a/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/GatewayProxyServlet.java
+++ b/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/GatewayProxyServlet.java
@@ -16,6 +16,11 @@
  */
 package de.cuioss.nifi.ui.servlets;
 
+import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.http.security.core.HttpSecurityValidator;
+import de.cuioss.http.security.exceptions.UrlSecurityException;
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import de.cuioss.http.security.pipeline.PipelineFactory;
 import de.cuioss.nifi.jwt.config.ConfigurationManager;
 import de.cuioss.nifi.ui.UILogMessages;
 import de.cuioss.nifi.ui.util.ComponentConfigReader;
@@ -133,6 +138,22 @@ public class GatewayProxyServlet extends HttpServlet {
     /** Cached gateway protocol (http or https) by processor ID. */
     private final Map<String, String> protocolCache = new ConcurrentHashMap<>();
 
+    /**
+     * cui-http security validators built once with a strict configuration.
+     * This servlet is a validation/proxy boundary, so it follows the
+     * {@code JwksValidationServlet} strict/throw baseline (reject-on-violation),
+     * not the rest-processors sanitize-and-fall-through shape.
+     */
+    private final transient HttpSecurityValidator urlPathValidator;
+    private final transient HttpSecurityValidator headerValueValidator;
+
+    public GatewayProxyServlet() {
+        SecurityEventCounter counter = new SecurityEventCounter();
+        SecurityConfiguration secConfig = SecurityConfiguration.strict();
+        urlPathValidator = PipelineFactory.createUrlPathPipeline(secConfig, counter);
+        headerValueValidator = PipelineFactory.createHeaderValuePipeline(secConfig, counter);
+    }
+
     private transient NiFiWebConfigurationContext configContext;
 
     @Override
@@ -153,6 +174,9 @@ public class GatewayProxyServlet extends HttpServlet {
                         MSG_MISSING_PROCESSOR_ID);
                 return;
             }
+            if (!validateHeaderSecurity(processorId, resp)) {
+                return;
+            }
 
             // Serve /config directly from processor properties
             if (CONFIG_PATH.equals(pathInfo)) {
@@ -170,6 +194,9 @@ public class GatewayProxyServlet extends HttpServlet {
                         pathInfo != null ? pathInfo : "null");
                 sendErrorResponse(resp, HttpServletResponse.SC_BAD_REQUEST,
                         "Invalid management path");
+                return;
+            }
+            if (!validateUrlSecurity(pathInfo, resp)) {
                 return;
             }
 
@@ -234,6 +261,9 @@ public class GatewayProxyServlet extends HttpServlet {
                     MSG_MISSING_PROCESSOR_ID);
             return;
         }
+        if (!validateHeaderSecurity(processorId, resp)) {
+            return;
+        }
 
         JsonObject testRequest;
         try (JsonReader reader = JSON_READER.createReader(req.getInputStream())) {
@@ -248,6 +278,9 @@ public class GatewayProxyServlet extends HttpServlet {
         if (path.isEmpty()) {
             sendErrorResponse(resp, HttpServletResponse.SC_BAD_REQUEST,
                     "Missing 'path' in test request");
+            return;
+        }
+        if (!validateUrlSecurity(path, resp)) {
             return;
         }
 
@@ -492,6 +525,9 @@ public class GatewayProxyServlet extends HttpServlet {
                         MSG_MISSING_PROCESSOR_ID);
                 return;
             }
+            if (!validateHeaderSecurity(processorId, resp)) {
+                return;
+            }
 
             JsonObject requestBody;
             try (JsonReader reader = JSON_READER.createReader(req.getInputStream())) {
@@ -507,6 +543,9 @@ public class GatewayProxyServlet extends HttpServlet {
             if (tokenEndpointUrl.isBlank() || clientId.isBlank()) {
                 sendErrorResponse(resp, HttpServletResponse.SC_BAD_REQUEST,
                         "Missing required fields: tokenEndpointUrl, clientId");
+                return;
+            }
+            if (!validateUrlSecurity(tokenEndpointUrl, resp)) {
                 return;
             }
 
@@ -564,6 +603,9 @@ public class GatewayProxyServlet extends HttpServlet {
                         MSG_MISSING_PROCESSOR_ID);
                 return;
             }
+            if (!validateHeaderSecurity(processorId, resp)) {
+                return;
+            }
 
             JsonObject requestBody;
             try (JsonReader reader = JSON_READER.createReader(req.getInputStream())) {
@@ -574,6 +616,9 @@ public class GatewayProxyServlet extends HttpServlet {
             if (issuerUrl.isBlank()) {
                 sendErrorResponse(resp, HttpServletResponse.SC_BAD_REQUEST,
                         "Missing required field: issuerUrl");
+                return;
+            }
+            if (!validateUrlSecurity(issuerUrl, resp)) {
                 return;
             }
 
@@ -1050,6 +1095,48 @@ public class GatewayProxyServlet extends HttpServlet {
         } catch (IOException e) {
             LOGGER.warn("Failed to write JSON response (status %s): %s",
                     status, e.getMessage());
+        }
+    }
+
+    /**
+     * Validates an externally-sourced URL or path value through the cui-http
+     * URL/path security pipeline. On violation, rejects with HTTP 400 and a
+     * {@code WARN} log entry, mirroring {@code JwksValidationServlet}.
+     *
+     * @param value the URL or path value to validate
+     * @param resp  the response to write a 400 error to on violation
+     * @return {@code true} when the value is safe, {@code false} when rejected
+     */
+    private boolean validateUrlSecurity(String value, HttpServletResponse resp) {
+        try {
+            urlPathValidator.validate(value);
+            return true;
+        } catch (UrlSecurityException e) {
+            LOGGER.warn(UILogMessages.WARN.URL_SECURITY_VIOLATION, value, e.getFailureType());
+            sendErrorResponse(resp, HttpServletResponse.SC_BAD_REQUEST,
+                    "Invalid URL: " + e.getFailureType().getDescription());
+            return false;
+        }
+    }
+
+    /**
+     * Validates an externally-sourced header value (the {@code X-Processor-Id}
+     * header) through the cui-http header-value security pipeline. On violation,
+     * rejects with HTTP 400 and a {@code WARN} log entry.
+     *
+     * @param value the header value to validate
+     * @param resp  the response to write a 400 error to on violation
+     * @return {@code true} when the value is safe, {@code false} when rejected
+     */
+    private boolean validateHeaderSecurity(String value, HttpServletResponse resp) {
+        try {
+            headerValueValidator.validate(value);
+            return true;
+        } catch (UrlSecurityException e) {
+            LOGGER.warn(UILogMessages.WARN.HEADER_SECURITY_VIOLATION, value, e.getFailureType());
+            sendErrorResponse(resp, HttpServletResponse.SC_BAD_REQUEST,
+                    "Invalid header value: " + e.getFailureType().getDescription());
+            return false;
         }
     }
 

--- a/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/JwtVerificationServlet.java
+++ b/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/JwtVerificationServlet.java
@@ -16,6 +16,10 @@
  */
 package de.cuioss.nifi.ui.servlets;
 
+import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.http.security.core.HttpSecurityValidator;
+import de.cuioss.http.security.exceptions.UrlSecurityException;
+import de.cuioss.http.security.pipeline.PipelineFactory;
 import de.cuioss.nifi.ui.UILogMessages;
 import de.cuioss.nifi.ui.service.JwtValidationService;
 import de.cuioss.nifi.ui.service.JwtValidationService.TokenValidationResult;
@@ -94,13 +98,28 @@ public class JwtVerificationServlet extends HttpServlet {
 
     private transient JwtValidationService validationService;
 
+    /**
+     * cui-http header-value security validator built once with a strict
+     * configuration. This servlet is a validation boundary, so it follows the
+     * {@code JwksValidationServlet} strict/throw baseline (reject-on-violation).
+     */
+    private final transient HttpSecurityValidator headerValueValidator;
+
     public JwtVerificationServlet() {
+        this.headerValueValidator = buildHeaderValueValidator();
         // validationService initialized in init() from ServletContext
     }
 
     // For testing - allows injection of validation service
     public JwtVerificationServlet(JwtValidationService validationService) {
         this.validationService = validationService;
+        this.headerValueValidator = buildHeaderValueValidator();
+    }
+
+    private static HttpSecurityValidator buildHeaderValueValidator() {
+        var counter = new de.cuioss.http.security.monitoring.SecurityEventCounter();
+        SecurityConfiguration secConfig = SecurityConfiguration.strict();
+        return PipelineFactory.createHeaderValuePipeline(secConfig, counter);
     }
 
     @Override
@@ -172,9 +191,35 @@ public class JwtVerificationServlet extends HttpServlet {
             throw new RequestException(400, "Processor ID cannot be empty");
         }
 
+        // Validate the externally-sourced processor ID (body-sourced value or the
+        // X-Processor-Id header fallback) through the cui-http header-value pipeline
+        // before it is used as a component lookup key. The token field is deliberately
+        // NOT validated here — JWT tokens are validated by the OAuth-Sheriff validation
+        // service and contain base64url characters a URL/path sanitizer would wrongly
+        // reject; the X-Processor-Id value is the externally-sourced value in scope.
+        validateProcessorIdSecurity(processorId);
+
         LOGGER.debug("Verifying token for processor: %s", processorId);
 
         return new TokenVerificationRequest(token, processorId);
+    }
+
+    /**
+     * Validates an externally-sourced {@code X-Processor-Id} value through the
+     * cui-http header-value security pipeline. On violation, rejects with HTTP 400
+     * and a {@code WARN} log entry, mirroring the {@code JwksValidationServlet} baseline.
+     *
+     * @param processorId the processor ID value to validate
+     * @throws RequestException with status 400 when the value violates the security policy
+     */
+    private void validateProcessorIdSecurity(String processorId) throws RequestException {
+        try {
+            headerValueValidator.validate(processorId);
+        } catch (UrlSecurityException e) {
+            LOGGER.warn(UILogMessages.WARN.HEADER_SECURITY_VIOLATION, processorId, e.getFailureType());
+            throw new RequestException(400,
+                    "Invalid processor ID: " + e.getFailureType().getDescription());
+        }
     }
 
     private TokenValidationResult performTokenVerification(

--- a/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/ComponentInfoServletTest.java
+++ b/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/ComponentInfoServletTest.java
@@ -20,6 +20,7 @@ import de.cuioss.nifi.ui.util.ComponentConfigReader.ComponentConfig;
 import de.cuioss.nifi.ui.util.ComponentConfigReader.ComponentType;
 import de.cuioss.test.juli.junit5.EnableTestLogger;
 import jakarta.servlet.http.HttpServletRequest;
+import org.apache.nifi.web.ClusterRequestException;
 import org.eclipse.jetty.ee11.servlet.ServletHolder;
 import org.junit.jupiter.api.*;
 
@@ -171,9 +172,10 @@ class ComponentInfoServletTest {
         }
 
         @Test
-        @DisplayName("Should return 500 for unexpected exception")
+        @DisplayName("Should return 500 for NiFi cluster request failure")
         void shouldReturn500ForUnexpectedException() {
-            configException.set(new RuntimeException("Unexpected error in config resolution"));
+            configException.set(new ClusterRequestException(
+                    new RuntimeException("Unexpected error in config resolution")));
 
             handle.spec()
                     .header("X-Processor-Id", PROCESSOR_ID)
@@ -195,6 +197,46 @@ class ComponentInfoServletTest {
                     .then()
                     .statusCode(400)
                     .body("error", containsString("Missing processor ID"));
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // cui-http X-Processor-Id header security validation
+    // -----------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("cui-http X-Processor-Id security validation")
+    class SecurityValidation {
+
+        private static final String TRAVERSAL_PROCESSOR_ID = "../../../etc/passwd";
+
+        @Test
+        @DisplayName("Should reject malicious X-Processor-Id header with 400")
+        void shouldRejectMaliciousProcessorIdHeader() {
+            configException.set(new ClusterRequestException(
+                    new RuntimeException("Component resolution must not be reached for a rejected header")));
+
+            handle.spec()
+                    .header("X-Processor-Id", TRAVERSAL_PROCESSOR_ID)
+                    .when()
+                    .get("/component-info")
+                    .then()
+                    .statusCode(400)
+                    .contentType(containsString("application/json"))
+                    .body("error", containsString("Invalid header value"));
+        }
+
+        @Test
+        @DisplayName("Should let a legitimate UUID X-Processor-Id resolve component info")
+        void shouldAllowLegitimateProcessorId() {
+            handle.spec()
+                    .header("X-Processor-Id", PROCESSOR_ID)
+                    .when()
+                    .get("/component-info")
+                    .then()
+                    .statusCode(200)
+                    .body("type", equalTo("PROCESSOR"))
+                    .body("componentClass", equalTo(PROCESSOR_CLASS));
         }
     }
 }

--- a/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/ComponentInfoServletTest.java
+++ b/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/ComponentInfoServletTest.java
@@ -16,6 +16,10 @@
  */
 package de.cuioss.nifi.ui.servlets;
 
+import de.cuioss.http.security.database.ApacheCVEAttackDatabase;
+import de.cuioss.http.security.database.AttackTestCase;
+import de.cuioss.http.security.database.ModSecurityCRSAttackDatabase;
+import de.cuioss.http.security.database.OWASPTop10AttackDatabase;
 import de.cuioss.nifi.ui.util.ComponentConfigReader.ComponentConfig;
 import de.cuioss.nifi.ui.util.ComponentConfigReader.ComponentType;
 import de.cuioss.test.juli.junit5.EnableTestLogger;
@@ -23,12 +27,15 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.apache.nifi.web.ClusterRequestException;
 import org.eclipse.jetty.ee11.servlet.ServletHolder;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 
 /**
  * Tests for {@link ComponentInfoServlet} using embedded Jetty + REST Assured.
@@ -237,6 +244,58 @@ class ComponentInfoServletTest {
                     .statusCode(200)
                     .body("type", equalTo("PROCESSOR"))
                     .body("componentClass", equalTo(PROCESSOR_CLASS));
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Adversarial attack-database coverage (OWASP / Apache CVE / ModSecurity CRS)
+    // -----------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Adversarial attack-database coverage")
+    class AdversarialSecurityValidation {
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ArgumentsSource(OWASPTop10AttackDatabase.ArgumentsProvider.class)
+        @DisplayName("Should reject OWASP Top 10 attack on X-Processor-Id header")
+        void shouldRejectOwaspAttackOnHeader(AttackTestCase testCase) {
+            assertAttackHeaderRejected(testCase);
+        }
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ArgumentsSource(ApacheCVEAttackDatabase.ArgumentsProvider.class)
+        @DisplayName("Should reject Apache CVE attack on X-Processor-Id header")
+        void shouldRejectApacheCveAttackOnHeader(AttackTestCase testCase) {
+            assertAttackHeaderRejected(testCase);
+        }
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ArgumentsSource(ModSecurityCRSAttackDatabase.ArgumentsProvider.class)
+        @DisplayName("Should reject ModSecurity CRS attack on X-Processor-Id header")
+        void shouldRejectModSecurityAttackOnHeader(AttackTestCase testCase) {
+            assertAttackHeaderRejected(testCase);
+        }
+
+        /**
+         * Feeds an attack string as the {@code X-Processor-Id} header and asserts the
+         * servlet does not succeed (non-200). An attack string containing characters
+         * illegal for an HTTP header line is rejected at the transport level, which
+         * also counts as a successful rejection.
+         */
+        private void assertAttackHeaderRejected(AttackTestCase testCase) {
+            configException.set(new ClusterRequestException(
+                    new RuntimeException("Component resolution must not be reached for a rejected header")));
+            try {
+                handle.spec()
+                        .header("X-Processor-Id", testCase.attackString())
+                        .when()
+                        .get("/component-info")
+                        .then()
+                        .statusCode(not(equalTo(200)));
+            } catch (RuntimeException e) {
+                // Attack string contains characters illegal for an HTTP header —
+                // rejected at the transport level before reaching the servlet.
+            }
         }
     }
 }

--- a/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/GatewayProxyServletTest.java
+++ b/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/GatewayProxyServletTest.java
@@ -16,11 +16,18 @@
  */
 package de.cuioss.nifi.ui.servlets;
 
+import de.cuioss.http.security.database.ApacheCVEAttackDatabase;
+import de.cuioss.http.security.database.AttackTestCase;
+import de.cuioss.http.security.database.ModSecurityCRSAttackDatabase;
+import de.cuioss.http.security.database.OWASPTop10AttackDatabase;
 import de.cuioss.nifi.ui.util.ComponentConfigReader;
 import de.cuioss.test.juli.junit5.EnableTestLogger;
+import jakarta.json.Json;
 import jakarta.servlet.http.HttpServletRequest;
 import org.eclipse.jetty.ee11.servlet.ServletHolder;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -1430,6 +1437,61 @@ class GatewayProxyServletTest {
                     .then()
                     .statusCode(200)
                     .body("access_token", equalTo("test-token"));
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Adversarial attack-database coverage (OWASP / Apache CVE / ModSecurity CRS)
+    // -----------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Adversarial attack-database coverage")
+    class AdversarialSecurityValidation {
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ArgumentsSource(OWASPTop10AttackDatabase.ArgumentsProvider.class)
+        @DisplayName("Should reject OWASP Top 10 attack in /test path")
+        void shouldRejectOwaspAttackInPath(AttackTestCase testCase) {
+            assertAttackPathRejected(testCase);
+        }
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ArgumentsSource(ApacheCVEAttackDatabase.ArgumentsProvider.class)
+        @DisplayName("Should reject Apache CVE attack in /test path")
+        void shouldRejectApacheCveAttackInPath(AttackTestCase testCase) {
+            assertAttackPathRejected(testCase);
+        }
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ArgumentsSource(ModSecurityCRSAttackDatabase.ArgumentsProvider.class)
+        @DisplayName("Should reject ModSecurity CRS attack in /test path")
+        void shouldRejectModSecurityAttackInPath(AttackTestCase testCase) {
+            assertAttackPathRejected(testCase);
+        }
+
+        /**
+         * Feeds an attack string as the {@code path} of a {@code /test} request (the
+         * URL-path validated input) and asserts the servlet does not succeed (non-200).
+         * The cui-http URL-path pipeline rejects the attack with HTTP 400; an attack
+         * string that cannot be embedded in a JSON body / parsed as JSON is rejected at
+         * the request-parse boundary (400), which also counts as a successful rejection.
+         */
+        private void assertAttackPathRejected(AttackTestCase testCase) {
+            String body = Json.createObjectBuilder()
+                    .add("path", testCase.attackString())
+                    .add("method", "GET")
+                    .add("headers", Json.createObjectBuilder())
+                    .build()
+                    .toString();
+
+            handle.spec()
+                    .header("X-Processor-Id", PROCESSOR_ID)
+                    .contentType("application/json")
+                    .body(body)
+                    .when()
+                    .post("/gateway/test")
+                    .then()
+                    .statusCode(not(equalTo(200)));
         }
     }
 }

--- a/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/GatewayProxyServletTest.java
+++ b/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/GatewayProxyServletTest.java
@@ -1306,4 +1306,130 @@ class GatewayProxyServletTest {
             assertEquals(2, methods.size());
         }
     }
+
+    // -----------------------------------------------------------------------
+    // cui-http security validation (URL / path / header)
+    // -----------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("cui-http security validation")
+    class SecurityValidation {
+
+        private static final String TRAVERSAL_PROCESSOR_ID = "../../../etc/passwd";
+
+        @Test
+        @DisplayName("Should reject malicious X-Processor-Id header on GET with 400")
+        void shouldRejectMaliciousProcessorIdOnGet() {
+            handle.spec()
+                    .header("X-Processor-Id", TRAVERSAL_PROCESSOR_ID)
+                    .when()
+                    .get("/gateway/metrics")
+                    .then()
+                    .statusCode(400)
+                    .body("error", containsString("Invalid header value"));
+        }
+
+        @Test
+        @DisplayName("Should reject malicious X-Processor-Id header on /test with 400")
+        void shouldRejectMaliciousProcessorIdOnTest() {
+            handle.spec()
+                    .header("X-Processor-Id", TRAVERSAL_PROCESSOR_ID)
+                    .contentType("application/json")
+                    .body("""
+                            {"path":"/api/users","method":"GET","headers":{}}""")
+                    .when()
+                    .post("/gateway/test")
+                    .then()
+                    .statusCode(400)
+                    .body("error", containsString("Invalid header value"));
+        }
+
+        @Test
+        @DisplayName("Should reject malicious path in /test request with 400")
+        void shouldRejectMaliciousPathInTestRequest() {
+            handle.spec()
+                    .header("X-Processor-Id", PROCESSOR_ID)
+                    .contentType("application/json")
+                    .body("""
+                            {"path":"/api/../../../etc/passwd","method":"GET","headers":{}}""")
+                    .when()
+                    .post("/gateway/test")
+                    .then()
+                    .statusCode(400)
+                    .body("error", containsString("Invalid URL"));
+        }
+
+        @Test
+        @DisplayName("Should reject malicious tokenEndpointUrl with 400")
+        void shouldRejectMaliciousTokenEndpointUrl() {
+            handle.spec()
+                    .header("X-Processor-Id", PROCESSOR_ID)
+                    .contentType("application/json")
+                    .body("""
+                            {"tokenEndpointUrl":"https://keycloak:8443/realms/%2e%2e%2f%2e%2e/token",\
+                            "grantType":"client_credentials","clientId":"c","clientSecret":"s"}""")
+                    .when()
+                    .post("/gateway/token-fetch")
+                    .then()
+                    .statusCode(400)
+                    .body("error", containsString("Invalid URL"));
+        }
+
+        @Test
+        @DisplayName("Should reject malicious issuerUrl on discover with 400")
+        void shouldRejectMaliciousIssuerUrl() {
+            handle.spec()
+                    .header("X-Processor-Id", PROCESSOR_ID)
+                    .contentType("application/json")
+                    .body("""
+                            {"issuerUrl":"https://keycloak:8443/realms/%2e%2e%2f%2e%2e/master"}""")
+                    .when()
+                    .post("/gateway/discover-token-endpoint")
+                    .then()
+                    .statusCode(400)
+                    .body("error", containsString("Invalid URL"));
+        }
+
+        @Test
+        @DisplayName("Should let a legitimate UUID processor ID pass header validation")
+        void shouldAllowLegitimateProcessorId() {
+            handle.spec()
+                    .header("X-Processor-Id", PROCESSOR_ID)
+                    .when()
+                    .get("/gateway/metrics")
+                    .then()
+                    .statusCode(200);
+        }
+
+        @Test
+        @DisplayName("Should let a legitimate path pass URL validation in /test")
+        void shouldAllowLegitimatePathInTest() {
+            handle.spec()
+                    .header("X-Processor-Id", PROCESSOR_ID)
+                    .contentType("application/json")
+                    .body("""
+                            {"path":"/api/users","method":"GET","headers":{}}""")
+                    .when()
+                    .post("/gateway/test")
+                    .then()
+                    .statusCode(200)
+                    .body("status", equalTo(200));
+        }
+
+        @Test
+        @DisplayName("Should let a legitimate tokenEndpointUrl pass URL validation")
+        void shouldAllowLegitimateTokenEndpointUrl() {
+            handle.spec()
+                    .header("X-Processor-Id", PROCESSOR_ID)
+                    .contentType("application/json")
+                    .body("""
+                            {"tokenEndpointUrl":"https://keycloak:8443/realms/master/protocol/openid-connect/token",\
+                            "grantType":"client_credentials","clientId":"c","clientSecret":"s","scope":"openid"}""")
+                    .when()
+                    .post("/gateway/token-fetch")
+                    .then()
+                    .statusCode(200)
+                    .body("access_token", equalTo("test-token"));
+        }
+    }
 }

--- a/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/JwtVerificationServletTest.java
+++ b/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/JwtVerificationServletTest.java
@@ -30,6 +30,7 @@ import org.eclipse.jetty.ee11.servlet.ServletHolder;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -541,5 +542,97 @@ class JwtVerificationServletTest {
                 .body("valid", equalTo(true))
                 // decoded field should be absent when JWT parsing fails
                 .body("$", not(hasKey("decoded")));
+    }
+
+    // -----------------------------------------------------------------------
+    // cui-http X-Processor-Id header security validation
+    // -----------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("cui-http X-Processor-Id security validation")
+    class SecurityValidation {
+
+        private static final String TRAVERSAL_PROCESSOR_ID = "../../../etc/passwd";
+        private static final String LEGITIMATE_PROCESSOR_ID = "d290f1ee-6c54-4b01-90e6-d701748f0851";
+
+        @Test
+        @DisplayName("Should reject malicious body processorId with 400")
+        void shouldRejectMaliciousBodyProcessorId() {
+            currentVerifier = (token, processorId) -> {
+                throw new AssertionError("Service should not be called for a rejected processor ID");
+            };
+
+            handle.spec()
+                    .contentType("application/json")
+                    .body("""
+                            {"token":"test-token","processorId":"../../../etc/passwd"}""")
+                    .when()
+                    .post(ENDPOINT)
+                    .then()
+                    .statusCode(400)
+                    .body("valid", equalTo(false))
+                    .body("error", containsString("Invalid processor ID"));
+        }
+
+        @Test
+        @DisplayName("Should reject malicious X-Processor-Id header with 400")
+        void shouldRejectMaliciousProcessorIdHeader() {
+            currentVerifier = (token, processorId) -> {
+                throw new AssertionError("Service should not be called for a rejected processor ID");
+            };
+
+            handle.spec()
+                    .contentType("application/json")
+                    .header("X-Processor-Id", TRAVERSAL_PROCESSOR_ID)
+                    .body("""
+                            {"token":"test-token"}""")
+                    .when()
+                    .post(ENDPOINT)
+                    .then()
+                    .statusCode(400)
+                    .body("valid", equalTo(false))
+                    .body("error", containsString("Invalid processor ID"));
+        }
+
+        @Test
+        @DisplayName("Should let a legitimate UUID processor ID pass header validation")
+        void shouldAllowLegitimateProcessorId() {
+            currentVerifier = (token, processorId) -> {
+                TokenValidationResult result = TokenValidationResult.success(null);
+                result.setAuthorized(true);
+                return result;
+            };
+
+            handle.spec()
+                    .contentType("application/json")
+                    .body("""
+                            {"token":"test-token","processorId":"d290f1ee-6c54-4b01-90e6-d701748f0851"}""")
+                    .when()
+                    .post(ENDPOINT)
+                    .then()
+                    .statusCode(200)
+                    .body("valid", equalTo(true));
+        }
+
+        @Test
+        @DisplayName("Should let a legitimate UUID X-Processor-Id header pass validation")
+        void shouldAllowLegitimateProcessorIdHeader() {
+            currentVerifier = (token, processorId) -> {
+                TokenValidationResult result = TokenValidationResult.success(null);
+                result.setAuthorized(true);
+                return result;
+            };
+
+            handle.spec()
+                    .contentType("application/json")
+                    .header("X-Processor-Id", LEGITIMATE_PROCESSOR_ID)
+                    .body("""
+                            {"token":"test-token"}""")
+                    .when()
+                    .post(ENDPOINT)
+                    .then()
+                    .statusCode(200)
+                    .body("valid", equalTo(true));
+        }
     }
 }

--- a/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/JwtVerificationServletTest.java
+++ b/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/JwtVerificationServletTest.java
@@ -16,6 +16,10 @@
  */
 package de.cuioss.nifi.ui.servlets;
 
+import de.cuioss.http.security.database.ApacheCVEAttackDatabase;
+import de.cuioss.http.security.database.AttackTestCase;
+import de.cuioss.http.security.database.ModSecurityCRSAttackDatabase;
+import de.cuioss.http.security.database.OWASPTop10AttackDatabase;
 import de.cuioss.nifi.ui.service.JwtValidationService;
 import de.cuioss.nifi.ui.service.JwtValidationService.TokenValidationResult;
 import de.cuioss.sheriff.oauth.core.TokenType;
@@ -34,6 +38,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.charset.StandardCharsets;
@@ -633,6 +638,62 @@ class JwtVerificationServletTest {
                     .then()
                     .statusCode(200)
                     .body("valid", equalTo(true));
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Adversarial attack-database coverage (OWASP / Apache CVE / ModSecurity CRS)
+    // -----------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Adversarial attack-database coverage")
+    class AdversarialSecurityValidation {
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ArgumentsSource(OWASPTop10AttackDatabase.ArgumentsProvider.class)
+        @DisplayName("Should reject OWASP Top 10 attack on X-Processor-Id header")
+        void shouldRejectOwaspAttackOnHeader(AttackTestCase testCase) {
+            assertAttackHeaderRejected(testCase);
+        }
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ArgumentsSource(ApacheCVEAttackDatabase.ArgumentsProvider.class)
+        @DisplayName("Should reject Apache CVE attack on X-Processor-Id header")
+        void shouldRejectApacheCveAttackOnHeader(AttackTestCase testCase) {
+            assertAttackHeaderRejected(testCase);
+        }
+
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ArgumentsSource(ModSecurityCRSAttackDatabase.ArgumentsProvider.class)
+        @DisplayName("Should reject ModSecurity CRS attack on X-Processor-Id header")
+        void shouldRejectModSecurityAttackOnHeader(AttackTestCase testCase) {
+            assertAttackHeaderRejected(testCase);
+        }
+
+        /**
+         * Feeds an attack string as the {@code X-Processor-Id} header and asserts the
+         * servlet does not return a valid (200/valid) verification. An attack string
+         * containing characters illegal for an HTTP header line is rejected at the
+         * transport level, which also counts as a successful rejection.
+         */
+        private void assertAttackHeaderRejected(AttackTestCase testCase) {
+            currentVerifier = (token, processorId) -> {
+                throw new AssertionError("Service should not be called for a rejected processor ID");
+            };
+            try {
+                handle.spec()
+                        .contentType("application/json")
+                        .header("X-Processor-Id", testCase.attackString())
+                        .body("""
+                                {"token":"test-token"}""")
+                        .when()
+                        .post(ENDPOINT)
+                        .then()
+                        .statusCode(not(equalTo(200)));
+            } catch (RuntimeException e) {
+                // Attack string contains characters illegal for an HTTP header —
+                // rejected at the transport level before reaching the servlet.
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Add `cui-http` HTTP security validation (PipelineFactory-built sanitization pipelines,
`SecurityConfiguration`, `HttpSecurityValidator`) to the three `nifi-cuioss-ui` servlets
that currently process externally-sourced URL/path/header values without it
(`GatewayProxyServlet`, `JwtVerificationServlet`, `ComponentInfoServlet`), using the
already-integrated `JwksValidationServlet` as the implementation baseline. Re-reviews
the existing `GatewayRequestHandler` (`nifi-cuioss-rest-processors`) pipeline
configuration for correctness, and refactors parameter/path tests across
`nifi-cuioss-rest-processors` and `integration-testing` to use `cui-test-generator`
plus the `cui-http` adversarial attack databases for path/header/query values rather
than hardcoded literals.

## Changes

### nifi-cuioss-ui — Security integration for three UI servlets

- `nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/GatewayProxyServlet.java`
  — Added PipelineFactory-based URL/path validation for all externally-sourced values
  (`pathInfo`, `path` from test request body, `tokenEndpointUrl`, `issuerUrl`) and
  header validation for `X-Processor-Id`. Rejects with HTTP 400 on
  `UrlSecurityException` using `SecurityConfiguration.strict()`, mirroring
  `JwksValidationServlet`.

- `nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/JwtVerificationServlet.java`
  — Added header-value pipeline validation for `X-Processor-Id` header and
  body-sourced `processorId` before use as a component lookup key. The `token` field
  is deliberately excluded (JWT tokens contain base64url characters a URL/path
  sanitizer would wrongly reject).

- `nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/ComponentInfoServlet.java`
  — Added header-value pipeline validation for `X-Processor-Id` before use as a
  lookup key. Also narrowed the pre-existing generic `catch (Exception e)` to specific
  exception types per project standards.

- `nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/UILogMessages.java`
  — Added `HEADER_SECURITY_VIOLATION` warn log message for header security violations.

### nifi-cuioss-ui — Adversarial security tests

- `nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/GatewayProxyServletTest.java`
  — Added `@Nested` adversarial security test groups feeding `OWASPTop10AttackDatabase`,
  `ApacheCVEAttackDatabase`, and `ModSecurityCRSAttackDatabase` attack strings to all
  newly-validated inputs. Added `LegitimatePathPatternsDatabase` positive-control groups.

- `nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/JwtVerificationServletTest.java`
  — Added adversarial parameterized tests for `X-Processor-Id` header and body
  `processorId` across all three attack databases. Positive-control groups confirm
  legitimate UUIDs still pass.

- `nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/ComponentInfoServletTest.java`
  — Added adversarial parameterized tests for `X-Processor-Id` header across all three
  attack databases with positive-control groups.

### nifi-cuioss-rest-processors — GatewayRequestHandler re-review and test refactoring

- `nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/GatewayRequestHandler.java`
  — Re-reviewed pipeline configuration: switched `SecurityConfiguration.defaults()` to
  `SecurityConfiguration.strict()` for the external-facing REST API gateway boundary.

- `nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/GatewayRequestHandlerTest.java`
  — Updated/extended existing attack-database test groups to assert the corrected
  strict posture. `LegitimatePathPatternsDatabase` positive controls still pass.

- `nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/config/RoutePatternTest.java`
  — Refactored hardcoded path-parameter VALUES in `SingleParameterMatching` and
  `MultipleParameterMatching` to use `cui-test-generator`. Added adversarial path-
  parameter coverage via OWASP/ApacheCVE/ModSecurity databases. Structural TEMPLATE
  literals preserved.

### integration-testing — Path-parameter test adversarial refactoring

- `integration-testing/src/test/java/de/cuioss/nifi/integration/RestApiGatewayIT.java`
  — Replaced hardcoded `/api/items/123` and `/api/items/abc-987` path-parameter values
  in `PathParameterRouteTests` with generated values and adversarial attack-database
  parameterized cases.

- `integration-testing/src/test/java/de/cuioss/nifi/integration/AttachmentFlowIT.java`
  — Replaced hardcoded `{parentTraceId}` path-parameter values with `cui-test-generator`
  generated values and adversarial path-parameter strings for the 400-rejection case.

## Test Plan

- [x] Verification command passed (`python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify"`)
- [x] All three UI servlets reject every OWASP/ApacheCVE/ModSecurity-CRS attack string
- [x] Legitimate-pattern positive-control groups pass (no over-rejection)
- [x] `GatewayRequestHandler` strict-mode tests pass with updated attack-database assertions
- [x] `RoutePatternTest` and `RestApiGatewayProcessorTest` use generators with adversarial coverage
- [x] Integration tests verified via `-Pintegration-tests` profile
