### PR TITLE
chore(config): migrate marshal.json to id-keyed step map

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -38,12 +38,12 @@
         "default:verify:module-tests"
       ],
       "per_task_budget_reserve_tokens": "50K",
-      "verification_steps": [
-        "default:verify:quality-gate",
-        "default:verify:module-tests",
-        "default:verify:integration-tests",
-        "default:verify:e2e"
-      ],
+      "verification_steps": {
+        "default:verify:quality-gate": {},
+        "default:verify:module-tests": {},
+        "default:verify:integration-tests": {},
+        "default:verify:e2e": {}
+      },
       "effort": {
         "default": "level-4",
         "verification-feedback": "level-3"
@@ -51,32 +51,34 @@
     },
     "phase-6-finalize": {
       "max_iterations": 3,
-      "review_bot_buffer_seconds": 180,
-      "pr_merge_strategy": "squash",
       "finalize_without_asking": true,
       "loop_back_without_asking": false,
-      "final_merge_without_asking": false,
       "self_review": "auto",
       "qgate": "auto",
       "simplify": "auto",
       "checks_wait_timeout_seconds": 600,
-      "auto_rebase_threshold": "no_overlap_only",
       "drop_review_on_scope_gate": false,
-      "steps": [
-        "default:pre-push-quality-gate",
-        "default:finalize-step-whole-tree-gate",
-        "default:commit-push",
-        "default:finalize-step-simplify",
-        "default:create-pr",
-        "default:ci-verify",
-        "default:automated-review",
-        "default:sonar-roundtrip",
-        "default:lessons-capture",
-        "default:branch-cleanup",
-        "default:record-metrics",
-        "default:finalize-step-print-phase-breakdown",
-        "default:archive-plan"
-      ],
+      "steps": {
+        "default:pre-push-quality-gate": {},
+        "default:finalize-step-whole-tree-gate": {},
+        "default:commit-push": {},
+        "default:finalize-step-simplify": {},
+        "default:create-pr": {},
+        "default:ci-verify": {},
+        "default:automated-review": {
+          "review_bot_buffer_seconds": 180
+        },
+        "default:sonar-roundtrip": {},
+        "default:lessons-capture": {},
+        "default:branch-cleanup": {
+          "pr_merge_strategy": "squash",
+          "final_merge_without_asking": false,
+          "auto_rebase_threshold": "no_overlap_only"
+        },
+        "default:record-metrics": {},
+        "default:finalize-step-print-phase-breakdown": {},
+        "default:archive-plan": {}
+      },
       "effort": {
         "default": "level-3",
         "verification-feedback": "level-3",


### PR DESCRIPTION
Migrate `.plan/marshal.json` to the id-keyed step-map config shape introduced by plan-marshall PR #716 (config-schema-step-nested-params).

## Changes
- `phase-5-execute.verification_steps`: array → id-keyed map (`{step_id: {}}`), order preserved.
- `phase-6-finalize.steps`: array → id-keyed map, with the formerly-flat step-owned params folded into their owning steps:
  - `review_bot_buffer_seconds` → `default:automated-review`
  - `pr_merge_strategy` / `final_merge_without_asking` / `auto_rebase_threshold` → `default:branch-cleanup`
- Phase-level knobs (`max_iterations`, ceremony gates, `effort`, `checks_wait_timeout_seconds`) stay flat siblings of `steps`.
- `per_deliverable_build` stays a list (unchanged by the schema migration).

Applied additively; no behavior change. JSON validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the configuration structure for the verification and finalization phases to use key-based step settings instead of list-based step identifiers.
  * Relocated specific step timing and merge/cleanup options under their corresponding step entries for clearer organization and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->