### PR TITLE
chore(config): remove dead execute_task_skills block from marshal.json

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -167,12 +167,7 @@
   "skill_domains": {
     "system": {
       "defaults": [],
-      "optionals": [],
-      "execute_task_skills": {
-        "documentation": "plan-marshall:execute-task",
-        "implementation": "plan-marshall:execute-task",
-        "module_testing": "plan-marshall:execute-task"
-      }
+      "optionals": []
     },
     "java": {
       "bundle": "pm-dev-java",


### PR DESCRIPTION
The `execute_task_skills` profile→skill map was removed from plan-marshall (PR #746). This strips the now-dead block from this repo's seeded `.plan/marshal.json`; the `system` domain retains its `defaults`/`optionals`. Config-only change.

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified system configuration by removing unused task execution routing mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->