### PR TITLE
chore(config): seed all five re-review knobs into default:automated-review

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -66,7 +66,11 @@
         "default:create-pr": {},
         "default:ci-verify": {},
         "default:automated-review": {
-          "review_bot_buffer_seconds": 180
+          "review_bot_buffer_seconds": 180,
+          "re_review_on_loopback": false,
+          "re_review_on_branch_cleanup": true,
+          "re_review_await_timeout_seconds": 600,
+          "re_review_on_timeout": "ask"
         },
         "default:sonar-roundtrip": {},
         "default:lessons-capture": {},


### PR DESCRIPTION
Aligns `.plan/marshal.json` with the plan-marshall meta-project (PR #748): seeds all five re-review knobs explicitly into the `default:automated-review` step block for self-documenting config.

- `re_review_on_loopback` (false)
- `re_review_on_branch_cleanup` (true)
- `re_review_await_timeout_seconds` (600)
- `re_review_on_timeout` ("ask")

alongside the existing `review_bot_buffer_seconds` (180). No behavioural change — values are the contract defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review configuration to enhance handling of review triggers, timeout behavior, and branch cleanup processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->