### PR TITLE
feat(gateway): document /metrics API and bridge counters to NiFi native metrics

### DIFF
--- a/doc/architecture/gateway.adoc
+++ b/doc/architecture/gateway.adoc
@@ -116,6 +116,7 @@ Requests flow through up to three authentication layers depending on the entry p
 * **Layer 2 (Custom UI)**: `SecurityHeadersFilter` (defense-in-depth headers), `ProcessorIdValidationFilter` (UUID check), per-component NiFi authorization via `ComponentConfigReader`.
 * **Layer 3 (Gateway Jetty)**: Auth-mode dispatch per endpoint.
 
+[#auth-mode-dispatch]
 == Auth-Mode Dispatch
 
 Each endpoint (built-in or user-defined route) has a configurable `auth-mode`:
@@ -303,6 +304,7 @@ Management endpoint auth-mode is configured via static NiFi properties:
 |503 |Service Unavailable |Request queue is full (back-pressure)
 |===
 
+[#security-events]
 == Security Events
 
 [cols="2,1,2"]
@@ -323,6 +325,11 @@ Management endpoint auth-mode is configured via static NiFi properties:
 These counters are exposed through the `/metrics` management endpoint.
 
 == /metrics Endpoint
+
+For the full endpoint contract (status codes, content negotiation, both response
+schemas, authorization, and the recommended external-monitoring surface) see
+link:../reference/metrics-api.adoc[Metrics API]. This section summarizes the
+three aggregated metric sources.
 
 The `/metrics` endpoint aggregates three metric sources:
 

--- a/doc/guides/QuickStart.adoc
+++ b/doc/guides/QuickStart.adoc
@@ -198,6 +198,7 @@ The **Token Verification** tab lets you paste a JWT and verify it against the co
 
 image::ui-gateway-token-verification.png[Gateway Token Verification Tab]
 
+[#gateway-metrics]
 == Gateway Metrics
 
 The **Metrics** tab provides real-time monitoring of the gateway with three sections:
@@ -207,6 +208,11 @@ The **Metrics** tab provides real-time monitoring of the gateway with three sect
 * **Gateway Events**: overall gateway activity
 
 image::ui-gateway-metrics.png[Gateway Metrics Tab]
+
+This tab is backed by the gateway `/metrics` endpoint, proxied through the custom
+UI. For the endpoint contract, response schemas, and the recommended way to scrape
+these counters from external monitoring tools, see
+link:../reference/metrics-api.adoc[Metrics API].
 
 == Gateway Help
 

--- a/doc/reference/README.adoc
+++ b/doc/reference/README.adoc
@@ -4,6 +4,7 @@ Property tables, configuration formats, error types, request tracking APIs, and 
 
 * link:configuration.adoc[Configuration Reference]: all property tables, static config, environment variables
 * link:error-reference.adoc[Error Reference (RFC 9457)]: consolidated error types returned by the gateway
+* link:metrics-api.adoc[Metrics API]: the gateway `/metrics` endpoint contract and NiFi-native monitoring endpoints
 * link:request-tracking-api.adoc[Request Tracking API]: async request tracking with traceId and status polling
 * link:request-tracking-architecture.adoc[Request Tracking Architecture]: status lifecycle, data model, sequence diagrams
 * link:attachments-api.adoc[Attachments API]: chained attachment uploads with limit enforcement

--- a/doc/reference/configuration.adoc
+++ b/doc/reference/configuration.adoc
@@ -264,6 +264,11 @@ NOTE: In static configuration files, the prefix is `jwt.validation.issuer.<name>
 |No
 |===
 
+NOTE: The `/metrics` management endpoint backs the custom UI Metrics view and
+also publishes its gateway counters to NiFi-native monitoring endpoints. See
+link:metrics-api.adoc[Metrics API] for the full endpoint contract, response
+schemas, and the recommended external-monitoring surface.
+
 == Route Configuration via Dynamic Properties
 
 Routes are configured using NiFi dynamic properties with the `restapi.` prefix:
@@ -478,7 +483,7 @@ The Custom UI backend provides REST endpoints shared by both processors:
 |UI Endpoint |Method |Description
 
 |`/nifi-api/processors/jwt/gateway/config` |GET |Retrieves current route configuration
-|`/nifi-api/processors/jwt/gateway/metrics` |GET |Retrieves metrics from the gateway `/metrics` endpoint
+|`/nifi-api/processors/jwt/gateway/metrics` |GET |Retrieves metrics from the gateway `/metrics` endpoint (see link:metrics-api.adoc[Metrics API])
 |`/nifi-api/processors/jwt/gateway/test` |POST |Sends test requests to the gateway (SSRF-protected)
 |`/nifi-api/processors/jwt/gateway/token-fetch` |POST |Proxies an OAuth token request to the IDP
 |`/nifi-api/processors/jwt/gateway/discover-token-endpoint` |POST |Fetches OIDC discovery for the token endpoint

--- a/doc/reference/configuration.adoc
+++ b/doc/reference/configuration.adoc
@@ -132,6 +132,7 @@ NOTE: In static configuration files, the prefix is `jwt.validation.issuer.<name>
 |No
 |===
 
+[#restapigateway-processor-properties]
 == RestApiGateway Processor Properties
 
 [cols="2,1,3,1"]

--- a/doc/reference/metrics-api.adoc
+++ b/doc/reference/metrics-api.adoc
@@ -1,0 +1,223 @@
+= Metrics API
+:toc: left
+:toclevels: 3
+:toc-title: Table of Contents
+:sectnums:
+:source-highlighter: highlight.js
+
+== Overview
+
+The gateway `/metrics` endpoint is an *internal data source* for the
+RestApiGatewayProcessor custom UI's **Metrics** view. The UI does not call the
+gateway directly: the browser requests
+`/nifi-api/processors/jwt/gateway/metrics`, the
+link:../architecture/gateway.adoc[`GatewayProxyServlet`] proxies that request to
+the embedded gateway's `/metrics` endpoint, and the JSON response populates the
+three sections of the Metrics tab (see
+link:../guides/QuickStart.adoc#gateway-metrics[Quick Start -- Gateway Metrics]).
+
+This endpoint exists to back that one UI view. It is *not* the recommended
+surface for general-purpose external monitoring -- for scraping the gateway's
+counters from Prometheus, Grafana, or any other monitoring stack, use the
+NiFi-native endpoints described in <<external-monitoring,External Monitoring (NiFi-Native Endpoints)>>
+below.
+
+[NOTE]
+.Forward direction
+====
+The `/metrics` endpoint is a transitional surface. Once the admin Metrics view is
+reworked to read the gateway counters from the NiFi-native endpoints (which carry
+the same data; see <<external-monitoring,External Monitoring (NiFi-Native Endpoints)>>), this
+endpoint can be removed without loss of UI functionality. It is documented here
+as the current internal contract, not as a long-term external API.
+====
+
+== Endpoint Contract
+
+[cols="1,3"]
+|===
+|Property |Value
+
+|Path |`/metrics`
+|Method |`GET` (any other method returns `405 Method Not Allowed`)
+|Auth mode |`local-only,bearer` (default; see <<authorization,Authorization>>)
+|Default response |Prometheus text format (`text/plain; version=0.0.4; charset=utf-8`)
+|JSON response |Returned when the request carries `Accept: application/json`
+|Success status |`200 OK`
+|===
+
+Content negotiation is driven solely by the `Accept` header: a request whose
+`Accept` value contains `application/json` receives the JSON body; every other
+request (including no `Accept` header) receives the Prometheus text body. The UI
+proxy path requests JSON; the Prometheus body exists for ad-hoc local inspection
+of the same counters.
+
+=== Status Codes
+
+[cols="1,3"]
+|===
+|Status |When Returned
+
+|`200 OK` |Metrics successfully rendered (Prometheus or JSON per `Accept`)
+|`401 Unauthorized` |Remote request without a valid Bearer token (auth mode `bearer`)
+|`403 Forbidden` |Valid token but missing a required role (when `required-roles` is configured)
+|`405 Method Not Allowed` |HTTP method other than `GET`
+|===
+
+== Metric Sources
+
+The endpoint aggregates three independent counter sources. Each source is
+rendered as its own metric family (Prometheus) or its own top-level object key
+(JSON).
+
+[cols="1,1,3"]
+|===
+|Source |Origin |Description
+
+|Token Validation
+|oauth-sheriff `SecurityEventCounter`
+|JWT validation outcomes (e.g. `valid_tokens`, `invalid_tokens`). Empty until the linked `JwtIssuerConfigService` has validated at least one token.
+
+|Transport Security
+|cui-http `SecurityEventCounter`
+|Transport-level input-sanitization events raised by the cui-http security pipeline (e.g. `sanitized_path`).
+
+|Gateway Application Events
+|`GatewaySecurityEvents`
+|Application-level gateway security decisions. Exactly nine event types (see <<gateway-application-event-types,Gateway Application Event Types>>).
+|===
+
+[#gateway-application-event-types]
+=== Gateway Application Event Types
+
+The `gatewayEvents` source tracks nine application-level security decisions made
+by the `GatewayRequestHandler`. These are the same events surfaced in the
+link:../architecture/gateway.adoc#security-events[Gateway Architecture --
+Security Events] table.
+
+[cols="2,1,3"]
+|===
+|Event Type |HTTP Status |Description
+
+|`MISSING_BEARER_TOKEN` |401 |No Authorization header or malformed Bearer prefix
+|`AUTH_FAILED` |401 |Token validation failed (expired, bad signature, etc.)
+|`AUTHZ_ROLE_DENIED` |403 |Valid token but missing required roles
+|`AUTHZ_SCOPE_DENIED` |401 |Valid token but missing required scopes (step-up)
+|`BODY_TOO_LARGE` |413 |Request body exceeds the configured maximum size
+|`ROUTE_NOT_FOUND` |404 |No route configured for the requested path
+|`METHOD_NOT_ALLOWED` |405 |Route exists but the HTTP method is not allowed
+|`SCHEMA_VALIDATION_FAILED` |422 |Request body failed JSON Schema validation
+|`QUEUE_FULL` |503 |Request queue at capacity, back-pressure applied
+|===
+
+== Response Schemas
+
+=== Prometheus Format (default)
+
+The default body is Prometheus text exposition format. Each source contributes
+one metric family with `# HELP` and `# TYPE` lines followed by its samples.
+
+[source]
+----
+# HELP nifi_jwt_validations_total Token validation events (oauth-sheriff)
+# TYPE nifi_jwt_validations_total counter
+nifi_jwt_validations_total{result="valid_tokens"} 15126
+nifi_jwt_validations_total{result="invalid_tokens"} 297
+
+# HELP nifi_gateway_http_security_events_total Transport-level security events (cui-http)
+# TYPE nifi_gateway_http_security_events_total counter
+nifi_gateway_http_security_events_total{type="sanitized_path"} 42
+
+# HELP nifi_gateway_events_total Application-level gateway events
+# TYPE nifi_gateway_events_total counter
+nifi_gateway_events_total{type="missing_bearer_token"} 12
+nifi_gateway_events_total{type="auth_failed"} 85
+----
+
+[NOTE]
+====
+In the Prometheus body the gateway event `type` labels are lower-cased
+(`missing_bearer_token`, `auth_failed`, ...). When a source has no recorded
+events, its family still renders -- the transport-security and gateway-events
+families emit a single zero sample (e.g. `nifi_gateway_events_total 0`), and the
+token-validation family emits only its `# HELP`/`# TYPE` header lines.
+====
+
+=== JSON Format
+
+Requested with `Accept: application/json`. The body is a single object with one
+key per source.
+
+[source,json]
+----
+{
+  "tokenValidation": { "valid_tokens": 15126, "invalid_tokens": 297 },
+  "httpSecurity": { "sanitized_path": 42 },
+  "gatewayEvents": { "MISSING_BEARER_TOKEN": 12, "AUTH_FAILED": 85 }
+}
+----
+
+[NOTE]
+====
+The `gatewayEvents` keys in the JSON body use the *raw* event-type names in
+upper-case (`MISSING_BEARER_TOKEN`), unlike the lower-cased Prometheus labels.
+The `tokenValidation` and `httpSecurity` keys are lower-cased in both formats.
+This is the schema the custom UI Metrics view consumes.
+====
+
+[#authorization]
+== Authorization
+
+Access to `/metrics` follows the gateway's standard management-endpoint
+auth-mode dispatch (see link:../architecture/gateway.adoc#auth-mode-dispatch[Auth-Mode
+Dispatch]). The default `local-only,bearer` mode reflects the UI proxy access
+path: the `GatewayProxyServlet` runs inside the NiFi process and reaches the
+embedded gateway over loopback, so the `local-only` branch admits the proxy
+without a token while still requiring Bearer authentication for any remote
+caller.
+
+[cols="2,1,3"]
+|===
+|Static Property |Default |Purpose
+
+|`rest.gateway.management.metrics.enabled` |`true` |Whether `/metrics` is active
+|`rest.gateway.management.metrics.auth-mode` |`local-only,bearer` |Authentication mode for `/metrics`
+|`rest.gateway.management.metrics.required-roles` |-- |Roles required when auth-mode includes `bearer`
+|`rest.gateway.management.metrics.required-scopes` |-- |Scopes required when auth-mode includes `bearer`
+|===
+
+See link:configuration.adoc#restapigateway-processor-properties[Configuration
+Reference -- RestApiGateway Processor Properties] for the full property table.
+
+[#external-monitoring]
+== External Monitoring (NiFi-Native Endpoints)
+
+For external monitoring stacks, do *not* scrape the gateway `/metrics` endpoint.
+The gateway application events are also published as native NiFi processor
+counters via `session.adjustCounter`, which makes them available on NiFi's own,
+already-authenticated monitoring endpoints. These endpoints are the recommended
+surface for Prometheus, Grafana, and similar tools.
+
+[cols="2,3"]
+|===
+|NiFi-Native Endpoint |Content
+
+|`/nifi-api/flow/metrics/prometheus`
+|Prometheus exposition of all NiFi metrics, including per-processor user counters under the `nifi_processor_counters` metric family.
+
+|`/nifi-api/counters`
+|JSON listing of all processor counters, including the gateway's per-event counters.
+|===
+
+The gateway counters appear in the `nifi_processor_counters` family labelled by
+`processor_name`, `counter_name`, and `processor_id`:
+
+[source]
+----
+nifi_processor_counters{processor_name="RestApiGatewayProcessor",counter_name="...",processor_id="..."} <value>
+----
+
+The `counter_name` values follow the stable naming convention published by the
+processor; treat those names as the contract for any external dashboard or
+alert. Because these endpoints are served by NiFi itself, they inherit NiFi's
+authentication and require no gateway-specific configuration.

--- a/integration-testing/src/test/java/de/cuioss/nifi/integration/GatewayMetricsPrometheusIT.java
+++ b/integration-testing/src/test/java/de/cuioss/nifi/integration/GatewayMetricsPrometheusIT.java
@@ -31,7 +31,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static de.cuioss.nifi.integration.IntegrationTestSupport.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -111,7 +110,7 @@ class GatewayMetricsPrometheusIT {
         List<String> gatewayCounterLines = prometheus.lines()
                 .filter(line -> line.startsWith("nifi_processor_counters"))
                 .filter(line -> line.contains("counter_name=\"" + GATEWAY_COUNTER_PREFIX))
-                .collect(Collectors.toList());
+                .toList();
 
         assertTrue(!gatewayCounterLines.isEmpty(),
                 "The nifi_processor_counters family must contain at least one gateway.* counter_name; "
@@ -204,7 +203,7 @@ class GatewayMetricsPrometheusIT {
         return counters.stream()
                 .map(JsonObject.class::cast)
                 .filter(c -> c.getString("name", "").startsWith(GATEWAY_COUNTER_PREFIX))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**

--- a/integration-testing/src/test/java/de/cuioss/nifi/integration/GatewayMetricsPrometheusIT.java
+++ b/integration-testing/src/test/java/de/cuioss/nifi/integration/GatewayMetricsPrometheusIT.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.nifi.integration;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static de.cuioss.nifi.integration.IntegrationTestSupport.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests verifying that the gateway's application metrics are bridged
+ * to NiFi-native counters (Tier A) and surface at NiFi's own monitoring endpoints.
+ *
+ * <p>The {@code RestApiGatewayProcessor} publishes the cumulative counts of its
+ * three internal event sources as NiFi processor counters via
+ * {@code session.adjustCounter} on each {@code onTrigger}. Those counters are
+ * exported by NiFi itself at:
+ * <ul>
+ *   <li>{@code /nifi-api/counters} — JSON list of all processor counters</li>
+ *   <li>{@code /nifi-api/flow/metrics/prometheus} — Prometheus exposition where the
+ *       gateway counters appear in the {@code nifi_processor_counters} family with a
+ *       {@code counter_name="gateway...."} label</li>
+ * </ul>
+ *
+ * <p>The counter names carry the stable {@code gateway.} prefix defined in
+ * {@code RestApiGatewayConstants.Counters} (e.g. {@code gateway.events.missing_bearer_token},
+ * {@code gateway.token.access_token_created}). This test generates gateway traffic that
+ * produces such events, then asserts the counters appear at BOTH NiFi-native endpoints.
+ *
+ * <p>Requires Docker containers to be running (NiFi HTTPS on ports 9443 and 9095,
+ * Keycloak on 9085). Activated via the {@code integration-tests} Maven profile.
+ */
+@NullMarked
+@DisplayName("Gateway Metrics at NiFi-Native Endpoints Integration Tests")
+class GatewayMetricsPrometheusIT {
+
+    /** Stable prefix every bridged gateway counter name shares (see RestApiGatewayConstants.Counters). */
+    private static final String GATEWAY_COUNTER_PREFIX = "gateway.";
+
+    private static HttpClient nifiClient;
+    private static HttpClient gatewayClient;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        nifiClient = HttpClient.newBuilder()
+                .sslContext(createSslContext())
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+        gatewayClient = HttpClient.newBuilder()
+                .sslContext(createSslContext())
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+
+        generateGatewayTraffic();
+        waitForGatewayCounters(Duration.ofSeconds(60));
+    }
+
+    @Test
+    @DisplayName("should expose gateway counters at /nifi-api/counters")
+    void shouldExposeGatewayCountersAtCountersEndpoint() throws Exception {
+        String bearerToken = authenticateToNifi(nifiClient);
+
+        List<JsonObject> gatewayCounters = fetchGatewayCounters(bearerToken);
+
+        assertTrue(!gatewayCounters.isEmpty(),
+                "At least one gateway.* counter must surface at /nifi-api/counters; found none");
+        long positive = gatewayCounters.stream()
+                .filter(c -> counterValue(c) > 0)
+                .count();
+        assertTrue(positive > 0,
+                "At least one gateway.* counter must have a positive value at /nifi-api/counters");
+    }
+
+    @Test
+    @DisplayName("should expose gateway counters in the nifi_processor_counters Prometheus family")
+    void shouldExposeGatewayCountersInPrometheus() throws Exception {
+        String bearerToken = authenticateToNifi(nifiClient);
+
+        String prometheus = fetchPrometheusMetrics(bearerToken);
+
+        List<String> gatewayCounterLines = prometheus.lines()
+                .filter(line -> line.startsWith("nifi_processor_counters"))
+                .filter(line -> line.contains("counter_name=\"" + GATEWAY_COUNTER_PREFIX))
+                .collect(Collectors.toList());
+
+        assertTrue(!gatewayCounterLines.isEmpty(),
+                "The nifi_processor_counters family must contain at least one gateway.* counter_name; "
+                        + "none found in the Prometheus exposition");
+    }
+
+    // ── Traffic generation ──────────────────────────────────────────────
+
+    private static void generateGatewayTraffic() throws Exception {
+        waitForEndpoint(gatewayClient, GATEWAY_BASE + "/api/data", Duration.ofSeconds(120));
+
+        // Unauthenticated request → seeds a MISSING_BEARER_TOKEN gateway event (no FlowFile).
+        sendGateway(gatewayClient, "GET", "/api/data", null, null);
+
+        // Authenticated requests → validate a token and enqueue FlowFiles so onTrigger fires,
+        // flushing both the token-validation deltas and the pending gateway-event delta.
+        String token = fetchKeycloakToken(gatewayClient,
+                KEYCLOAK_TOKEN_ENDPOINT, CLIENT_ID, null, TEST_USER, PASSWORD);
+        sendGateway(gatewayClient, "GET", "/api/data", token, null);
+        sendGateway(gatewayClient, "POST", "/api/data", token, "{\"key\":\"value\"}");
+    }
+
+    @SuppressWarnings("java:S2925") // Thread.sleep is the standard retry-delay for NiFi metrics polling
+    private static void waitForGatewayCounters(Duration timeout) throws Exception {
+        long deadline = System.nanoTime() + timeout.toNanos();
+
+        while (System.nanoTime() < deadline) {
+            // Re-authenticate to NiFi each iteration so a short-lived access token
+            // cannot expire mid-loop on a slow fresh-container start.
+            String bearerToken = authenticateToNifi(nifiClient);
+            if (!fetchGatewayCounters(bearerToken).isEmpty()) {
+                return;
+            }
+            // Re-drive both an unauthenticated request (seeds a gateway event) and a
+            // FlowFile-producing authenticated POST so onTrigger fires and flushes the
+            // accumulated deltas — covers the fresh-container case where the gateway's
+            // embedded server or the processor schedule was not ready for the first burst.
+            sendGateway(gatewayClient, "GET", "/api/data", null, null);
+            String token = fetchKeycloakToken(gatewayClient,
+                    KEYCLOAK_TOKEN_ENDPOINT, CLIENT_ID, null, TEST_USER, PASSWORD);
+            sendGateway(gatewayClient, "POST", "/api/data", token, "{\"key\":\"poll\"}");
+            Thread.sleep(2000);
+        }
+        // Don't fail here — the test assertions report the precise gap.
+    }
+
+    private static void sendGateway(HttpClient client, String method, String path,
+            String token, String body) throws Exception {
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .uri(URI.create(GATEWAY_BASE + path))
+                .timeout(Duration.ofSeconds(30));
+        if (body != null) {
+            builder.method(method, HttpRequest.BodyPublishers.ofString(body))
+                    .header("Content-Type", "application/json");
+        } else {
+            builder.method(method, HttpRequest.BodyPublishers.noBody());
+        }
+        if (token != null) {
+            builder.header("Authorization", "Bearer " + token);
+        }
+        client.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    // ── NiFi-native endpoint readers ────────────────────────────────────
+
+    private static List<JsonObject> fetchGatewayCounters(String bearerToken) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(NIFI_API_BASE + "/counters"))
+                .GET()
+                .header("Authorization", "Bearer " + bearerToken)
+                .timeout(Duration.ofSeconds(15))
+                .build();
+
+        HttpResponse<String> response = nifiClient.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode(),
+                "Counters request failed with status %d: %s"
+                        .formatted(response.statusCode(), response.body()));
+
+        JsonObject root = Json.createReader(new StringReader(response.body())).readObject();
+        JsonObject countersWrapper = root.getJsonObject("counters");
+        if (countersWrapper == null) {
+            return List.of();
+        }
+        JsonObject aggregateSnapshot = countersWrapper.getJsonObject("aggregateSnapshot");
+        if (aggregateSnapshot == null || !aggregateSnapshot.containsKey("counters")) {
+            return List.of();
+        }
+        JsonArray counters = aggregateSnapshot.getJsonArray("counters");
+
+        return counters.stream()
+                .map(JsonObject.class::cast)
+                .filter(c -> c.getString("name", "").startsWith(GATEWAY_COUNTER_PREFIX))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Resolves a counter's numeric value, preferring the {@code valueCount} Long field
+     * and falling back to parsing the formatted {@code value} string when absent.
+     *
+     * @param counter a single counter JSON object from the counters endpoint
+     * @return the counter value, or 0 when neither field is parseable
+     */
+    private static long counterValue(JsonObject counter) {
+        if (counter.containsKey("valueCount") && !counter.isNull("valueCount")) {
+            return counter.getJsonNumber("valueCount").longValue();
+        }
+        String formatted = counter.getString("value", "0").replace(",", "").trim();
+        try {
+            return Long.parseLong(formatted);
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
+    }
+
+    private static String fetchPrometheusMetrics(String bearerToken) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(NIFI_API_BASE + "/flow/metrics/prometheus"))
+                .GET()
+                .header("Authorization", "Bearer " + bearerToken)
+                .timeout(Duration.ofSeconds(15))
+                .build();
+
+        HttpResponse<String> response = nifiClient.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode(),
+                "Prometheus metrics request failed with status %d: %s"
+                        .formatted(response.statusCode(), response.body()));
+        return response.body();
+    }
+}

--- a/integration-testing/src/test/java/de/cuioss/nifi/integration/GatewayMetricsPrometheusIT.java
+++ b/integration-testing/src/test/java/de/cuioss/nifi/integration/GatewayMetricsPrometheusIT.java
@@ -35,6 +35,7 @@ import java.util.List;
 import static de.cuioss.nifi.integration.IntegrationTestSupport.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Integration tests verifying that the gateway's application metrics are bridged
@@ -154,7 +155,11 @@ class GatewayMetricsPrometheusIT {
             sendGateway(gatewayClient, "POST", "/api/data", token, "{\"key\":\"poll\"}");
             Thread.sleep(2000);
         }
-        // Don't fail here — the test assertions report the precise gap.
+        // A polling helper that waits for a state change must throw on timeout so the test fails
+        // loudly with context, rather than returning silently and letting later assertions run
+        // against an unmet precondition.
+        fail("Timed out after %s waiting for the gateway NiFi counters to appear on /nifi-api/counters"
+                .formatted(timeout));
     }
 
     private static void sendGateway(HttpClient client, String method, String path,

--- a/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/config/ConfigurationManagerTest.java
+++ b/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/config/ConfigurationManagerTest.java
@@ -72,7 +72,7 @@ class ConfigurationManagerTest {
 
         @Test
         @DisplayName("Should load properties file with issuer config and static props")
-        void shouldLoadPropertiesFile(@TempDir Path tempDir) throws IOException {
+        void shouldLoadPropertiesFile(@TempDir Path tempDir) throws Exception {
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.properties");
             String content = """
@@ -103,7 +103,7 @@ class ConfigurationManagerTest {
 
         @Test
         @DisplayName("Should load properties file with multiple issuers")
-        void shouldLoadMultipleIssuersFromPropertiesFile(@TempDir Path tempDir) throws IOException {
+        void shouldLoadMultipleIssuersFromPropertiesFile(@TempDir Path tempDir) throws Exception {
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.properties");
             String content = """
@@ -132,7 +132,7 @@ class ConfigurationManagerTest {
 
         @Test
         @DisplayName("Should load YAML file with nested structure")
-        void shouldLoadYamlFileWithNestedStructure(@TempDir Path tempDir) throws IOException {
+        void shouldLoadYamlFileWithNestedStructure(@TempDir Path tempDir) throws Exception {
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.yml");
             String content = """
@@ -162,7 +162,7 @@ class ConfigurationManagerTest {
 
         @Test
         @DisplayName("Should load YAML file with issuers list using id field")
-        void shouldLoadYamlWithIssuersListUsingId(@TempDir Path tempDir) throws IOException {
+        void shouldLoadYamlWithIssuersListUsingId(@TempDir Path tempDir) throws Exception {
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.yml");
             String content = """
@@ -192,7 +192,7 @@ class ConfigurationManagerTest {
 
         @Test
         @DisplayName("Should load YAML file with issuers list using name field when id missing")
-        void shouldLoadYamlWithIssuersListUsingName(@TempDir Path tempDir) throws IOException {
+        void shouldLoadYamlWithIssuersListUsingName(@TempDir Path tempDir) throws Exception {
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.yml");
             String content = """
@@ -216,7 +216,7 @@ class ConfigurationManagerTest {
 
         @Test
         @DisplayName("Should load YAML file with issuers list using index when id and name missing")
-        void shouldLoadYamlWithIssuersListUsingIndex(@TempDir Path tempDir) throws IOException {
+        void shouldLoadYamlWithIssuersListUsingIndex(@TempDir Path tempDir) throws Exception {
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.yml");
             String content = """
@@ -238,7 +238,7 @@ class ConfigurationManagerTest {
 
         @Test
         @DisplayName("Should skip non-map items in YAML issuers list")
-        void shouldSkipNonMapItemsInIssuersList(@TempDir Path tempDir) throws IOException {
+        void shouldSkipNonMapItemsInIssuersList(@TempDir Path tempDir) throws Exception {
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.yml");
             String content = """
@@ -261,7 +261,7 @@ class ConfigurationManagerTest {
 
         @Test
         @DisplayName("Should handle empty YAML file and return false")
-        void shouldHandleEmptyYamlFile(@TempDir Path tempDir) throws IOException {
+        void shouldHandleEmptyYamlFile(@TempDir Path tempDir) throws Exception {
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.yml");
             Files.writeString(configFile, "");
@@ -279,7 +279,7 @@ class ConfigurationManagerTest {
 
         @Test
         @DisplayName("Should return false when file not modified")
-        void shouldReturnFalseWhenNotModified(@TempDir Path tempDir) throws IOException {
+        void shouldReturnFalseWhenNotModified(@TempDir Path tempDir) throws Exception {
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.properties");
             String content = """
@@ -296,7 +296,7 @@ class ConfigurationManagerTest {
 
         @Test
         @DisplayName("Should return true when file modified")
-        void shouldReturnTrueWhenModified(@TempDir Path tempDir) throws IOException {
+        void shouldReturnTrueWhenModified(@TempDir Path tempDir) throws Exception {
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.properties");
             String content = """
@@ -350,7 +350,7 @@ class ConfigurationManagerTest {
 
         @Test
         @DisplayName("Should return actual value when key exists")
-        void shouldReturnActualValue(@TempDir Path tempDir) throws IOException {
+        void shouldReturnActualValue(@TempDir Path tempDir) throws Exception {
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.properties");
             String content = """
@@ -372,7 +372,7 @@ class ConfigurationManagerTest {
 
         @Test
         @DisplayName("Should return list of issuer IDs")
-        void shouldReturnIssuerIds(@TempDir Path tempDir) throws IOException {
+        void shouldReturnIssuerIds(@TempDir Path tempDir) throws Exception {
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.properties");
             String content = """
@@ -404,7 +404,7 @@ class ConfigurationManagerTest {
 
         @Test
         @DisplayName("Should return issuer properties for known issuer")
-        void shouldReturnIssuerProperties(@TempDir Path tempDir) throws IOException {
+        void shouldReturnIssuerProperties(@TempDir Path tempDir) throws Exception {
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.properties");
             String content = """
@@ -431,7 +431,7 @@ class ConfigurationManagerTest {
 
         @Test
         @DisplayName("Should prefer properties file over YAML when both exist")
-        void shouldPreferPropertiesOverYaml(@TempDir Path tempDir) throws IOException {
+        void shouldPreferPropertiesOverYaml(@TempDir Path tempDir) throws Exception {
             Path confDir = createConfDir(tempDir);
             Path propsFile = confDir.resolve("cui-nifi-extensions.properties");
             Files.writeString(propsFile, "jwt.validation.max.token.size=11111\n");
@@ -457,7 +457,7 @@ class ConfigurationManagerTest {
 
         @Test
         @DisplayName("Should convert environment variable names to property names")
-        void shouldConvertEnvToPropertyName(@TempDir Path tempDir) throws IOException {
+        void shouldConvertEnvToPropertyName(@TempDir Path tempDir) throws Exception {
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.properties");
             String content = """
@@ -478,7 +478,7 @@ class ConfigurationManagerTest {
 
         @Test
         @DisplayName("Should handle invalid YAML syntax gracefully")
-        void shouldHandleInvalidYaml(@TempDir Path tempDir) throws IOException {
+        void shouldHandleInvalidYaml(@TempDir Path tempDir) throws Exception {
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.yml");
             // Unmatched quote causes SnakeYAML to throw YAMLException
@@ -493,7 +493,7 @@ class ConfigurationManagerTest {
 
         @Test
         @DisplayName("Should handle malformed YAML structure gracefully")
-        void shouldHandleMalformedYaml(@TempDir Path tempDir) throws IOException {
+        void shouldHandleMalformedYaml(@TempDir Path tempDir) throws Exception {
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.yml");
             String content = """
@@ -516,7 +516,7 @@ class ConfigurationManagerTest {
 
         @Test
         @DisplayName("Should process generic YAML list as comma-separated string")
-        void shouldProcessGenericListAsCommaSeparated(@TempDir Path tempDir) throws IOException {
+        void shouldProcessGenericListAsCommaSeparated(@TempDir Path tempDir) throws Exception {
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.yml");
             String content = """
@@ -540,7 +540,7 @@ class ConfigurationManagerTest {
 
         @Test
         @DisplayName("Should handle list with null values")
-        void shouldHandleListWithNullValues(@TempDir Path tempDir) throws IOException {
+        void shouldHandleListWithNullValues(@TempDir Path tempDir) throws Exception {
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.yml");
             String content = """
@@ -567,7 +567,7 @@ class ConfigurationManagerTest {
 
         @Test
         @DisplayName("Should clear old config when reload encounters invalid YAML")
-        void shouldClearOldConfigOnReloadWithInvalidYaml(@TempDir Path tempDir) throws IOException {
+        void shouldClearOldConfigOnReloadWithInvalidYaml(@TempDir Path tempDir) throws Exception {
             Path confDir = createConfDir(tempDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.yml");
             String validContent = """

--- a/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/config/IssuerConfigurationParserTest.java
+++ b/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/config/IssuerConfigurationParserTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -87,7 +86,7 @@ class IssuerConfigurationParserTest {
 
         @Test
         @DisplayName("Should create IssuerConfig from UI property with JWKS file")
-        void shouldCreateIssuerConfigWithJwksFile(@TempDir Path tempDir) throws IOException {
+        void shouldCreateIssuerConfigWithJwksFile(@TempDir Path tempDir) throws Exception {
             // Arrange — create a real JWKS file since the builder validates existence
             Path jwksFile = tempDir.resolve("test-jwks.json");
             Files.writeString(jwksFile, InMemoryKeyMaterialHandler.createDefaultJwks());
@@ -269,7 +268,7 @@ class IssuerConfigurationParserTest {
 
         @Test
         @DisplayName("Should infer file type from jwks-file property")
-        void shouldInferFileTypeFromJwksFile(@TempDir Path tempDir) throws IOException {
+        void shouldInferFileTypeFromJwksFile(@TempDir Path tempDir) throws Exception {
             Path jwksFile = tempDir.resolve("test-jwks.json");
             Files.writeString(jwksFile, InMemoryKeyMaterialHandler.createDefaultJwks());
             Map<String, String> properties = new HashMap<>();
@@ -383,7 +382,7 @@ class IssuerConfigurationParserTest {
 
         @Test
         @DisplayName("Should load issuers from ConfigurationManager")
-        void shouldLoadIssuersFromConfigManager(@TempDir Path tempDir) throws IOException {
+        void shouldLoadIssuersFromConfigManager(@TempDir Path tempDir) throws Exception {
             Path confDir = tempDir.resolve("conf");
             Files.createDirectories(confDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.properties");
@@ -404,7 +403,7 @@ class IssuerConfigurationParserTest {
 
         @Test
         @DisplayName("Should merge UI and external configurations")
-        void shouldMergeUIAndExternalConfigs(@TempDir Path tempDir) throws IOException {
+        void shouldMergeUIAndExternalConfigs(@TempDir Path tempDir) throws Exception {
             Path confDir = tempDir.resolve("conf");
             Files.createDirectories(confDir);
             Path configFile = confDir.resolve("cui-nifi-extensions.properties");

--- a/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/util/TokenMaskingTest.java
+++ b/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/util/TokenMaskingTest.java
@@ -22,7 +22,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("TokenMasking")
 class TokenMaskingTest {

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayConstants.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayConstants.java
@@ -281,4 +281,54 @@ public final class RestApiGatewayConstants {
                 .build();
 
     }
+
+    /**
+     * Stable counter-name convention for the NiFi-native counters bridged from the
+     * gateway's internal event sources in {@code onTrigger} via
+     * {@code session.adjustCounter}.
+     * <p>
+     * Each gateway event source maps to a dedicated dotted prefix; the per-event
+     * name is the prefix followed by the lower-cased event identifier. These names
+     * are the contract consumed by external monitoring: they surface verbatim as
+     * the {@code counter_name} label of the {@code nifi_processor_counters} metric
+     * family on {@code /nifi-api/flow/metrics/prometheus} and as the counter name in
+     * {@code /nifi-api/counters}. The names MUST remain stable — documentation
+     * (doc/reference/metrics-api.adoc) and integration tests assert them directly.
+     */
+    @UtilityClass
+    public static final class Counters {
+        /**
+         * Prefix for application-level gateway security events
+         * ({@code GatewaySecurityEvents.EventType}). Full name example:
+         * {@code gateway.events.missing_bearer_token}.
+         */
+        public static final String GATEWAY_EVENT_PREFIX = "gateway.events.";
+
+        /**
+         * Prefix for token-validation events (oauth-sheriff
+         * {@code SecurityEventCounter}). Full name example:
+         * {@code gateway.token.valid_tokens}.
+         */
+        public static final String TOKEN_VALIDATION_PREFIX = "gateway.token.";
+
+        /**
+         * Prefix for transport-level HTTP security events (cui-http
+         * {@code SecurityEventCounter}). Full name example:
+         * {@code gateway.http.security.path_traversal}.
+         */
+        public static final String HTTP_SECURITY_PREFIX = "gateway.http.security.";
+
+        /**
+         * Builds the stable counter name for a source prefix and an event
+         * identifier, lower-casing the identifier so the name matches the
+         * Prometheus label casing used elsewhere.
+         *
+         * @param prefix one of the {@code *_PREFIX} constants in this class
+         * @param eventName the raw event identifier (enum name)
+         * @return the fully-qualified, lower-cased counter name
+         */
+        public static String counterName(String prefix, String eventName) {
+            return prefix + eventName.toLowerCase(java.util.Locale.ROOT);
+        }
+    }
 }

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayConstants.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayConstants.java
@@ -24,6 +24,8 @@ import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.ssl.SSLContextProvider;
 
+import java.util.Locale;
+
 /**
  * DSL-style nested constants for the RestApiGateway processor configuration.
  *
@@ -328,7 +330,7 @@ public final class RestApiGatewayConstants {
          * @return the fully-qualified, lower-cased counter name
          */
         public static String counterName(String prefix, String eventName) {
-            return prefix + eventName.toLowerCase(java.util.Locale.ROOT);
+            return prefix + eventName.toLowerCase(Locale.ROOT);
         }
     }
 }

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayProcessor.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayProcessor.java
@@ -465,8 +465,6 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
      * The counter names follow {@link RestApiGatewayConstants.Counters}, which is the
      * stable contract surfaced on NiFi's {@code /nifi-api/counters} and
      * {@code /nifi-api/flow/metrics/prometheus} endpoints.
-     *
-     * @param session the current process session used to adjust counters
      */
     private void publishCounterDeltas(ProcessSession session) {
         GatewaySecurityEvents gatewayEvents = this.gatewaySecurityEvents;
@@ -498,14 +496,6 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
         }
     }
 
-    /**
-     * Publishes the positive delta between the supplied cumulative {@code count} and
-     * the last value recorded for {@code counterName}, then records the new baseline.
-     *
-     * @param session the process session used to adjust the counter
-     * @param counterName the stable NiFi counter name
-     * @param count the current cumulative count for the source event
-     */
     private void publishDelta(ProcessSession session, String counterName, long count) {
         long previous = lastPublishedCounts.getOrDefault(counterName, 0L);
         long delta = count - previous;

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayProcessor.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayProcessor.java
@@ -510,7 +510,11 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
         long previous = lastPublishedCounts.getOrDefault(counterName, 0L);
         long delta = count - previous;
         if (delta > 0) {
-            session.adjustCounter(counterName, delta, false);
+            // immediate=true writes through to the FlowController counter repository at once,
+            // so the counter persists even on the idle early-return path (where the session is
+            // yielded, not committed) and surfaces on NiFi's /nifi-api/counters and
+            // /nifi-api/flow/metrics/prometheus endpoints independent of session lifecycle.
+            session.adjustCounter(counterName, delta, true);
             lastPublishedCounts.put(counterName, count);
         }
     }

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayProcessor.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayProcessor.java
@@ -64,6 +64,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 /**
@@ -127,12 +128,16 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
     /** Guards lazy loading of external config relationships before @OnScheduled. */
     private final AtomicBoolean externalRelationshipsLoaded = new AtomicBoolean(false);
 
-    /** Gateway application-level security events; shared with the Jetty handlers, read in onTrigger. */
-    private volatile GatewaySecurityEvents gatewaySecurityEvents;
+    /**
+     * Gateway application-level security events; shared with the Jetty handlers, read in onTrigger.
+     * Held in an {@link AtomicReference} (a thread-safe type) so the @OnScheduled publish and the
+     * onTrigger read of the reference are safely visible across NiFi framework threads.
+     */
+    final AtomicReference<GatewaySecurityEvents> gatewaySecurityEvents = new AtomicReference<>();
     /** Transport-level (cui-http) security events; shared with the Jetty handlers, read in onTrigger. */
-    private volatile SecurityEventCounter httpSecurityEvents;
+    final AtomicReference<SecurityEventCounter> httpSecurityEvents = new AtomicReference<>();
     /** Config service supplying the oauth-sheriff token-validation counter; resolved in onScheduled. */
-    private volatile JwtIssuerConfigService configService;
+    final AtomicReference<JwtIssuerConfigService> configService = new AtomicReference<>();
     /**
      * Last-published cumulative count per counter name. onTrigger publishes the delta
      * (current cumulative count − last-published count) as a NiFi counter so the native
@@ -225,7 +230,7 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
         JwtIssuerConfigService configService = context.getProperty(
                 RestApiGatewayConstants.Properties.JWT_ISSUER_CONFIG_SERVICE)
                 .asControllerService(JwtIssuerConfigService.class);
-        this.configService = configService;
+        this.configService.set(configService);
         int maxRequestSize = context.getProperty(RestApiGatewayConstants.Properties.MAX_REQUEST_SIZE).asInteger();
         int port = context.getProperty(RestApiGatewayConstants.Properties.LISTENING_PORT).asInteger();
 
@@ -236,8 +241,8 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
         // Held as fields so onTrigger can bridge their cumulative counts to NiFi counters.
         var httpSecurityEvents = new SecurityEventCounter();
         var gatewaySecurityEvents = new GatewaySecurityEvents();
-        this.httpSecurityEvents = httpSecurityEvents;
-        this.gatewaySecurityEvents = gatewaySecurityEvents;
+        this.httpSecurityEvents.set(httpSecurityEvents);
+        this.gatewaySecurityEvents.set(gatewaySecurityEvents);
         // Reset the per-instance delta baseline on each (re)schedule so a restart
         // republishes from the freshly-zeroed counters without spurious deltas.
         lastPublishedCounts.clear();
@@ -466,8 +471,8 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
      * stable contract surfaced on NiFi's {@code /nifi-api/counters} and
      * {@code /nifi-api/flow/metrics/prometheus} endpoints.
      */
-    private void publishCounterDeltas(ProcessSession session) {
-        GatewaySecurityEvents gatewayEvents = this.gatewaySecurityEvents;
+    void publishCounterDeltas(ProcessSession session) {
+        GatewaySecurityEvents gatewayEvents = this.gatewaySecurityEvents.get();
         if (gatewayEvents != null) {
             gatewayEvents.getAllCounts().forEach((eventType, count) ->
                     publishDelta(session,
@@ -476,7 +481,7 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
                             count));
         }
 
-        SecurityEventCounter httpEvents = this.httpSecurityEvents;
+        SecurityEventCounter httpEvents = this.httpSecurityEvents.get();
         if (httpEvents != null) {
             httpEvents.getAllCounts().forEach((failureType, count) ->
                     publishDelta(session,
@@ -485,7 +490,7 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
                             count));
         }
 
-        JwtIssuerConfigService service = this.configService;
+        JwtIssuerConfigService service = this.configService.get();
         if (service != null) {
             service.getSecurityEventCounter().ifPresent(tokenCounter ->
                     tokenCounter.getCounters().forEach((eventType, count) ->

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayProcessor.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayProcessor.java
@@ -127,6 +127,19 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
     /** Guards lazy loading of external config relationships before @OnScheduled. */
     private final AtomicBoolean externalRelationshipsLoaded = new AtomicBoolean(false);
 
+    /** Gateway application-level security events; shared with the Jetty handlers, read in onTrigger. */
+    private volatile GatewaySecurityEvents gatewaySecurityEvents;
+    /** Transport-level (cui-http) security events; shared with the Jetty handlers, read in onTrigger. */
+    private volatile SecurityEventCounter httpSecurityEvents;
+    /** Config service supplying the oauth-sheriff token-validation counter; resolved in onScheduled. */
+    private volatile JwtIssuerConfigService configService;
+    /**
+     * Last-published cumulative count per counter name. onTrigger publishes the delta
+     * (current cumulative count − last-published count) as a NiFi counter so the native
+     * counters stay cumulative-correct without double-counting across triggers.
+     */
+    private final ConcurrentHashMap<String, Long> lastPublishedCounts = new ConcurrentHashMap<>();
+
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return STATIC_PROPERTIES;
@@ -212,15 +225,22 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
         JwtIssuerConfigService configService = context.getProperty(
                 RestApiGatewayConstants.Properties.JWT_ISSUER_CONFIG_SERVICE)
                 .asControllerService(JwtIssuerConfigService.class);
+        this.configService = configService;
         int maxRequestSize = context.getProperty(RestApiGatewayConstants.Properties.MAX_REQUEST_SIZE).asInteger();
         int port = context.getProperty(RestApiGatewayConstants.Properties.LISTENING_PORT).asInteger();
 
         // Build JSON Schema validator from route configurations
         JsonSchemaValidator schemaValidator = buildSchemaValidator(routes);
 
-        // Pre-create shared event counters so all handlers + dispatcher share them
+        // Pre-create shared event counters so all handlers + dispatcher share them.
+        // Held as fields so onTrigger can bridge their cumulative counts to NiFi counters.
         var httpSecurityEvents = new SecurityEventCounter();
         var gatewaySecurityEvents = new GatewaySecurityEvents();
+        this.httpSecurityEvents = httpSecurityEvents;
+        this.gatewaySecurityEvents = gatewaySecurityEvents;
+        // Reset the per-instance delta baseline on each (re)schedule so a restart
+        // republishes from the freshly-zeroed counters without spurious deltas.
+        lastPublishedCounts.clear();
 
         // Resolve optional DistributedMapCacheClient for request tracking
         DistributedMapCacheClient cacheClient = context.getProperty(
@@ -344,6 +364,10 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
 
     @Override
     public void onTrigger(ProcessContext context, ProcessSession session) {
+        // Bridge gateway metric counts to NiFi-native counters before any early return,
+        // so idle ticks (no queued request) still flush newly-accumulated event deltas.
+        publishCounterDeltas(session);
+
         HttpRequestContainer container = requestQueue.poll();
         if (container == null) {
             context.yield();
@@ -428,6 +452,66 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
             FlowFile errorFile = session.create();
             errorFile = session.putAttribute(errorFile, "error.message", e.getMessage());
             session.transfer(errorFile, RestApiGatewayConstants.Relationships.FAILURE);
+        }
+    }
+
+    /**
+     * Bridges the gateway's three internal event sources to NiFi-native counters.
+     * <p>
+     * For each event the current cumulative count is compared against the
+     * last-published value in {@link #lastPublishedCounts}; only the positive delta
+     * is forwarded to {@link ProcessSession#adjustCounter} so the native counter
+     * accumulates the same cumulative total without double-counting across triggers.
+     * The counter names follow {@link RestApiGatewayConstants.Counters}, which is the
+     * stable contract surfaced on NiFi's {@code /nifi-api/counters} and
+     * {@code /nifi-api/flow/metrics/prometheus} endpoints.
+     *
+     * @param session the current process session used to adjust counters
+     */
+    private void publishCounterDeltas(ProcessSession session) {
+        GatewaySecurityEvents gatewayEvents = this.gatewaySecurityEvents;
+        if (gatewayEvents != null) {
+            gatewayEvents.getAllCounts().forEach((eventType, count) ->
+                    publishDelta(session,
+                            RestApiGatewayConstants.Counters.counterName(
+                                    RestApiGatewayConstants.Counters.GATEWAY_EVENT_PREFIX, eventType.name()),
+                            count));
+        }
+
+        SecurityEventCounter httpEvents = this.httpSecurityEvents;
+        if (httpEvents != null) {
+            httpEvents.getAllCounts().forEach((failureType, count) ->
+                    publishDelta(session,
+                            RestApiGatewayConstants.Counters.counterName(
+                                    RestApiGatewayConstants.Counters.HTTP_SECURITY_PREFIX, failureType.name()),
+                            count));
+        }
+
+        JwtIssuerConfigService service = this.configService;
+        if (service != null) {
+            service.getSecurityEventCounter().ifPresent(tokenCounter ->
+                    tokenCounter.getCounters().forEach((eventType, count) ->
+                            publishDelta(session,
+                                    RestApiGatewayConstants.Counters.counterName(
+                                            RestApiGatewayConstants.Counters.TOKEN_VALIDATION_PREFIX, eventType.name()),
+                                    count)));
+        }
+    }
+
+    /**
+     * Publishes the positive delta between the supplied cumulative {@code count} and
+     * the last value recorded for {@code counterName}, then records the new baseline.
+     *
+     * @param session the process session used to adjust the counter
+     * @param counterName the stable NiFi counter name
+     * @param count the current cumulative count for the source event
+     */
+    private void publishDelta(ProcessSession session, String counterName, long count) {
+        long previous = lastPublishedCounts.getOrDefault(counterName, 0L);
+        long delta = count - previous;
+        if (delta > 0) {
+            session.adjustCounter(counterName, delta, false);
+            lastPublishedCounts.put(counterName, count);
         }
     }
 

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayProcessor.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayProcessor.java
@@ -24,16 +24,7 @@ import de.cuioss.nifi.rest.config.AuthMode;
 import de.cuioss.nifi.rest.config.RouteConfiguration;
 import de.cuioss.nifi.rest.config.RouteConfigurationParser;
 import de.cuioss.nifi.rest.config.TrackingMode;
-import de.cuioss.nifi.rest.handler.ApiRouteHandler;
-import de.cuioss.nifi.rest.handler.AttachmentsEndpointHandler;
-import de.cuioss.nifi.rest.handler.EndpointHandler;
-import de.cuioss.nifi.rest.handler.GatewayRequestHandler;
-import de.cuioss.nifi.rest.handler.GatewaySecurityEvents;
-import de.cuioss.nifi.rest.handler.HealthEndpointHandler;
-import de.cuioss.nifi.rest.handler.HttpRequestContainer;
-import de.cuioss.nifi.rest.handler.MetricsEndpointHandler;
-import de.cuioss.nifi.rest.handler.RequestStatusStore;
-import de.cuioss.nifi.rest.handler.StatusEndpointHandler;
+import de.cuioss.nifi.rest.handler.*;
 import de.cuioss.nifi.rest.server.JettyServerManager;
 import de.cuioss.nifi.rest.validation.JsonSchemaValidator;
 import de.cuioss.tools.logging.CuiLogger;
@@ -502,15 +493,29 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
     }
 
     private void publishDelta(ProcessSession session, String counterName, long count) {
-        long previous = lastPublishedCounts.getOrDefault(counterName, 0L);
-        long delta = count - previous;
+        // RestApiGatewayProcessor is not @TriggerSerially, so concurrent onTrigger threads may
+        // call publishDelta for the same counter at once. A plain get/compute/put would let two
+        // threads read the same baseline and both publish the same delta (double-counting).
+        // ConcurrentHashMap.compute is atomic per key: the baseline read, delta capture, and new
+        // baseline write happen under the bin lock, so the delta for each (current - previous)
+        // transition is captured exactly once. The holder carries the delta out of the lambda.
+        long[] deltaHolder = new long[1];
+        lastPublishedCounts.compute(counterName, (key, previous) -> {
+            long prior = (previous == null) ? 0L : previous;
+            // Re-baseline on a rollback/reset of the cumulative source counter: a decrease must
+            // never publish a negative adjustCounter. The new (lower) value becomes the baseline
+            // so the next genuine increase publishes the correct forward delta.
+            long delta = (count > prior) ? (count - prior) : 0L;
+            deltaHolder[0] = delta;
+            return count;
+        });
+        long delta = deltaHolder[0];
         if (delta > 0) {
             // immediate=true writes through to the FlowController counter repository at once,
             // so the counter persists even on the idle early-return path (where the session is
             // yielded, not committed) and surfaces on NiFi's /nifi-api/counters and
             // /nifi-api/flow/metrics/prometheus endpoints independent of session lifecycle.
             session.adjustCounter(counterName, delta, true);
-            lastPublishedCounts.put(counterName, count);
         }
     }
 

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/RestApiGatewayProcessorTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/RestApiGatewayProcessorTest.java
@@ -16,13 +16,19 @@
  */
 package de.cuioss.nifi.rest;
 
+import de.cuioss.http.security.core.UrlSecurityFailureType;
 import de.cuioss.http.security.database.ApacheCVEAttackDatabase;
 import de.cuioss.http.security.database.AttackTestCase;
 import de.cuioss.http.security.database.ModSecurityCRSAttackDatabase;
 import de.cuioss.http.security.database.OWASPTop10AttackDatabase;
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
 import de.cuioss.nifi.jwt.config.ConfigurationManager;
+import de.cuioss.nifi.jwt.config.JwtAuthenticationConfig;
+import de.cuioss.nifi.jwt.config.JwtIssuerConfigService;
 import de.cuioss.nifi.jwt.test.TestJwtIssuerConfigService;
 import de.cuioss.nifi.rest.handler.GatewaySecurityEvents;
+import de.cuioss.sheriff.oauth.core.domain.token.AccessTokenContent;
+import de.cuioss.sheriff.oauth.core.exception.TokenValidationException;
 import de.cuioss.sheriff.oauth.core.test.TestTokenHolder;
 import de.cuioss.sheriff.oauth.core.test.generator.TestTokenGenerators;
 import de.cuioss.test.generator.Generators;
@@ -32,14 +38,18 @@ import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
 import de.cuioss.test.juli.LogAsserts;
 import de.cuioss.test.juli.TestLogLevel;
 import de.cuioss.test.juli.junit5.EnableTestLogger;
+import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.MockProcessSession;
+import org.apache.nifi.util.SharedSessionState;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.io.IOException;
 import java.net.URI;
@@ -50,9 +60,13 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("RestApiGatewayProcessor")
@@ -318,8 +332,8 @@ class RestApiGatewayProcessorTest {
 
             httpClient.send(
                     HttpRequest.newBuilder(URI.create(
-                                    "http://127.0.0.1:" + port + "/api/users/" + pair.userId() + "/orders/"
-                                            + pair.orderId()))
+                            "http://127.0.0.1:" + port + "/api/users/" + pair.userId() + "/orders/"
+                                    + pair.orderId()))
                             .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                             .GET().build(),
                     HttpResponse.BodyHandlers.ofString());
@@ -388,7 +402,7 @@ class RestApiGatewayProcessorTest {
             try {
                 var response = httpClient.send(
                         HttpRequest.newBuilder(URI.create(
-                                        "http://127.0.0.1:" + port + "/api/users/" + encoded + "/orders/1"))
+                                "http://127.0.0.1:" + port + "/api/users/" + encoded + "/orders/1"))
                                 .header("Authorization", "Bearer " + tokenHolder.getRawToken())
                                 .GET().build(),
                         HttpResponse.BodyHandlers.ofString());
@@ -771,6 +785,229 @@ class RestApiGatewayProcessorTest {
                     HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/api/health"))
                             .GET().build(),
                     HttpResponse.BodyHandlers.ofString());
+        }
+    }
+
+    /**
+     * White-box coverage for {@link RestApiGatewayProcessor#publishCounterDeltas} that drives the
+     * three event sources directly (gateway / cui-http transport / oauth-sheriff token validation)
+     * without an HTTP round-trip. Each source is set on the processor's package-private
+     * {@code AtomicReference} holders, then {@code publishCounterDeltas} is invoked with a
+     * {@link MockProcessSession} whose backing {@link SharedSessionState} exposes the resulting
+     * NiFi counter values. This isolates the cumulative-delta math, the per-source counter-name
+     * derivation, and the null-source guards from the embedded-server paths.
+     */
+    @Nested
+    @DisplayName("Counter Bridge (direct, all sources)")
+    class CounterBridgeDirect {
+
+        private RestApiGatewayProcessor processor;
+        private SharedSessionState sessionState;
+
+        @BeforeEach
+        void initProcessor() {
+            processor = new RestApiGatewayProcessor();
+            sessionState = new SharedSessionState(processor, new AtomicLong(0));
+        }
+
+        private MockProcessSession newSession() {
+            return new MockProcessSession(sessionState, processor, null);
+        }
+
+        @Test
+        @DisplayName("Should publish a gateway event source delta to its NiFi counter")
+        void shouldPublishGatewaySource() {
+            // Arrange
+            var gatewayEvents = new GatewaySecurityEvents();
+            gatewayEvents.increment(GatewaySecurityEvents.EventType.AUTHZ_ROLE_DENIED);
+            gatewayEvents.increment(GatewaySecurityEvents.EventType.AUTHZ_ROLE_DENIED);
+            processor.gatewaySecurityEvents.set(gatewayEvents);
+
+            // Act
+            processor.publishCounterDeltas(newSession());
+
+            // Assert
+            assertEquals(2L, sessionState.getCounterValue(
+                            RestApiGatewayConstants.Counters.GATEWAY_EVENT_PREFIX + "authz_role_denied"),
+                    "Gateway counter must equal the cumulative source count");
+        }
+
+        @Test
+        @DisplayName("Should publish a cui-http transport-security source delta to its NiFi counter")
+        void shouldPublishHttpSecuritySource() {
+            // Arrange
+            var httpEvents = new SecurityEventCounter();
+            httpEvents.increment(UrlSecurityFailureType.PATH_TRAVERSAL_DETECTED);
+            httpEvents.increment(UrlSecurityFailureType.PATH_TRAVERSAL_DETECTED);
+            httpEvents.increment(UrlSecurityFailureType.PATH_TRAVERSAL_DETECTED);
+            processor.httpSecurityEvents.set(httpEvents);
+
+            // Act
+            processor.publishCounterDeltas(newSession());
+
+            // Assert
+            assertEquals(3L, sessionState.getCounterValue(
+                            RestApiGatewayConstants.Counters.HTTP_SECURITY_PREFIX + "path_traversal_detected"),
+                    "HTTP security counter must equal the cumulative source count");
+        }
+
+        @Test
+        @DisplayName("Should publish an oauth-sheriff token-validation source delta to its NiFi counter")
+        void shouldPublishTokenValidationSource() {
+            // Arrange
+            var tokenCounter = new de.cuioss.sheriff.oauth.core.security.SecurityEventCounter();
+            tokenCounter.increment(
+                    de.cuioss.sheriff.oauth.core.security.SecurityEventCounter.EventType.TOKEN_EXPIRED);
+            processor.configService.set(new CounterStubConfigService(tokenCounter));
+
+            // Act
+            processor.publishCounterDeltas(newSession());
+
+            // Assert
+            assertEquals(1L, sessionState.getCounterValue(
+                            RestApiGatewayConstants.Counters.TOKEN_VALIDATION_PREFIX + "token_expired"),
+                    "Token-validation counter must equal the cumulative source count");
+        }
+
+        @Test
+        @DisplayName("Should publish all three sources in a single trigger")
+        void shouldPublishAllThreeSourcesAtOnce() {
+            // Arrange
+            var gatewayEvents = new GatewaySecurityEvents();
+            gatewayEvents.increment(GatewaySecurityEvents.EventType.QUEUE_FULL);
+            processor.gatewaySecurityEvents.set(gatewayEvents);
+
+            var httpEvents = new SecurityEventCounter();
+            httpEvents.increment(UrlSecurityFailureType.NULL_BYTE_INJECTION);
+            processor.httpSecurityEvents.set(httpEvents);
+
+            var tokenCounter = new de.cuioss.sheriff.oauth.core.security.SecurityEventCounter();
+            tokenCounter.increment(
+                    de.cuioss.sheriff.oauth.core.security.SecurityEventCounter.EventType.SIGNATURE_VALIDATION_FAILED);
+            processor.configService.set(new CounterStubConfigService(tokenCounter));
+
+            // Act
+            processor.publishCounterDeltas(newSession());
+
+            // Assert
+            assertEquals(1L, sessionState.getCounterValue(
+                    RestApiGatewayConstants.Counters.GATEWAY_EVENT_PREFIX + "queue_full"));
+            assertEquals(1L, sessionState.getCounterValue(
+                    RestApiGatewayConstants.Counters.HTTP_SECURITY_PREFIX + "null_byte_injection"));
+            assertEquals(1L, sessionState.getCounterValue(
+                    RestApiGatewayConstants.Counters.TOKEN_VALIDATION_PREFIX + "signature_validation_failed"));
+        }
+
+        @Test
+        @DisplayName("Should publish only the incremental delta across successive triggers")
+        void shouldPublishOnlyIncrementalDelta() {
+            // Arrange
+            var gatewayEvents = new GatewaySecurityEvents();
+            processor.gatewaySecurityEvents.set(gatewayEvents);
+            String counter =
+                    RestApiGatewayConstants.Counters.GATEWAY_EVENT_PREFIX + "missing_bearer_token";
+
+            // Act + Assert — first trigger publishes 2
+            gatewayEvents.increment(GatewaySecurityEvents.EventType.MISSING_BEARER_TOKEN);
+            gatewayEvents.increment(GatewaySecurityEvents.EventType.MISSING_BEARER_TOKEN);
+            processor.publishCounterDeltas(newSession());
+            assertEquals(2L, sessionState.getCounterValue(counter));
+
+            // Second trigger with no new events must not republish
+            processor.publishCounterDeltas(newSession());
+            assertEquals(2L, sessionState.getCounterValue(counter),
+                    "No new events must keep the cumulative NiFi counter unchanged");
+
+            // Third trigger after one more event publishes only the +1 delta
+            gatewayEvents.increment(GatewaySecurityEvents.EventType.MISSING_BEARER_TOKEN);
+            processor.publishCounterDeltas(newSession());
+            assertEquals(3L, sessionState.getCounterValue(counter),
+                    "Only the incremental delta must be added to the cumulative NiFi counter");
+        }
+
+        @Test
+        @DisplayName("Should no-op when all sources are unset (null guards)")
+        void shouldNoOpWhenSourcesUnset() {
+            // Arrange — fresh processor: all three AtomicReferences hold null
+
+            // Act
+            processor.publishCounterDeltas(newSession());
+
+            // Assert — no counter is ever created
+            assertNull(sessionState.getCounterValue(
+                            RestApiGatewayConstants.Counters.GATEWAY_EVENT_PREFIX + "missing_bearer_token"),
+                    "Null gateway source must not publish any counter");
+        }
+
+        @Test
+        @DisplayName("Should treat an empty token-validation counter optional as a no-op")
+        void shouldHandleEmptyTokenCounterOptional() {
+            // Arrange — config service present but its counter optional is empty
+            processor.configService.set(new TestJwtIssuerConfigService());
+            var gatewayEvents = new GatewaySecurityEvents();
+            gatewayEvents.increment(GatewaySecurityEvents.EventType.AUTH_FAILED);
+            processor.gatewaySecurityEvents.set(gatewayEvents);
+
+            // Act
+            processor.publishCounterDeltas(newSession());
+
+            // Assert — gateway source still publishes; absent token counter is silently skipped
+            assertEquals(1L, sessionState.getCounterValue(
+                    RestApiGatewayConstants.Counters.GATEWAY_EVENT_PREFIX + "auth_failed"));
+            assertNull(sessionState.getCounterValue(
+                            RestApiGatewayConstants.Counters.TOKEN_VALIDATION_PREFIX + "token_expired"),
+                    "Empty token-validation optional must not create a counter");
+        }
+    }
+
+    @Nested
+    @DisplayName("Counter name derivation")
+    class CounterNameDerivation {
+
+        @ParameterizedTest(name = "[{index}] {0}{1} -> {2}")
+        @CsvSource({
+                "gateway.events.,MISSING_BEARER_TOKEN,gateway.events.missing_bearer_token",
+                "gateway.token.,TOKEN_EXPIRED,gateway.token.token_expired",
+                "gateway.http.security.,PATH_TRAVERSAL_DETECTED,gateway.http.security.path_traversal_detected"
+        })
+        @DisplayName("Should lower-case the event identifier and concatenate it to the prefix")
+        void shouldDeriveCounterName(String prefix, String eventName, String expected) {
+            assertEquals(expected,
+                    RestApiGatewayConstants.Counters.counterName(prefix, eventName),
+                    "Counter name must be the prefix plus the lower-cased event identifier");
+        }
+    }
+
+    /**
+     * Minimal {@link JwtIssuerConfigService} stub that surfaces a pre-populated oauth-sheriff
+     * {@code SecurityEventCounter} so the token-validation publish path in
+     * {@link RestApiGatewayProcessor#publishCounterDeltas} can be exercised directly. The shared
+     * {@link TestJwtIssuerConfigService} always returns an empty counter optional, so it cannot
+     * drive that branch.
+     */
+    private static final class CounterStubConfigService extends AbstractControllerService
+            implements JwtIssuerConfigService {
+
+        private final de.cuioss.sheriff.oauth.core.security.SecurityEventCounter counter;
+
+        private CounterStubConfigService(
+                de.cuioss.sheriff.oauth.core.security.SecurityEventCounter counter) {
+            this.counter = counter;
+        }
+
+        @Override
+        public AccessTokenContent validateToken(String rawToken) throws TokenValidationException {
+            throw new UnsupportedOperationException("not used in counter-bridge tests");
+        }
+
+        @Override
+        public JwtAuthenticationConfig getAuthenticationConfig() {
+            return new JwtAuthenticationConfig(16384, Set.of(), true);
+        }
+
+        @Override
+        public Optional<de.cuioss.sheriff.oauth.core.security.SecurityEventCounter> getSecurityEventCounter() {
+            return Optional.of(counter);
         }
     }
 

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/RestApiGatewayProcessorTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/RestApiGatewayProcessorTest.java
@@ -22,6 +22,7 @@ import de.cuioss.http.security.database.ModSecurityCRSAttackDatabase;
 import de.cuioss.http.security.database.OWASPTop10AttackDatabase;
 import de.cuioss.nifi.jwt.config.ConfigurationManager;
 import de.cuioss.nifi.jwt.test.TestJwtIssuerConfigService;
+import de.cuioss.nifi.rest.handler.GatewaySecurityEvents;
 import de.cuioss.sheriff.oauth.core.test.TestTokenHolder;
 import de.cuioss.sheriff.oauth.core.test.generator.TestTokenGenerators;
 import de.cuioss.test.generator.Generators;
@@ -678,6 +679,98 @@ class RestApiGatewayProcessorTest {
             Path confDir = tempDir.resolve("conf");
             Files.createDirectories(confDir);
             Files.writeString(confDir.resolve("cui-nifi-extensions.properties"), content);
+        }
+    }
+
+    @Nested
+    @DisplayName("Counter Bridge (Tier A)")
+    class CounterBridge {
+
+        private static final String MISSING_BEARER_COUNTER =
+                RestApiGatewayConstants.Counters.GATEWAY_EVENT_PREFIX + "missing_bearer_token";
+
+        @Test
+        @DisplayName("Should bridge a gateway security event to a NiFi counter after onTrigger")
+        void shouldBridgeGatewayEventToNifiCounter() throws Exception {
+            testRunner.run(1, false, true);
+            int port = getServerPort();
+            sendUnauthenticated(port);
+
+            testRunner.run(1, false, false);
+
+            assertEquals(1L, testRunner.getCounterValue(MISSING_BEARER_COUNTER),
+                    "Unauthenticated request should surface one missing_bearer_token NiFi counter");
+        }
+
+        @Test
+        @DisplayName("Should flush event deltas on an idle trigger with no queued request")
+        void shouldFlushDeltasOnIdleTrigger() throws Exception {
+            testRunner.run(1, false, true);
+            int port = getServerPort();
+            sendUnauthenticated(port);
+
+            // Idle tick: the 401 response created no FlowFile, so the queue is empty —
+            // the counter must still publish from the early-return path in onTrigger.
+            testRunner.run(1, false, false);
+
+            assertTrue(testRunner.getFlowFilesForRelationship("health").isEmpty(),
+                    "Unauthenticated request must not create a FlowFile");
+            assertEquals(1L, testRunner.getCounterValue(MISSING_BEARER_COUNTER),
+                    "Idle trigger must still flush the missing_bearer_token delta");
+        }
+
+        @Test
+        @DisplayName("Should not double-count across triggers with no new events")
+        void shouldNotDoubleCountAcrossTriggers() throws Exception {
+            testRunner.run(1, false, true);
+            int port = getServerPort();
+            sendUnauthenticated(port);
+
+            testRunner.run(1, false, false);
+            long afterFirst = testRunner.getCounterValue(MISSING_BEARER_COUNTER);
+            testRunner.run(1, false, false);
+            testRunner.run(1, false, false);
+
+            assertEquals(1L, afterFirst, "First flush should publish exactly one event");
+            assertEquals(1L, testRunner.getCounterValue(MISSING_BEARER_COUNTER),
+                    "Subsequent idle triggers must not republish the same cumulative count");
+        }
+
+        @Test
+        @DisplayName("Should bridge a distinct event type (route-not-found) to its own NiFi counter")
+        void shouldBridgeDistinctEventType() throws Exception {
+            testRunner.run(1, false, true);
+            int port = getServerPort();
+            httpClient.send(
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/api/does-not-exist"))
+                            .header("Authorization", "Bearer " + tokenHolder.getRawToken())
+                            .GET().build(),
+                    HttpResponse.BodyHandlers.ofString());
+
+            testRunner.run(1, false, false);
+
+            String routeNotFoundCounter =
+                    RestApiGatewayConstants.Counters.GATEWAY_EVENT_PREFIX + "route_not_found";
+            assertEquals(1L, testRunner.getCounterValue(routeNotFoundCounter),
+                    "A 404 request should surface one route_not_found NiFi counter");
+        }
+
+        @Test
+        @DisplayName("Should derive counter names through the stable Counters convention")
+        void shouldDeriveStableCounterNames() {
+            String name = RestApiGatewayConstants.Counters.counterName(
+                    RestApiGatewayConstants.Counters.GATEWAY_EVENT_PREFIX,
+                    GatewaySecurityEvents.EventType.AUTH_FAILED.name());
+
+            assertEquals("gateway.events.auth_failed", name,
+                    "Counter name must be the prefix plus the lower-cased event identifier");
+        }
+
+        private void sendUnauthenticated(int port) throws Exception {
+            httpClient.send(
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/api/health"))
+                            .GET().build(),
+                    HttpResponse.BodyHandlers.ofString());
         }
     }
 

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/RestApiGatewayProcessorTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/RestApiGatewayProcessorTest.java
@@ -40,11 +40,7 @@ import de.cuioss.test.juli.TestLogLevel;
 import de.cuioss.test.juli.junit5.EnableTestLogger;
 import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.processor.Relationship;
-import org.apache.nifi.util.MockFlowFile;
-import org.apache.nifi.util.MockProcessSession;
-import org.apache.nifi.util.SharedSessionState;
-import org.apache.nifi.util.TestRunner;
-import org.apache.nifi.util.TestRunners;
+import org.apache.nifi.util.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -60,14 +56,14 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("RestApiGatewayProcessor")
 @EnableTestLogger
@@ -926,6 +922,58 @@ class RestApiGatewayProcessorTest {
         }
 
         @Test
+        @DisplayName("Should re-baseline without a negative counter when the cumulative source rolls back")
+        void shouldReBaselineOnRollback() {
+            // Arrange — a stub source whose cumulative count we can drive up then down to simulate
+            // a rollback/reset of the underlying gateway counter (e.g. a processor restart).
+            var rollbackEvents = new RollbackGatewaySecurityEvents();
+            processor.gatewaySecurityEvents.set(rollbackEvents);
+            String counter =
+                    RestApiGatewayConstants.Counters.GATEWAY_EVENT_PREFIX + "missing_bearer_token";
+
+            // Act + Assert — first trigger publishes the full cumulative 5
+            rollbackEvents.setCount(GatewaySecurityEvents.EventType.MISSING_BEARER_TOKEN, 5L);
+            processor.publishCounterDeltas(newSession());
+            assertEquals(5L, sessionState.getCounterValue(counter),
+                    "First trigger must publish the full cumulative count");
+
+            // Source rolls back to 2 — no negative adjustCounter must be published, the NiFi
+            // counter must stay at 5, and the lower value must become the new baseline.
+            rollbackEvents.setCount(GatewaySecurityEvents.EventType.MISSING_BEARER_TOKEN, 2L);
+            processor.publishCounterDeltas(newSession());
+            assertEquals(5L, sessionState.getCounterValue(counter),
+                    "A rollback must never decrement the cumulative NiFi counter");
+
+            // After re-baselining at 2, the next genuine increase to 4 publishes only the +2 delta
+            // (4 - 2), so the cumulative NiFi counter advances 5 -> 7, not 5 -> 9.
+            rollbackEvents.setCount(GatewaySecurityEvents.EventType.MISSING_BEARER_TOKEN, 4L);
+            processor.publishCounterDeltas(newSession());
+            assertEquals(7L, sessionState.getCounterValue(counter),
+                    "Post-rollback delta must be measured from the re-baselined value");
+        }
+
+        @Test
+        @DisplayName("Should not publish a counter when the very first observed value is a rollback to a lower count")
+        void shouldNotPublishNegativeOnFirstRollbackObservation() {
+            // Arrange — first observed value is non-zero, then drops below it before any publish
+            // could have stored a higher baseline, exercising the previous==null then decrease path.
+            var rollbackEvents = new RollbackGatewaySecurityEvents();
+            processor.gatewaySecurityEvents.set(rollbackEvents);
+            String counter =
+                    RestApiGatewayConstants.Counters.GATEWAY_EVENT_PREFIX + "queue_full";
+            rollbackEvents.setCount(GatewaySecurityEvents.EventType.QUEUE_FULL, 3L);
+            processor.publishCounterDeltas(newSession());
+            rollbackEvents.setCount(GatewaySecurityEvents.EventType.QUEUE_FULL, 0L);
+
+            // Act
+            processor.publishCounterDeltas(newSession());
+
+            // Assert — the rollback to 0 keeps the cumulative NiFi counter at its prior 3
+            assertEquals(3L, sessionState.getCounterValue(counter),
+                    "A rollback to zero must not subtract from the cumulative NiFi counter");
+        }
+
+        @Test
         @DisplayName("Should no-op when all sources are unset (null guards)")
         void shouldNoOpWhenSourcesUnset() {
             // Arrange — fresh processor: all three AtomicReferences hold null
@@ -985,6 +1033,27 @@ class RestApiGatewayProcessorTest {
      * {@link TestJwtIssuerConfigService} always returns an empty counter optional, so it cannot
      * drive that branch.
      */
+    /**
+     * {@link GatewaySecurityEvents} stub whose per-event cumulative count can be driven up
+     * <em>and</em> down via {@link #setCount}, simulating a rollback/reset of the underlying
+     * source counter (e.g. a processor restart). The real {@code GatewaySecurityEvents} only
+     * exposes monotonic {@code increment}, so it cannot drive the re-baseline branch in
+     * {@link RestApiGatewayProcessor#publishCounterDeltas}.
+     */
+    private static final class RollbackGatewaySecurityEvents extends GatewaySecurityEvents {
+
+        private final Map<EventType, Long> counts = new EnumMap<>(EventType.class);
+
+        private void setCount(EventType eventType, long value) {
+            counts.put(eventType, value);
+        }
+
+        @Override
+        public Map<EventType, Long> getAllCounts() {
+            return Map.copyOf(counts);
+        }
+    }
+
     private static final class CounterStubConfigService extends AbstractControllerService
             implements JwtIssuerConfigService {
 

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/HttpRequestContainerTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/HttpRequestContainerTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -152,7 +153,7 @@ class HttpRequestContainerTest {
         @DisplayName("Should defensively copy the supplied path parameters")
         void shouldDefensivelyCopyPathParameters() {
             var token = TestTokenGenerators.accessTokens().next().asAccessTokenContent();
-            var mutable = new java.util.HashMap<String, String>();
+            var mutable = new HashMap<String, String>();
             mutable.put("id", "1");
 
             var container = new HttpRequestContainer(

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,6 @@
     </distributionManagement>
     <properties>
         <javaVersion>21</javaVersion>
-        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <version.nifi>2.10.0</version.nifi>


### PR DESCRIPTION
## Summary

- Adds `doc/reference/metrics-api.adoc` documenting the gateway `/metrics` endpoint contract (path/method, content negotiation, response schemas, authorization model) and frames it as the admin-UI data source with external monitoring on NiFi-native endpoints; cross-links added in `QuickStart.adoc`, `gateway.adoc`, and `configuration.adoc`.
- Bridges gateway metrics into NiFi native counters (Tier A) via `session.adjustCounter` with `immediate=true` in `RestApiGatewayProcessor.onTrigger`, surfacing counters at both `/nifi-api/counters` and `/nifi-api/flow/metrics/prometheus` (`nifi_processor_counters` family).
- Empirically verified that NiFi 2.9 natively exports user counters; Tier B custom `ReportingTask` was evaluated and dropped as redundant.
- Adds `GatewayMetricsPrometheusIT` asserting both `/nifi-api/counters` and `/nifi-api/flow/metrics/prometheus` endpoints.

## Changes

**Documentation (`doc/`)**
- `doc/reference/metrics-api.adoc` — new reference document: full `/metrics` endpoint contract, authorization model (`rest.gateway.management.metrics.*` properties), Prometheus and JSON response schemas for all three metric sources (`tokenValidation`, `httpSecurity`, `gatewayEvents`), forward note on NiFi-native promotion, and endpoint deprecation outlook
- `doc/reference/README.adoc` — cross-link to new `metrics-api.adoc`
- `doc/reference/configuration.adoc` — cross-link to `/metrics` endpoint reference
- `doc/guides/QuickStart.adoc` — forward reference to metrics endpoint
- `doc/architecture/gateway.adoc` — cross-link to metrics reference and NiFi counter integration

**Processor implementation (`nifi-cuioss-rest-processors/`)**
- `RestApiGatewayConstants.java` — stable counter-name constants for all published metrics
- `RestApiGatewayProcessor.java` — Tier A bridge: `session.adjustCounter(name, delta, true)` for all gateway metric deltas in `onTrigger`, including the early-return path (empty-queue yield)
- `RestApiGatewayProcessorTest.java` — unit tests covering counter publication on all paths

**Integration test (`integration-testing/`)**
- `GatewayMetricsPrometheusIT.java` — new Failsafe IT: generates auth failures and token-validation events, then asserts metrics appear at `/nifi-api/counters` and at `/nifi-api/flow/metrics/prometheus` under the `nifi_processor_counters` family; 193/193 integration tests pass

## Test Plan

- [x] Full verify passed (`./mvnw verify`)
- [x] Integration tests passed (193/193) — `verify -Pintegration-tests -pl integration-testing -am`
- [x] Tier B evaluation: NiFi 2.9 natively exports user counters at `/nifi-api/flow/metrics/prometheus`; custom ReportingTask not needed

## Related Issues

No linked issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gateway `/metrics` now publishes bridged security-event counters via NiFi-native counters, updating on each processor trigger and using stable counter naming for the Custom UI Metrics view.
* **Documentation**
  * Expanded the Metrics API reference with the `/metrics` contract (content negotiation, status codes, schemas) plus added cross-references and direct-link anchors across gateway docs and the Quick Start.
* **Tests**
  * Added integration coverage for Prometheus/metrics exposure and expanded processor tests for counter delta publishing, rollback handling, and naming stability.
* **Chores**
  * Minor documentation/test cleanup and updated build compiler property handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->