### PR TITLE
fix(ci): build non-main branches via pull_request so Sonar produces PR analysis

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,8 +1,11 @@
 name: End-to-End Tests
 
 on:
+  # main builds on push; every other branch builds via its pull_request to main.
+  # Non-main branches are not in the push list, so there is one run per PR update and
+  # no push/PR duplicate — superseding the former fork-only `if:` guard.
   push:
-    branches: [main, "feature/*", "fix/*", "chore/*", "release/*", "dependabot/**"]
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -12,7 +15,6 @@ permissions:
 
 jobs:
   e2e-tests:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-integration-tests.yml@14a19791f40f31521ba48fc84d699ef5e52ff7c1 # v0.6.6
     with:
       report-name: e-2-e-playwright

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,8 +1,11 @@
 name: Integration Tests
 
 on:
+  # main builds on push; every other branch builds via its pull_request to main.
+  # Non-main branches are not in the push list, so there is one run per PR update and
+  # no push/PR duplicate — superseding the former fork-only `if:` guard.
   push:
-    branches: [main, "feature/*", "fix/*", "chore/*", "release/*", "dependabot/**"]
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -12,7 +15,6 @@ permissions:
 
 jobs:
   integration-tests:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-integration-tests.yml@14a19791f40f31521ba48fc84d699ef5e52ff7c1 # v0.6.6
     with:
       report-name: integration-testing

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,8 +2,13 @@
 name: Maven Build
 
 on:
+  # main builds on push (the SonarCloud branch baseline that PR analyses diff against).
+  # Every other branch builds via its pull_request to main, which produces a Sonar
+  # pull-request analysis (PR decoration + plan-marshall sonar-roundtrip both rely on it).
+  # Because non-main branches are not in the push list, there is exactly one build per
+  # PR update and no push/PR duplicate — superseding the former fork-only `if:` guard.
   push:
-    branches: [main, "feature/*", "fix/*", "chore/*", "release/*", "dependabot/**"]
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -13,9 +18,6 @@ permissions:
 
 jobs:
   build:
-    # Run on push events, OR on pull_request only if from a fork
-    # This prevents duplicate runs: push handles internal branches, PR handles forks
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@14a19791f40f31521ba48fc84d699ef5e52ff7c1 # v0.6.6
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Problem

For internal (same-repo) branches, `maven.yml`, `integration-tests.yml`, and `e2e-tests.yml` built on the **push** event and skipped the **pull_request** event via a fork-only guard:

```yaml
if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
```

This deliberately prevented duplicate runs — but it meant internal branches only ever got a Sonar **branch** analysis, never a **pull-request** analysis. SonarCloud therefore had no `pullRequest=<n>` data for internal PRs:

- `api/components/show?component=cuioss_nifi-extensions` → **200** (project + main analysis exist)
- `api/measures/component?...&pullRequest=362` → **404** (no PR analysis)

So SonarCloud PR decoration and plan-marshall's `sonar-roundtrip` step (which queries the PR-scoped endpoint) silently got nothing for every internal PR.

## Fix

- **push** trigger restricted to `main` — keeps the SonarCloud main baseline that PR analyses diff against.
- Every other branch builds via its **pull_request** to `main`, producing a Sonar **pull-request** analysis.
- Non-main branches are no longer in the push list, so there is exactly **one build per PR update** and **no push/PR duplicate** — the fork-only `if:` guard is removed.

Applied identically to all three build workflows for consistency.

## Trade-off

A branch push no longer triggers CI until a (draft) PR to `main` exists. This PR itself exercises the new path — its checks run via the `pull_request` event under the changed workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows (e2e tests, integration tests, and Maven builds) so push-triggered runs occur on the `main` branch only.
  * Removed additional job-level execution guards, streamlining CI pipeline behavior to consistently run the appropriate checks for `push` and `pull_request` events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->