### PR TITLE
chore(plan): migrate architecture skill names to the persona/ref/profile rename

### DIFF
--- a/.plan/project-architecture/e-2-e-playwright-maven/enriched.json
+++ b/.plan/project-architecture/e-2-e-playwright-maven/enriched.json
@@ -16,11 +16,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",
@@ -33,15 +33,15 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
-          "skill": "plan-marshall:dev-general-module-testing"
+          "skill": "plan-marshall:persona-module-tester"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",
@@ -58,11 +58,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",

--- a/.plan/project-architecture/e-2-e-playwright-npm/enriched.json
+++ b/.plan/project-architecture/e-2-e-playwright-npm/enriched.json
@@ -28,11 +28,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core JavaScript development standards covering ES modules, modern patterns, and code quality",
@@ -44,15 +44,15 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
-          "skill": "plan-marshall:dev-general-module-testing"
+          "skill": "plan-marshall:persona-module-tester"
         },
         {
           "description": "Core JavaScript development standards covering ES modules, modern patterns, and code quality",
@@ -68,11 +68,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         }
       ]
     }

--- a/.plan/project-architecture/integration-testing/enriched.json
+++ b/.plan/project-architecture/integration-testing/enriched.json
@@ -18,11 +18,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",
@@ -35,15 +35,15 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
-          "skill": "plan-marshall:dev-general-module-testing"
+          "skill": "plan-marshall:persona-module-tester"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",
@@ -60,11 +60,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",

--- a/.plan/project-architecture/nifi-cuioss-api-nar/enriched.json
+++ b/.plan/project-architecture/nifi-cuioss-api-nar/enriched.json
@@ -16,11 +16,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",
@@ -33,15 +33,15 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
-          "skill": "plan-marshall:dev-general-module-testing"
+          "skill": "plan-marshall:persona-module-tester"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",
@@ -58,11 +58,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",

--- a/.plan/project-architecture/nifi-cuioss-api/enriched.json
+++ b/.plan/project-architecture/nifi-cuioss-api/enriched.json
@@ -18,11 +18,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",
@@ -35,15 +35,15 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
-          "skill": "plan-marshall:dev-general-module-testing"
+          "skill": "plan-marshall:persona-module-tester"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",
@@ -60,11 +60,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",

--- a/.plan/project-architecture/nifi-cuioss-common/enriched.json
+++ b/.plan/project-architecture/nifi-cuioss-common/enriched.json
@@ -29,11 +29,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",
@@ -46,15 +46,15 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
-          "skill": "plan-marshall:dev-general-module-testing"
+          "skill": "plan-marshall:persona-module-tester"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",
@@ -71,11 +71,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",

--- a/.plan/project-architecture/nifi-cuioss-nar/enriched.json
+++ b/.plan/project-architecture/nifi-cuioss-nar/enriched.json
@@ -19,11 +19,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",
@@ -36,15 +36,15 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
-          "skill": "plan-marshall:dev-general-module-testing"
+          "skill": "plan-marshall:persona-module-tester"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",
@@ -61,11 +61,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",

--- a/.plan/project-architecture/nifi-cuioss-processors/enriched.json
+++ b/.plan/project-architecture/nifi-cuioss-processors/enriched.json
@@ -21,11 +21,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",
@@ -38,15 +38,15 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
-          "skill": "plan-marshall:dev-general-module-testing"
+          "skill": "plan-marshall:persona-module-tester"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",
@@ -63,11 +63,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",

--- a/.plan/project-architecture/nifi-cuioss-rest-processors/enriched.json
+++ b/.plan/project-architecture/nifi-cuioss-rest-processors/enriched.json
@@ -30,11 +30,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",
@@ -47,15 +47,15 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
-          "skill": "plan-marshall:dev-general-module-testing"
+          "skill": "plan-marshall:persona-module-tester"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",
@@ -72,11 +72,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",

--- a/.plan/project-architecture/nifi-cuioss-ui-maven/enriched.json
+++ b/.plan/project-architecture/nifi-cuioss-ui-maven/enriched.json
@@ -27,11 +27,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",
@@ -44,15 +44,15 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
-          "skill": "plan-marshall:dev-general-module-testing"
+          "skill": "plan-marshall:persona-module-tester"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",
@@ -69,11 +69,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",

--- a/.plan/project-architecture/nifi-cuioss-ui-npm/enriched.json
+++ b/.plan/project-architecture/nifi-cuioss-ui-npm/enriched.json
@@ -21,11 +21,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core JavaScript development standards covering ES modules, modern patterns, and code quality",
@@ -37,15 +37,15 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
-          "skill": "plan-marshall:dev-general-module-testing"
+          "skill": "plan-marshall:persona-module-tester"
         },
         {
           "description": "Core JavaScript development standards covering ES modules, modern patterns, and code quality",
@@ -61,11 +61,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         }
       ]
     }

--- a/.plan/project-architecture/nifi-extensions/enriched.json
+++ b/.plan/project-architecture/nifi-extensions/enriched.json
@@ -25,11 +25,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",
@@ -42,15 +42,15 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
-          "skill": "plan-marshall:dev-general-module-testing"
+          "skill": "plan-marshall:persona-module-tester"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",
@@ -67,11 +67,11 @@
       "defaults": [
         {
           "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:dev-agent-behavior-rules"
+          "skill": "plan-marshall:persona-plan-marshall-agent"
         },
         {
           "description": "Language-agnostic code quality, refactoring, and documentation principles",
-          "skill": "plan-marshall:dev-general-code-quality"
+          "skill": "plan-marshall:ref-code-quality"
         },
         {
           "description": "Core Java patterns including modern features and performance optimization",


### PR DESCRIPTION
plan-marshall renamed three foundation skills in [PR #759](https://github.com/cuioss/plan-marshall/pull/759):

- `dev-agent-behavior-rules` → `persona-plan-marshall-agent`
- `dev-general-module-testing` → `persona-module-tester`
- `dev-general-code-quality` → `ref-code-quality`

This updates the `skills_by_profile` notations across all 12 cached per-module architecture records under `.plan/project-architecture/*/enriched.json` so plan dispatch resolves the renamed skills instead of the now-deleted names. Pure notation rename — the resolved skill set per profile is unchanged.

Config-only; no source changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated skill configuration mappings across multiple project architecture modules to align with new persona-based and reference quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->