### PR TITLE
fix(ui): repair stylelint config so it runs + fix duplicate custom property

### DIFF
--- a/nifi-cuioss-ui/.stylelintrc.cjs
+++ b/nifi-cuioss-ui/.stylelintrc.cjs
@@ -38,6 +38,12 @@ module.exports = {
     // CUI Standards - Quality Rules
     "color-named": "never",
     "max-nesting-depth": 3,
-    "no-descending-specificity": null
+    "no-descending-specificity": null,
+
+    // Allow BEM modifier classes (e.g. .metric-card--active) used in the JS-rendered markup
+    "selector-class-pattern": [
+      "^[a-z][a-z0-9]*(-[a-z0-9]+)*(__[a-z0-9]+(-[a-z0-9]+)*)?(--[a-z0-9]+(-[a-z0-9]+)*)?$",
+      { "message": "Expected class selector to be kebab-case with optional BEM __element / --modifier" }
+    ]
   }
 }

--- a/nifi-cuioss-ui/package-lock.json
+++ b/nifi-cuioss-ui/package-lock.json
@@ -21,7 +21,8 @@
         "jest-environment-jsdom": "^30.4.1",
         "prettier": "^3.8.4",
         "stylelint": "^17.13.0",
-        "stylelint-config-standard": "^40.0.0"
+        "stylelint-config-standard": "^40.0.0",
+        "stylelint-order": "^8.1.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -9260,6 +9261,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/postcss-sorting": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-10.0.0.tgz",
+      "integrity": "sha512-TXbU+h6vVRW+86c/+ewhWq9k7pr7ijASTnepVhCQiC87zAOTkvB1v2dHyWP+ggstSTX/PNvjzS+IOqzejndz9w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "postcss": "^8.4.20"
+      }
+    },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
@@ -9970,6 +9981,23 @@
       },
       "peerDependencies": {
         "stylelint": "^17.0.0"
+      }
+    },
+    "node_modules/stylelint-order": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-8.1.1.tgz",
+      "integrity": "sha512-LqsEB6VggJuu5v10RtkrQsBObcdwBE7GuAOlwfc/LR3VL/w8UqKX2BOLIjhyGt0Gne/njo7gRNGiJAKhfmPMNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^8.5.8",
+        "postcss-sorting": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^16.18.0 || ^17.0.0"
       }
     },
     "node_modules/stylelint/node_modules/@csstools/css-calc": {

--- a/nifi-cuioss-ui/package.json
+++ b/nifi-cuioss-ui/package.json
@@ -43,7 +43,8 @@
     "jest-environment-jsdom": "^30.4.1",
     "prettier": "^3.8.4",
     "stylelint": "^17.13.0",
-    "stylelint-config-standard": "^40.0.0"
+    "stylelint-config-standard": "^40.0.0",
+    "stylelint-order": "^8.1.1"
   },
   "jest": {
     "verbose": false,

--- a/nifi-cuioss-ui/pom.xml
+++ b/nifi-cuioss-ui/pom.xml
@@ -282,6 +282,16 @@
                             <arguments>run lint</arguments>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>npm-stylelint</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <phase>verify</phase>
+                        <configuration>
+                            <arguments>run stylelint</arguments>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/nifi-cuioss-ui/src/main/webapp/css/modules/base.css
+++ b/nifi-cuioss-ui/src/main/webapp/css/modules/base.css
@@ -35,22 +35,22 @@ body {
 }
 
 .jwt-tabs-header .tabs {
+    display: flex;
     margin: 0;
     padding: 0;
-    display: flex;
 }
 
 .jwt-tabs-header .tabs .tab-item {
     display: block;
-    margin-right: 2px;
     padding: 10px 20px;
-    text-decoration: none;
-    color: var(--text-color);
-    background-color: var(--tab-background);
     border: 1px solid var(--border-color);
+    color: var(--text-color);
+    transition: all 0.2s ease;
+    margin-right: 2px;
+    text-decoration: none;
+    background-color: var(--tab-background);
     border-bottom: none;
     border-radius: 4px 4px 0 0;
-    transition: all 0.2s ease;
 }
 
 .jwt-tabs-header .tabs .tab-item:hover {
@@ -87,19 +87,20 @@ body {
 }
 
 /* Enhanced hidden state for loading indicator and other elements */
+
 /* This provides multiple ways to hide the loading indicator for robust test compatibility */
 .hidden,
 #loading-indicator.hidden,
 [aria-hidden="true"],
 #loading-indicator[aria-hidden="true"] {
     display: none !important;
-    visibility: hidden !important;
-    opacity: 0 !important;
-    height: 0 !important;
-    overflow: hidden !important;
     position: absolute !important;
-    left: -9999px !important;
     top: -9999px !important;
+    left: -9999px !important;
+    height: 0 !important;
+    opacity: 0 !important;
+    overflow: hidden !important;
+    visibility: hidden !important;
 }
 
 /* Force hide loading indicator when it has no content */
@@ -942,18 +943,19 @@ button:hover {
 
 .jwt-validator-tabs .tab-pane {
     display: none;
-    animation: fadeIn 0.3s ease-in;
+    animation: fade-in 0.3s ease-in;
 }
 
 .jwt-validator-tabs .tab-pane.active {
     display: block;
 }
 
-@keyframes fadeIn {
+@keyframes fade-in {
     from {
         opacity: 0;
         transform: translateY(10px);
     }
+
     to {
         opacity: 1;
         transform: translateY(0);

--- a/nifi-cuioss-ui/src/main/webapp/css/modules/contextHelp.css
+++ b/nifi-cuioss-ui/src/main/webapp/css/modules/contextHelp.css
@@ -36,25 +36,25 @@
 
 /* Disclosure panel */
 .context-help-panel {
-    border-left: 3px solid var(--primary-color);
-    background: var(--background-secondary);
-    padding: 8px 12px;
     margin: 4px 0 8px;
+    padding: 8px 12px;
+    background: var(--background-secondary);
+    border-left: 3px solid var(--primary-color);
     border-radius: 0 4px 4px 0;
-    animation: contextHelpFadeIn 0.15s ease-in;
+    animation: context-help-fade-in 0.15s ease-in;
 }
 
 .context-help-panel hr {
+    margin: 6px 0;
     border: none;
     border-top: 1px solid var(--border-color-light);
-    margin: 6px 0;
 }
 
 .context-help-description {
+    margin: 0;
     color: var(--text-secondary);
     font-size: 13px;
     line-height: 1.4;
-    margin: 0;
 }
 
 .context-help-property {
@@ -66,9 +66,9 @@
 }
 
 .context-help-property code {
+    padding: 1px 5px;
     background: var(--code-background);
     color: var(--code-color);
-    padding: 1px 5px;
     border-radius: 3px;
     font-family: monospace;
     font-size: 12px;
@@ -84,7 +84,14 @@
     border-top: none !important;
 }
 
-@keyframes contextHelpFadeIn {
-    from { opacity: 0; transform: translateY(-2px); }
-    to   { opacity: 1; transform: translateY(0); }
+@keyframes context-help-fade-in {
+    from {
+        opacity: 0;
+        transform: translateY(-2px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }

--- a/nifi-cuioss-ui/src/main/webapp/css/modules/endpointConfig.css
+++ b/nifi-cuioss-ui/src/main/webapp/css/modules/endpointConfig.css
@@ -306,7 +306,7 @@
 
 .timeout-input-group .field-attachments-timeout-unit {
     width: auto;
-    padding: 4px 4px;
+    padding: 4px;
     border-radius: 0 4px 4px 0;
     border: 1px solid var(--input-border, #ccc);
     font-size: 0.85em;
@@ -374,9 +374,9 @@
 /* Management endpoints section */
 
 .management-endpoints-display {
+    padding: 0 12px 12px;
     background: var(--mgmt-section-bg, #fafafa);
     border-radius: 6px;
-    padding: 0 12px 12px;
     margin-bottom: 16px;
 }
 
@@ -414,7 +414,7 @@
 
 .method-chip-area:focus-within {
     border-color: var(--primary-color, #2196f3);
-    box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.15);
+    box-shadow: 0 0 0 2px rgb(33 150 243 / 15%);
 }
 
 .method-chips {
@@ -454,8 +454,8 @@
 }
 
 .method-chip-remove:hover {
+    background: rgb(21 101 192 / 15%);
     opacity: 1;
-    background: rgba(21, 101, 192, 0.15);
 }
 
 .method-input-wrapper {
@@ -466,12 +466,12 @@
 
 .method-chip-text-input {
     width: 100%;
-    border: none;
-    outline: none;
     padding: 4px 0;
+    border: none;
+    background: transparent;
+    outline: none;
     font-family: inherit;
     font-size: 0.85rem;
-    background: transparent;
 }
 
 /* Override the form-field input styles for the chip text input */
@@ -486,16 +486,16 @@
     display: none;
     position: absolute;
     top: 100%;
-    left: 0;
     right: 0;
+    left: 0;
+    z-index: 100;
     margin: 4px 0 0;
     padding: 4px 0;
-    list-style: none;
-    background: var(--container-background, #fff);
     border: 1px solid var(--border-color, #ccc);
+    background: var(--container-background, #fff);
+    list-style: none;
     border-radius: 3px;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-    z-index: 100;
+    box-shadow: 0 4px 8px rgb(0 0 0 / 10%);
     max-height: 200px;
     overflow-y: auto;
 }
@@ -675,21 +675,21 @@
 
 .property-export-textarea {
     width: 100%;
+    padding: 8px;
+    border: 1px solid var(--border-color, #ccc);
+    background: var(--bg-secondary, #f5f5f5);
     font-family: monospace;
     font-size: 0.85rem;
-    background: var(--bg-secondary, #f5f5f5);
-    border: 1px solid var(--border-color, #ccc);
     border-radius: 3px;
-    padding: 8px;
     resize: vertical;
 }
 
 .copy-properties-button {
-    margin-top: 8px;
     padding: 6px 12px;
     border: 1px solid var(--primary-color, #2196f3);
-    color: var(--primary-color, #2196f3);
     background: transparent;
+    color: var(--primary-color, #2196f3);
+    margin-top: 8px;
     border-radius: 3px;
     cursor: pointer;
     font-size: 0.8rem;
@@ -717,7 +717,7 @@
 
 .auth-mode-chip-area:focus-within {
     border-color: var(--primary-color, #2196f3);
-    box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.15);
+    box-shadow: 0 0 0 2px rgb(33 150 243 / 15%);
 }
 
 .auth-mode-chips {
@@ -757,8 +757,8 @@
 }
 
 .auth-mode-chip-remove:hover {
+    background: rgb(21 101 192 / 15%);
     opacity: 1;
-    background: rgba(21, 101, 192, 0.15);
 }
 
 .auth-mode-input-wrapper {
@@ -769,12 +769,12 @@
 
 .auth-mode-chip-text-input {
     width: 100%;
-    border: none;
-    outline: none;
     padding: 4px 0;
+    border: none;
+    background: transparent;
+    outline: none;
     font-family: inherit;
     font-size: 0.85rem;
-    background: transparent;
 }
 
 /* Override the form-field input styles for the auth-mode chip text input */
@@ -789,16 +789,16 @@
     display: none;
     position: absolute;
     top: 100%;
-    left: 0;
     right: 0;
+    left: 0;
+    z-index: 100;
     margin: 4px 0 0;
     padding: 4px 0;
-    list-style: none;
-    background: var(--container-background, #fff);
     border: 1px solid var(--border-color, #ccc);
+    background: var(--container-background, #fff);
+    list-style: none;
     border-radius: 3px;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-    z-index: 100;
+    box-shadow: 0 4px 8px rgb(0 0 0 / 10%);
     max-height: 200px;
     overflow-y: auto;
 }
@@ -870,10 +870,10 @@
 
 /* Route form sections (fieldset grouping) */
 .route-form-section {
+    margin: 0 0 12px;
+    padding: 12px 0 0;
     border: none;
     border-top: 1px solid var(--border-light, #eee);
-    margin: 0 0 12px 0;
-    padding: 12px 0 0 0;
     min-width: 0; /* Firefox fieldset fix */
 }
 
@@ -883,11 +883,11 @@
 }
 
 .route-form-section-title {
+    padding: 0 4px;
+    color: var(--text-muted, #666);
     font-size: 0.85rem;
     font-weight: 600;
-    color: var(--text-muted, #666);
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    padding: 0 4px;
     margin-bottom: 8px;
 }

--- a/nifi-cuioss-ui/src/main/webapp/css/modules/endpointTester.css
+++ b/nifi-cuioss-ui/src/main/webapp/css/modules/endpointTester.css
@@ -127,7 +127,7 @@
     font-family: monospace;
     font-size: 0.8rem;
     white-space: pre-wrap;
-    word-break: break-word;
+    overflow-wrap: break-word;
     max-height: 400px;
     overflow-y: auto;
     border-top: 1px solid var(--border-light, #eee);
@@ -182,9 +182,9 @@
 }
 
 .token-fetch-body {
+    display: flex;
     padding: 12px;
     border-top: 1px solid var(--border-color, #ccc);
-    display: flex;
     flex-direction: column;
     gap: var(--spacing-sm, 8px);
 }
@@ -227,14 +227,14 @@
 }
 
 .discover-btn {
+    height: fit-content;
     padding: 6px 12px;
     border: 1px solid var(--border-color, #ccc);
-    border-radius: 4px;
     background: var(--bg-secondary, #f5f5f5);
+    border-radius: 4px;
     cursor: pointer;
     font-size: 0.8rem;
     white-space: nowrap;
-    height: fit-content;
 }
 
 .discover-btn:hover {

--- a/nifi-cuioss-ui/src/main/webapp/css/modules/help.css
+++ b/nifi-cuioss-ui/src/main/webapp/css/modules/help.css
@@ -5,9 +5,9 @@
 
 /* Help Tab Container */
 .help-tab {
+    margin: 0 auto;
     padding: 20px;
     max-width: 900px;
-    margin: 0 auto;
 }
 
 .help-header {
@@ -28,27 +28,27 @@
 }
 
 .help-section {
-    margin-bottom: 25px;
-    background: var(--background-light, #fff);
     border: 1px solid var(--border-color, #ddd);
-    border-radius: 4px;
+    background: var(--background-light, #fff);
     overflow: hidden;
+    margin-bottom: 25px;
+    border-radius: 4px;
 }
 
 /* Collapsible Headers */
 .collapsible-header {
+    display: flex;
     margin: 0;
     padding: 15px 20px;
-    background: var(--background-secondary, #f5f5f5);
     border: none;
+    background: var(--background-secondary, #f5f5f5);
+    color: var(--text-primary, #333);
+    transition: background-color 0.2s ease;
     cursor: pointer;
     user-select: none;
-    transition: background-color 0.2s ease;
-    display: flex;
     align-items: center;
     font-size: 16px;
     font-weight: 600;
-    color: var(--text-primary, #333);
 }
 
 .collapsible-header:hover {
@@ -105,12 +105,12 @@
 .collapsible-content code {
     display: inline-block;
     padding: 2px 6px;
-    background: var(--code-background, #f5f5f5);
     border: 1px solid var(--border-color-light, #eee);
-    border-radius: 3px;
-    font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
-    font-size: 13px;
+    background: var(--code-background, #f5f5f5);
     color: var(--code-color, #d14);
+    border-radius: 3px;
+    font-family: Consolas, Monaco, 'Courier New', monospace;
+    font-size: 13px;
 }
 
 .example-config {
@@ -130,10 +130,10 @@
 .example-config code {
     display: block;
     padding: 8px;
-    margin-top: 5px;
-    background: transparent;
     border: none;
+    background: transparent;
     color: var(--text-primary, #333);
+    margin-top: 5px;
 }
 
 /* Resource Links */
@@ -147,11 +147,11 @@
 }
 
 .resource-links a {
-    color: var(--primary-color, #1976d2);
-    text-decoration: none;
     display: inline-flex;
-    align-items: center;
+    color: var(--primary-color, #1976d2);
     transition: color 0.2s ease;
+    text-decoration: none;
+    align-items: center;
 }
 
 .resource-links a:hover {
@@ -182,7 +182,7 @@
 }
 
 /* Responsive Design */
-@media (max-width: 768px) {
+@media (width <= 768px) {
     .help-tab {
         padding: 15px;
     }

--- a/nifi-cuioss-ui/src/main/webapp/css/modules/icons.css
+++ b/nifi-cuioss-ui/src/main/webapp/css/modules/icons.css
@@ -1,7 +1,7 @@
 /**
  * Font Awesome font-family overrides.
  *
- * NiFi's SystemTokensService injects a massive <style> element (~230 KB) into
+ * NiFi's SystemTokensService injects a massive \3c style> element (~230 KB) into
  * the Custom UI iframe for theme propagation.  That injected CSS:
  *   1. Sets content: "" on every FA ::before pseudo-element, wiping icon glyphs
  *   2. Sets font-family: "Font Awesome 6 Free" via general .fa rules

--- a/nifi-cuioss-ui/src/main/webapp/css/modules/issuerConfigEditor.css
+++ b/nifi-cuioss-ui/src/main/webapp/css/modules/issuerConfigEditor.css
@@ -225,12 +225,12 @@
 /* Info message for missing CS configuration */
 
 .config-info-message {
+    margin: 15px 0;
     padding: 16px;
     border: 1px solid var(--primary-color, #2196f3);
-    border-radius: 4px;
     background: var(--info-bg, #e3f2fd);
     color: var(--text-color, #333);
-    margin: 15px 0;
+    border-radius: 4px;
 }
 
 .config-info-message i {

--- a/nifi-cuioss-ui/src/main/webapp/css/modules/metrics.css
+++ b/nifi-cuioss-ui/src/main/webapp/css/modules/metrics.css
@@ -35,7 +35,7 @@
 
 .metric-card:hover {
     transform: translateY(-1px);
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 2px 6px rgb(0 0 0 / 8%);
 }
 
 .metric-card--active {
@@ -57,7 +57,7 @@
 }
 
 .metric-card h4 {
-    margin: 0 0 4px 0;
+    margin: 0 0 4px;
     font-size: 12px;
     font-weight: 600;
     color: var(--text-secondary, #666);
@@ -101,7 +101,7 @@
 }
 
 .gateway-metrics-section h3 {
-    margin: 0 0 8px 0;
+    margin: 0 0 8px;
     font-size: 15px;
     color: var(--text-primary, #333);
 }
@@ -125,6 +125,7 @@
 /* Metrics action buttons — outlined style matching endpoint config buttons */
 #refresh-metrics-btn,
 #export-metrics-btn {
+    margin: 0 0 0 8px;
     padding: 4px 10px;
     border: 1px solid var(--primary-color, #0074d9);
     color: var(--primary-color, #0074d9);
@@ -132,7 +133,6 @@
     border-radius: 3px;
     font-size: 0.8rem;
     font-weight: 500;
-    margin: 0 0 0 8px;
 }
 
 #refresh-metrics-btn:hover,
@@ -155,21 +155,21 @@
 }
 
 .metrics-summary .metric-card {
-    background: var(--background-light, #fff);
-    border: 1px solid var(--border-color, #ddd);
-    border-radius: 4px;
     padding: 20px;
+    border: 1px solid var(--border-color, #ddd);
+    background: var(--background-light, #fff);
     text-align: center;
     transition: transform 0.2s ease;
+    border-radius: 4px;
 }
 
 .metrics-summary .metric-card:hover {
     transform: translateY(-2px);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 2px 8px rgb(0 0 0 / 10%);
 }
 
 .metrics-summary .metric-card h4 {
-    margin: 0 0 10px 0;
+    margin: 0 0 10px;
     font-size: 14px;
     color: var(--text-secondary, #666);
     font-weight: normal;
@@ -186,10 +186,10 @@
 }
 
 .metrics-list {
-    background: var(--background-light, #fff);
-    border: 1px solid var(--border-color, #ddd);
-    border-radius: 4px;
     padding: 15px;
+    border: 1px solid var(--border-color, #ddd);
+    background: var(--background-light, #fff);
+    border-radius: 4px;
 }
 
 .issuer-metric-item {
@@ -261,16 +261,16 @@
 .metrics-loading,
 .no-data,
 .no-errors {
-    text-align: center;
     padding: 20px;
     color: var(--text-secondary, #666);
+    text-align: center;
     font-style: italic;
 }
 
 .metrics-error {
-    text-align: center;
     padding: 40px;
     color: var(--error-color, #d32f2f);
+    text-align: center;
 }
 
 .metrics-error i {
@@ -284,13 +284,14 @@
 }
 
 /* Metrics not available state - consistent with error-message styling */
+
 /* Export options panel - hidden by default, shown via JS class toggle */
 .export-options {
     display: none;
-    margin-top: 15px;
     padding: 10px;
-    background: var(--background-light, #f5f5f5);
     border: 1px solid var(--border-color, #ddd);
+    background: var(--background-light, #f5f5f5);
+    margin-top: 15px;
     border-radius: 4px;
 }
 
@@ -299,7 +300,7 @@
 }
 
 .export-options h3 {
-    margin: 0 0 10px 0;
+    margin: 0 0 10px;
 }
 
 .export-options .btn {
@@ -322,12 +323,12 @@
 .metrics-not-available {
     display: flex;
     position: relative;
+    margin: 20px;
     padding: 12px 16px;
     border: 1px solid #fff3e0;
     color: #b23c00;
     background-color: #fff3e0;
     border-radius: 6px;
-    margin: 20px;
     box-shadow: 0 2px 4px rgb(255 152 0 / 10%);
     animation: error-slide-in 0.3s ease-out;
 }
@@ -345,7 +346,7 @@
 }
 
 .metrics-not-available h3 {
-    margin: 0 0 8px 0;
+    margin: 0 0 8px;
     font-size: 16px;
     font-weight: 600;
 }

--- a/nifi-cuioss-ui/src/main/webapp/css/modules/tokenVerifier.css
+++ b/nifi-cuioss-ui/src/main/webapp/css/modules/tokenVerifier.css
@@ -152,10 +152,10 @@
 
 /* Token expiration status styling */
 .verification-status {
+    display: flex;
     padding: 10px;
     border-radius: 5px;
     margin-bottom: 15px;
-    display: flex;
     align-items: center;
     gap: 10px;
     font-size: 16px;
@@ -163,19 +163,19 @@
 }
 
 .verification-status.valid {
-    background-color: rgba(40, 167, 69, 0.1);
+    background-color: rgb(40 167 69 / 10%);
     border: 1px solid #28a745;
     color: #052912;
 }
 
 .verification-status.invalid {
-    background-color: rgba(220, 53, 69, 0.1);
+    background-color: rgb(220 53 69 / 10%);
     border: 1px solid #dc3545;
-    color: #000000;
+    color: #000;
 }
 
 .verification-status.expired {
-    background-color: rgba(255, 193, 7, 0.1);
+    background-color: rgb(255 193 7 / 10%);
     border: 1px solid #ffc107;
     color: #5a4302;
 }
@@ -186,7 +186,7 @@
 
 /* Token expiration styling in claims */
 .claim.expired {
-    background-color: rgba(255, 193, 7, 0.1);
+    background-color: rgb(255 193 7 / 10%);
     padding: 8px;
     border-radius: 3px;
     border-left: 4px solid #ffc107;
@@ -208,7 +208,7 @@
 }
 
 .token-section h4 {
-    margin: 0 0 10px 0;
+    margin: 0 0 10px;
     color: var(--primary-color);
 }
 
@@ -226,8 +226,8 @@
 .verification-error {
     margin-top: 15px;
     padding: 10px;
-    background-color: rgba(220, 53, 69, 0.1);
+    background-color: rgb(220 53 69 / 10%);
     border: 1px solid #dc3545;
     border-radius: 5px;
-    color: #000000;
+    color: #000;
 }

--- a/nifi-cuioss-ui/src/main/webapp/css/modules/variables.css
+++ b/nifi-cuioss-ui/src/main/webapp/css/modules/variables.css
@@ -3,7 +3,7 @@
 :root {
     /* Primary colors */
     --primary-color: #0074d9;
-    --primary-color-dark: #0063b1;
+    --primary-color-dark: #1565c0;
     --primary-color-rgb: 0, 116, 217;
 
     /* Success colors */
@@ -39,7 +39,6 @@
     --text-primary: #333;
     --text-secondary: #666;
     --primary-color-light: #e3f2fd;
-    --primary-color-dark: #1565c0;
     --code-background: #f8f8f8;
     --code-color: #d14;
 }

--- a/nifi-cuioss-ui/src/main/webapp/css/styles.css
+++ b/nifi-cuioss-ui/src/main/webapp/css/styles.css
@@ -10,7 +10,7 @@
 @import url('modules/base.css');
 
 /* icons.css is loaded via <link> in index.html (not @import) to ensure
-   !important rules correctly override NiFi's dynamically injected <style>. */
+   !important rules correctly override NiFi's dynamically injected \3c style>. */
 
 /* Import component-specific styles */
 @import url('modules/jwksValidator.css');
@@ -27,12 +27,12 @@
     position: absolute;
     width: 1px;
     height: 1px;
-    padding: 0;
     margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
+    padding: 0;
     border: 0;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
 }
 
 .hidden {


### PR DESCRIPTION
Follow-up to #400 — stacked on `chore/stylelint-17-migration` (base = that branch, so this diff shows only the repair). Merge **after** #400.

`npm run stylelint` was silently broken and was never wired into the Maven build, so the config rotted unnoticed.

## Repairs
- **Config wouldn't load**: `.stylelintrc.js` used CommonJS `module.exports` under a `"type": "module"` package → stylelint 17's loader threw `ERR_INTERNAL_ASSERTION`. Renamed to **`.stylelintrc.cjs`**.
- **Missing plugin**: config referenced `stylelint-order`, which wasn't installed. Added it to devDependencies.
- **Not enforced**: wired `npm run stylelint` into the frontend-maven-plugin (`verify` phase, mirroring `npm-lint`) so it's a CI gate going forward.

## Violations fixed (115 surfaced once the linter actually ran)
- **`variables.css`** — removed a **duplicate `--primary-color-dark`**. Both definitions were in the same `:root`, so the cascade already made `#1565c0` (the later one) the effective value; kept `#1565c0` in the primary-colors group and dropped the dupe. ⚠️ If `#0063b1` was the intended shade, flip line 6.
- **`styles.css`** — deprecated `clip: rect(...)` in `.sr-only` → modern `clip-path: inset(50%)` (same visually-hidden behavior).
- **`endpointTester.css`** — deprecated `word-break: break-word` → `overflow-wrap: break-word`.
- **`base.css` / `contextHelp.css`** — camelCase `@keyframes` → kebab-case (refs are CSS-local), and expanded single-line keyframe steps.
- **`.stylelintrc.cjs`** — relaxed `selector-class-pattern` to allow the existing BEM `--modifier` classes (e.g. `.metric-card--active`, rendered from `metrics.js`).
- Everything else is `stylelint --fix` auto-correction: modern color-function notation, hex shortening, shorthand cleanup, property ordering — all semantically equivalent.

## Verification
- ✅ `npm run stylelint` clean (0 problems)
- ✅ Frontend build + new `npm-stylelint` gate
- ✅ `clean install`
- ✅ 193 integration tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hiding behavior for loading and screen-reader-only elements for better accessibility and test reliability.
  * Updated text wrapping in response views so long content breaks more cleanly.

* **Style**
  * Modernized and standardized visual styling across several UI screens, including spacing, hover effects, and responsive rules.
  * Updated theme color values and refined animation naming for consistent presentation.

* **Chores**
  * Added stylesheet validation to the build and updated style-related dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->