### PR TITLE
fix(rest): repair failure path, IPv6 loopback detection, and gateway hardening

### DIFF
--- a/doc/architecture/gateway.adoc
+++ b/doc/architecture/gateway.adoc
@@ -13,9 +13,9 @@ The `GatewayRequestHandler` processes each request through a 7-stage pipeline:
 1. **Input Sanitization**: Normalizes path, query parameters, and headers using cui-http `PipelineSet`. Returns 400 on invalid input.
 2. **Route Lookup**: Matches the sanitized path against configured routes using three ordered passes -- exact match, then prefix match, then pattern match against compiled `{placeholder}` route templates. The first pass to hit wins, so a literal path that also matches a pattern resolves to its exact handler. Pattern matches additionally extract the path parameters (see <<Path-Parameter Routes>>). Returns 404 if no pass matches.
 3. **Method Check**: Verifies the HTTP method is allowed for the matched route. Returns 405 with `Allow` header if not.
-4. **Body Size Check**: Reads the request body up to the configured maximum size (per-route or global). Returns 413 if the body exceeds the limit. This runs before authentication to avoid wasting CPU on oversized payloads.
-5. **JWT Authentication**: Auth-mode dispatch per endpoint: extracts `Bearer` token from the `Authorization` header and validates it via `JwtIssuerConfigService.validateToken()`. Returns 401 with `WWW-Authenticate: Bearer` on failure. Skipped for `NONE` and loopback `LOCAL_ONLY` requests.
-6. **Authorization**: Validates required roles and scopes using `AuthorizationValidator`. Returns 403 (missing roles) or 401 with `insufficient_scope` (missing scopes). Skipped when the route has no role or scope requirements.
+4. **JWT Authentication**: Auth-mode dispatch per endpoint: extracts `Bearer` token from the `Authorization` header and validates it via `JwtIssuerConfigService.validateToken()`. Returns 401 with `WWW-Authenticate: Bearer` on failure. Skipped for `NONE` and loopback `LOCAL_ONLY` requests. This runs before the body is read so unauthenticated clients cannot force the gateway to buffer request payloads.
+5. **Authorization**: Validates required roles and scopes using `AuthorizationValidator`. Returns 403 for missing roles and 403 with `insufficient_scope` for missing scopes (RFC 6750 Section 3.1). Skipped when the route has no role or scope requirements.
+6. **Body Size Check**: Reads the request body up to the configured maximum size (per-route or global). Returns 413 if the body exceeds the limit.
 7. **Delegate to Handler**: The matched `EndpointHandler.process()` executes handler-specific logic. For API routes (`ApiRouteHandler`), this includes optional JSON Schema validation (returns 422 on failure via `schemaPath`) and enqueue of `HttpRequestContainer` for `onTrigger` processing (returns 503 if the queue is full).
 
 All error responses use RFC 9457 `application/problem+json` format via `ProblemDetail`. See link:../reference/error-reference.adoc[Error Reference] for the full error type table.
@@ -294,7 +294,7 @@ Management endpoint auth-mode is configured via static NiFi properties:
 
 |400 |Bad Request |Input sanitization failed (malformed path, query, or headers)
 |401 |Unauthorized |Missing or invalid Bearer token; includes `WWW-Authenticate: Bearer` per RFC 6750
-|403 |Forbidden |Valid token but missing required roles for the matched route
+|403 |Forbidden |Valid token but missing required roles or scopes (`insufficient_scope`) for the matched route
 |404 |Not Found |No route configured for the requested path
 |405 |Method Not Allowed |Route exists but HTTP method not in allowed set; includes `Allow` header
 |409 |Conflict |Attachment limit reached or attachment window closed
@@ -314,7 +314,7 @@ Management endpoint auth-mode is configured via static NiFi properties:
 |MISSING_BEARER_TOKEN |401 |No Authorization header or malformed Bearer prefix
 |AUTH_FAILED |401 |Token validation failed (expired, bad signature, etc.)
 |AUTHZ_ROLE_DENIED |403 |Valid token but missing required roles
-|AUTHZ_SCOPE_DENIED |401 |Valid token but missing required scopes
+|AUTHZ_SCOPE_DENIED |403 |Valid token but missing required scopes (`insufficient_scope`, RFC 6750 Section 3.1)
 |BODY_TOO_LARGE |413 |Request body exceeds configured maximum
 |ROUTE_NOT_FOUND |404 |No route configured for requested path
 |METHOD_NOT_ALLOWED |405 |Route exists but HTTP method not allowed

--- a/doc/reference/error-reference.adoc
+++ b/doc/reference/error-reference.adoc
@@ -36,9 +36,9 @@ The `type` field links to this documentation page. Error responses are produced 
 |Missing or invalid Bearer token. Includes `WWW-Authenticate: Bearer` header per RFC 6750.
 |`Missing or malformed Authorization header`
 
-|401
-|Unauthorized
-|Valid token but missing required scopes. Includes `WWW-Authenticate: Bearer error="insufficient_scope", scope="<required>"`.
+|403
+|Forbidden
+|Valid token but missing required scopes (RFC 6750 Section 3.1). Includes `WWW-Authenticate: Bearer error="insufficient_scope", scope="<required>"`.
 |`Insufficient scopes: Missing scopes: [read]`
 
 |403

--- a/doc/reference/metrics-api.adoc
+++ b/doc/reference/metrics-api.adoc
@@ -102,7 +102,7 @@ Security Events] table.
 |`MISSING_BEARER_TOKEN` |401 |No Authorization header or malformed Bearer prefix
 |`AUTH_FAILED` |401 |Token validation failed (expired, bad signature, etc.)
 |`AUTHZ_ROLE_DENIED` |403 |Valid token but missing required roles
-|`AUTHZ_SCOPE_DENIED` |401 |Valid token but missing required scopes (step-up)
+|`AUTHZ_SCOPE_DENIED` |403 |Valid token but missing required scopes (`insufficient_scope`, RFC 6750 Section 3.1)
 |`BODY_TOO_LARGE` |413 |Request body exceeds the configured maximum size
 |`ROUTE_NOT_FOUND` |404 |No route configured for the requested path
 |`METHOD_NOT_ALLOWED` |405 |Route exists but the HTTP method is not allowed

--- a/nifi-cuioss-common/pom.xml
+++ b/nifi-cuioss-common/pom.xml
@@ -160,6 +160,18 @@
                     </ignoredDependencies>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/nifi-cuioss-common/src/main/java/de/cuioss/nifi/jwt/util/AuthorizationRequirements.java
+++ b/nifi-cuioss-common/src/main/java/de/cuioss/nifi/jwt/util/AuthorizationRequirements.java
@@ -123,7 +123,14 @@ Set<String> requiredScopes) {
         return new AuthorizationRequirements(requireValid, roles, scopes);
     }
 
-    private static Set<String> parseCommaSeparated(@Nullable String value) {
+    /**
+     * Parses a comma-separated string into a set of trimmed, non-empty values.
+     * Shared by processors that read comma-separated role/scope properties.
+     *
+     * @param value the raw comma-separated value (may be null or blank)
+     * @return the parsed set, or an empty set for null/blank input
+     */
+    public static Set<String> parseCommaSeparated(@Nullable String value) {
         if (value == null || value.isBlank()) {
             return Set.of();
         }

--- a/nifi-cuioss-rest-processors/pom.xml
+++ b/nifi-cuioss-rest-processors/pom.xml
@@ -146,6 +146,18 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayProcessor.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayProcessor.java
@@ -46,17 +46,20 @@ import org.apache.nifi.ssl.SSLContextProvider;
 import javax.net.ssl.SSLContext;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+
+import static de.cuioss.nifi.jwt.util.AuthorizationRequirements.parseCommaSeparated;
 
 /**
  * Multi-route REST API gateway with embedded HTTP server, JWT authentication,
@@ -205,6 +208,9 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
 
         if (routes.isEmpty()) {
             LOGGER.warn(RestApiLogMessages.WARN.INVALID_ROUTE_CONFIG, "(none)");
+            // Clear relationships from a previous schedule so stale routes do not survive;
+            // the embedded server (incl. management endpoints) is intentionally not started.
+            updateDynamicRelationships(List.of());
             return;
         }
 
@@ -225,8 +231,8 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
         int maxRequestSize = context.getProperty(RestApiGatewayConstants.Properties.MAX_REQUEST_SIZE).asInteger();
         int port = context.getProperty(RestApiGatewayConstants.Properties.LISTENING_PORT).asInteger();
 
-        // Build JSON Schema validator from route configurations
-        JsonSchemaValidator schemaValidator = buildSchemaValidator(routes);
+        // Build JSON Schema validator from route configurations (absent when no route uses one)
+        JsonSchemaValidator schemaValidator = buildSchemaValidator(routes).orElse(null);
 
         // Pre-create shared event counters so all handlers + dispatcher share them.
         // Held as fields so onTrigger can bridge their cumulative counts to NiFi counters.
@@ -370,8 +376,9 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
             return;
         }
 
+        FlowFile flowFile = null;
         try {
-            FlowFile flowFile = session.create();
+            flowFile = session.create();
 
             // Set route attributes
             Map<String, String> attributes = new HashMap<>();
@@ -389,6 +396,11 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
             // Set query parameters
             container.queryParameters().forEach((key, value) ->
                     attributes.put(RestApiAttributes.QUERY_PARAM_PREFIX + key, value));
+
+            // Set sanitized request headers (Authorization is excluded upstream);
+            // header names are lowercased for deterministic attribute keys
+            container.headers().forEach((name, value) ->
+                    attributes.put(RestApiAttributes.HEADER_PREFIX + name.toLowerCase(Locale.ROOT), value));
 
             // Set path parameters extracted from a pattern-matched route
             container.pathParameters().forEach((key, value) ->
@@ -445,6 +457,12 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
 
         } catch (ProcessException e) {
             LOGGER.error(e, RestApiLogMessages.ERROR.FLOWFILE_CREATION_FAILED, container.routeName(), e.getMessage());
+            // Remove the partially-built FlowFile: leaving it neither transferred nor removed
+            // makes the session commit throw FlowFileHandlingException, which would roll back
+            // the error FlowFile too and the failure relationship would never receive anything.
+            if (flowFile != null) {
+                session.remove(flowFile);
+            }
             FlowFile errorFile = session.create();
             errorFile = session.putAttribute(errorFile, "error.message", e.getMessage());
             session.transfer(errorFile, RestApiGatewayConstants.Relationships.FAILURE);
@@ -531,7 +549,7 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
         LOGGER.info(RestApiLogMessages.INFO.PROCESSOR_STOPPED, drained);
     }
 
-    private static JsonSchemaValidator buildSchemaValidator(List<RouteConfiguration> routes) {
+    private static Optional<JsonSchemaValidator> buildSchemaValidator(List<RouteConfiguration> routes) {
         Map<String, String> routeSchemas = new HashMap<>();
         for (RouteConfiguration route : routes) {
             if (route.hasSchemaValidation()) {
@@ -540,19 +558,9 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
             }
         }
         if (routeSchemas.isEmpty()) {
-            return null;
+            return Optional.empty();
         }
-        return new JsonSchemaValidator(routeSchemas);
-    }
-
-    private static Set<String> parseCommaSeparated(String value) {
-        if (value == null || value.isBlank()) {
-            return Set.of();
-        }
-        return Arrays.stream(value.split(","))
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
-                .collect(Collectors.toUnmodifiableSet());
+        return Optional.of(new JsonSchemaValidator(routeSchemas));
     }
 
     private void updateDynamicRelationships(List<RouteConfiguration> routes) {

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayProcessor.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayProcessor.java
@@ -398,9 +398,13 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
                     attributes.put(RestApiAttributes.QUERY_PARAM_PREFIX + key, value));
 
             // Set sanitized request headers (Authorization is excluded upstream);
-            // header names are lowercased for deterministic attribute keys
-            container.headers().forEach((name, value) ->
-                    attributes.put(RestApiAttributes.HEADER_PREFIX + name.toLowerCase(Locale.ROOT), value));
+            // header names are lowercased for deterministic attribute keys.
+            // Null values are skipped — FlowFile attributes reject null.
+            container.headers().forEach((name, value) -> {
+                if (value != null) {
+                    attributes.put(RestApiAttributes.HEADER_PREFIX + name.toLowerCase(Locale.ROOT), value);
+                }
+            });
 
             // Set path parameters extracted from a pattern-matched route
             container.pathParameters().forEach((key, value) ->

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiLogMessages.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiLogMessages.java
@@ -147,6 +147,18 @@ public final class RestApiLogMessages {
                 .template("Route '%s' has createFlowFile=false — skipping FlowFile creation")
                 .build();
 
+        public static final LogRecord SCHEMA_REGISTERED_INLINE = LogRecordModel.builder()
+                .prefix(PREFIX)
+                .identifier(19)
+                .template("Registered inline JSON Schema for route '%s'")
+                .build();
+
+        public static final LogRecord SCHEMA_REGISTERED_FROM_FILE = LogRecordModel.builder()
+                .prefix(PREFIX)
+                .identifier(20)
+                .template("Registered JSON Schema for route '%s' from %s")
+                .build();
+
     }
 
     @UtilityClass

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/config/RouteConfigurationParser.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/config/RouteConfigurationParser.java
@@ -32,6 +32,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static de.cuioss.nifi.jwt.util.AuthorizationRequirements.parseCommaSeparated;
+
 /**
  * Parses {@code restapi.*} dynamic properties into {@link RouteConfiguration} instances.
  * <p>
@@ -187,13 +189,6 @@ public class RouteConfigurationParser {
                 .stream()
                 .map(String::toUpperCase)
                 .collect(Collectors.toUnmodifiableSet());
-    }
-
-    private static Set<String> parseCommaSeparated(String value) {
-        if (value == null || value.isBlank()) {
-            return Set.of();
-        }
-        return Set.copyOf(Splitter.on(',').trimResults().omitEmptyStrings().splitToList(value));
     }
 
     private static int parsePositiveInt(String value, int defaultValue) {

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/ApiRouteHandler.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/ApiRouteHandler.java
@@ -24,7 +24,6 @@ import de.cuioss.nifi.rest.validation.JsonSchemaValidator;
 import de.cuioss.nifi.rest.validation.SchemaViolation;
 import de.cuioss.sheriff.token.validation.domain.token.AccessTokenContent;
 import de.cuioss.tools.logging.CuiLogger;
-import jakarta.json.Json;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/ApiRouteHandler.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/ApiRouteHandler.java
@@ -159,7 +159,8 @@ public final class ApiRouteHandler implements EndpointHandler {
         LOGGER.info(RestApiLogMessages.INFO.REQUEST_PROCESSED,
                 route.name(), method, path, Request.getRemoteAddr(request));
         if (tracked) {
-            sendTrackedResponse(response, callback, request, traceId, route.trackingMode());
+            RequestUtils.sendAcceptedResponse(request, response, callback, traceId,
+                    route.trackingMode() == TrackingMode.ATTACHMENTS);
         } else {
             sendSuccessResponse(response, callback, method);
         }
@@ -242,44 +243,6 @@ public final class ApiRouteHandler implements EndpointHandler {
         response.getHeaders().put(HttpHeader.CONTENT_TYPE, "application/json");
         response.getHeaders().put(HttpHeader.CONTENT_LENGTH, ACCEPTED_RESPONSE.length);
         response.write(true, ByteBuffer.wrap(ACCEPTED_RESPONSE), callback);
-    }
-
-    private static void sendTrackedResponse(Response response, Callback callback,
-            Request request, String traceId, TrackingMode trackingMode) {
-        // Build absolute Location URI from the Jetty request
-        var httpUri = request.getHttpURI();
-        String scheme = httpUri.getScheme();
-        String host = Request.getServerName(request);
-        int port = Request.getServerPort(request);
-        String locationUri;
-        if (("http".equals(scheme) && port == 80) || ("https".equals(scheme) && port == 443)) {
-            locationUri = "%s://%s/status/%s".formatted(scheme, host, traceId);
-        } else {
-            locationUri = "%s://%s:%d/status/%s".formatted(scheme, host, port, traceId);
-        }
-
-        // Build JSON body with HATEOAS _links (relative URI for proxy safety)
-        String statusPath = "/status/" + traceId;
-        var linksBuilder = Json.createObjectBuilder()
-                .add("status", Json.createObjectBuilder()
-                        .add("href", statusPath));
-        if (trackingMode == TrackingMode.ATTACHMENTS) {
-            linksBuilder.add("attachments", Json.createObjectBuilder()
-                    .add("href", "/attachments/" + traceId));
-        }
-        byte[] responseBody = Json.createObjectBuilder()
-                .add("status", "accepted")
-                .add("traceId", traceId)
-                .add("_links", linksBuilder)
-                .build()
-                .toString()
-                .getBytes(StandardCharsets.UTF_8);
-
-        response.setStatus(202);
-        response.getHeaders().put(HttpHeader.LOCATION, locationUri);
-        response.getHeaders().put(HttpHeader.CONTENT_TYPE, "application/json");
-        response.getHeaders().put(HttpHeader.CONTENT_LENGTH, responseBody.length);
-        response.write(true, ByteBuffer.wrap(responseBody), callback);
     }
 
     private static boolean isBodyMethod(String method) {

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/AttachmentsEndpointHandler.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/AttachmentsEndpointHandler.java
@@ -178,24 +178,12 @@ public final class AttachmentsEndpointHandler implements EndpointHandler {
 
         autoTransitionToProcessedIfMinMet(parentTraceId.get(), parent.get(), attachmentCount.get());
 
-        sendAcceptedResponse(request, response, callback, traceId);
+        RequestUtils.sendAcceptedResponse(request, response, callback, traceId, false);
     }
 
     private Optional<String> extractAndValidateParentTraceId(String path, Response response, Callback callback) {
-        if (!path.startsWith(ATTACHMENTS_PATH_PREFIX) || path.length() <= ATTACHMENTS_PATH_PREFIX.length()) {
-            ProblemDetail.badRequest("Missing parentTraceId in path. Expected: /attachments/{parentTraceId}")
-                    .sendResponse(response, callback);
-            return Optional.empty();
-        }
-        String parentTraceId = path.substring(ATTACHMENTS_PATH_PREFIX.length());
-        try {
-            UUID.fromString(parentTraceId);
-        } catch (IllegalArgumentException e) {
-            ProblemDetail.badRequest("Invalid parentTraceId format. Expected UUID.")
-                    .sendResponse(response, callback);
-            return Optional.empty();
-        }
-        return Optional.of(parentTraceId);
+        return RequestUtils.extractUuidPathParameter(
+                path, ATTACHMENTS_PATH_PREFIX, "parentTraceId", response, callback);
     }
 
     private Optional<RequestStatusEntry> lookupAndValidateParent(String parentTraceId, Response response, Callback callback) {
@@ -209,6 +197,7 @@ public final class AttachmentsEndpointHandler implements EndpointHandler {
             return Optional.empty();
         }
         if (parentEntry.isEmpty()) {
+            attachmentCounters.remove(parentTraceId);
             LOGGER.warn(RestApiLogMessages.WARN.PARENT_TRACE_NOT_FOUND, parentTraceId);
             ProblemDetail.notFound("No parent request found for traceId: " + parentTraceId)
                     .sendResponse(response, callback);
@@ -222,6 +211,9 @@ public final class AttachmentsEndpointHandler implements EndpointHandler {
             return Optional.empty();
         }
         if (!isAttachmentWindowOpen(parent)) {
+            // Terminal for this parent — evict its in-memory counter so the map
+            // does not grow unboundedly over the processor's lifetime
+            attachmentCounters.remove(parentTraceId);
             LOGGER.warn(RestApiLogMessages.WARN.ATTACHMENT_WINDOW_CLOSED,
                     parentTraceId, parent.status());
             ProblemDetail.conflict("Attachment window closed — parent request is already being processed")
@@ -312,36 +304,4 @@ public final class AttachmentsEndpointHandler implements EndpointHandler {
         }
     }
 
-    private static void sendAcceptedResponse(Request request, Response response, Callback callback, String traceId) {
-        String statusPath = "/status/" + traceId;
-        byte[] responseBody = Json.createObjectBuilder()
-                .add("status", "accepted")
-                .add("traceId", traceId)
-                .add("_links", Json.createObjectBuilder()
-                        .add("status", Json.createObjectBuilder()
-                                .add("href", statusPath)))
-                .build()
-                .toString()
-                .getBytes(StandardCharsets.UTF_8);
-
-        String locationUri = buildLocationUri(request, traceId);
-        response.setStatus(202);
-        response.getHeaders().put(HttpHeader.LOCATION, locationUri);
-        response.getHeaders().put(HttpHeader.CONTENT_TYPE, JSON_CONTENT_TYPE);
-        response.getHeaders().put(HttpHeader.CONTENT_LENGTH, responseBody.length);
-        response.write(true, ByteBuffer.wrap(responseBody), callback);
-    }
-
-    private static String buildLocationUri(Request request, String traceId) {
-        var httpUri = request.getHttpURI();
-        String scheme = httpUri.getScheme();
-        String host = Request.getServerName(request);
-        int port = Request.getServerPort(request);
-        boolean isDefaultPort = ("http".equals(scheme) && port == 80)
-                || ("https".equals(scheme) && port == 443);
-        if (isDefaultPort) {
-            return "%s://%s/status/%s".formatted(scheme, host, traceId);
-        }
-        return "%s://%s:%d/status/%s".formatted(scheme, host, port, traceId);
-    }
 }

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/AttachmentsEndpointHandler.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/AttachmentsEndpointHandler.java
@@ -20,7 +20,6 @@ import de.cuioss.nifi.rest.RestApiLogMessages;
 import de.cuioss.nifi.rest.config.AuthMode;
 import de.cuioss.sheriff.token.validation.domain.token.AccessTokenContent;
 import de.cuioss.tools.logging.CuiLogger;
-import jakarta.json.Json;
 import jakarta.json.JsonException;
 import lombok.Builder;
 import org.eclipse.jetty.http.HttpHeader;
@@ -30,8 +29,6 @@ import org.eclipse.jetty.util.Callback;
 import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -234,7 +231,7 @@ public final class AttachmentsEndpointHandler implements EndpointHandler {
                 .computeIfAbsent(parentTraceId, k -> new AtomicInteger(0))
                 .incrementAndGet();
         if (count > parent.attachmentsMaxCount()) {
-            attachmentCounters.get(parentTraceId).decrementAndGet();
+            rollbackAttachmentCount(parentTraceId);
             LOGGER.warn(RestApiLogMessages.WARN.ATTACHMENT_LIMIT_REACHED,
                     parentTraceId, count - 1, parent.attachmentsMaxCount());
             ProblemDetail.conflict("Attachment limit reached: " + parent.attachmentsMaxCount())
@@ -251,7 +248,7 @@ public final class AttachmentsEndpointHandler implements EndpointHandler {
         try {
             statusStore.accept(traceId, parentTraceId);
         } catch (IOException e) {
-            attachmentCounters.get(parentTraceId).decrementAndGet();
+            rollbackAttachmentCount(parentTraceId);
             LOGGER.warn(RestApiLogMessages.WARN.STATUS_STORE_ERROR, e.getMessage());
             ProblemDetail.serviceUnavailable("Status store temporarily unavailable")
                     .sendResponse(response, callback);
@@ -278,7 +275,7 @@ public final class AttachmentsEndpointHandler implements EndpointHandler {
                 sanitized.pathParameters());
 
         if (!queue.offer(container)) {
-            attachmentCounters.get(parentTraceId).decrementAndGet();
+            rollbackAttachmentCount(parentTraceId);
             gatewaySecurityEvents.increment(GatewaySecurityEvents.EventType.QUEUE_FULL);
             LOGGER.warn(RestApiLogMessages.WARN.QUEUE_FULL, "POST", sanitized.path(),
                     Request.getRemoteAddr(request));
@@ -287,6 +284,18 @@ public final class AttachmentsEndpointHandler implements EndpointHandler {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Decrements the attachment counter for a rolled-back registration. Null-safe:
+     * the counter may have been evicted concurrently by {@code lookupAndValidateParent}
+     * (parent gone or window closed on another thread) — a missing entry needs no rollback.
+     */
+    private void rollbackAttachmentCount(String parentTraceId) {
+        attachmentCounters.computeIfPresent(parentTraceId, (k, counter) -> {
+            counter.decrementAndGet();
+            return counter;
+        });
     }
 
     private void autoTransitionToProcessedIfMinMet(String parentTraceId, RequestStatusEntry parent, int count) {

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/GatewayRequestHandler.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/GatewayRequestHandler.java
@@ -217,14 +217,8 @@ public class GatewayRequestHandler extends Handler.Abstract {
             return;
         }
 
-        // 4. Body read + size check
-        Optional<byte[]> bodyOpt = readAndValidateBody(request, handler, method, path, response, callback);
-        if (bodyOpt.isEmpty()) {
-            return;
-        }
-        byte[] body = bodyOpt.get();
-
-        // 5. Auth-mode dispatch
+        // 4. Auth-mode dispatch — authenticate BEFORE buffering the request body so
+        // unauthenticated clients cannot make the server buffer up to maxRequestSize bytes
         AuthResult authResult = resolveAuth(handler.authModes(), request, response, callback,
                 method, path, remoteHost);
         if (authResult instanceof AuthResult.ErrorSent) {
@@ -232,12 +226,19 @@ public class GatewayRequestHandler extends Handler.Abstract {
         }
         AccessTokenContent token = ((AuthResult.Success) authResult).token();
 
-        // 6. Authorization (shared — skipped when roles+scopes are empty)
+        // 5. Authorization (shared — skipped when roles+scopes are empty)
         if (token != null && hasAuthorizationRequirements(handler)
                 && !authorizeRequest(token, handler, response, callback, method, path, remoteHost)) {
             return;
         }
         LOGGER.info(RestApiLogMessages.INFO.AUTH_SUCCESSFUL, method, path, remoteHost);
+
+        // 6. Body read + size check
+        Optional<byte[]> bodyOpt = readAndValidateBody(request, handler, method, path, response, callback);
+        if (bodyOpt.isEmpty()) {
+            return;
+        }
+        byte[] body = bodyOpt.get();
 
         // 7. Delegate to handler (attach extracted path parameters)
         handler.process(sanitized.get().withPathParameters(pathParameters), token, body, request, response, callback);
@@ -410,8 +411,9 @@ public class GatewayRequestHandler extends Handler.Abstract {
             response.getHeaders().put(WWW_AUTHENTICATE,
                     BEARER_INSUFFICIENT_SCOPE_TEMPLATE
                             .formatted(String.join(" ", handler.requiredScopes())));
+            // RFC 6750 §3.1: insufficient_scope → 403 Forbidden (401 is for missing/invalid tokens)
             sendProblemResponse(response, callback,
-                    ProblemDetail.unauthorized("Insufficient scopes: " + authResult.reason()));
+                    ProblemDetail.forbidden("Insufficient scopes: " + authResult.reason()));
         } else {
             gatewaySecurityEvents.increment(GatewaySecurityEvents.EventType.AUTHZ_ROLE_DENIED);
             sendProblemResponse(response, callback,

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/RequestUtils.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/RequestUtils.java
@@ -16,8 +16,20 @@
  */
 package de.cuioss.nifi.rest.handler;
 
+import jakarta.json.Json;
+import jakarta.json.JsonObjectBuilder;
 import lombok.experimental.UtilityClass;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Shared request utilities for endpoint handlers.
@@ -25,18 +37,107 @@ import org.eclipse.jetty.server.Request;
 @UtilityClass
 class RequestUtils {
 
-    private static final String IPV4_LOOPBACK = "127.0.0.1";
-    private static final String IPV6_LOOPBACK = "::1";
-
     /**
-     * Returns {@code true} if the request originates from a loopback address
-     * (127.0.0.1 or ::1).
+     * Returns {@code true} if the request originates from a loopback address.
+     * <p>
+     * Uses the remote {@link InetSocketAddress} and
+     * {@link java.net.InetAddress#isLoopbackAddress()} instead of comparing the
+     * string form: Jetty renders IPv6 addresses in normalized/bracketed form
+     * (e.g. {@code [0:0:0:0:0:0:0:1]}), which a literal {@code "::1"} comparison
+     * never matches.
      *
      * @param request the Jetty request
      * @return {@code true} for loopback requests
      */
     public static boolean isLoopbackRequest(Request request) {
-        String remoteAddr = Request.getRemoteAddr(request);
-        return IPV4_LOOPBACK.equals(remoteAddr) || IPV6_LOOPBACK.equals(remoteAddr);
+        SocketAddress remote = request.getConnectionMetaData().getRemoteSocketAddress();
+        return remote instanceof InetSocketAddress inet
+                && inet.getAddress() != null
+                && inet.getAddress().isLoopbackAddress();
+    }
+
+    /**
+     * Extracts and validates a UUID path parameter after the given prefix.
+     * On failure, a Problem Details response is sent and empty is returned.
+     *
+     * @param path      the sanitized request path
+     * @param prefix    the path prefix including trailing slash (e.g. {@code /status/})
+     * @param paramName the parameter name used in error messages (e.g. {@code traceId})
+     * @param response  the response to send errors to
+     * @param callback  the Jetty callback
+     * @return the validated UUID string, or empty if an error response was sent
+     */
+    public static Optional<String> extractUuidPathParameter(String path, String prefix,
+            String paramName, Response response, Callback callback) {
+        if (!path.startsWith(prefix) || path.length() <= prefix.length()) {
+            ProblemDetail.badRequest("Missing %s in path. Expected: %s{%s}"
+                    .formatted(paramName, prefix, paramName))
+                    .sendResponse(response, callback);
+            return Optional.empty();
+        }
+        String id = path.substring(prefix.length());
+        try {
+            UUID.fromString(id);
+        } catch (IllegalArgumentException e) {
+            ProblemDetail.badRequest("Invalid %s format. Expected UUID.".formatted(paramName))
+                    .sendResponse(response, callback);
+            return Optional.empty();
+        }
+        return Optional.of(id);
+    }
+
+    /**
+     * Builds the absolute {@code Location} URI for the status endpoint of the given traceId,
+     * omitting default ports (80/443).
+     *
+     * @param request the originating Jetty request (source of scheme/host/port)
+     * @param traceId the trace ID
+     * @return the absolute status URI
+     */
+    public static String buildStatusLocationUri(Request request, String traceId) {
+        String scheme = request.getHttpURI().getScheme();
+        String host = Request.getServerName(request);
+        int port = Request.getServerPort(request);
+        boolean isDefaultPort = ("http".equals(scheme) && port == 80)
+                || ("https".equals(scheme) && port == 443);
+        if (isDefaultPort) {
+            return "%s://%s/status/%s".formatted(scheme, host, traceId);
+        }
+        return "%s://%s:%d/status/%s".formatted(scheme, host, port, traceId);
+    }
+
+    /**
+     * Sends the shared 202 Accepted response with {@code Location} header and
+     * HATEOAS {@code _links} body used by tracked routes and the attachments endpoint.
+     *
+     * @param request                the originating Jetty request
+     * @param response               the response
+     * @param callback               the Jetty callback
+     * @param traceId                the accepted request's trace ID
+     * @param includeAttachmentsLink whether to add the {@code attachments} link
+     *                               (routes in ATTACHMENTS tracking mode)
+     */
+    public static void sendAcceptedResponse(Request request, Response response, Callback callback,
+            String traceId, boolean includeAttachmentsLink) {
+        String statusPath = "/status/" + traceId;
+        JsonObjectBuilder linksBuilder = Json.createObjectBuilder()
+                .add("status", Json.createObjectBuilder().add("href", statusPath));
+        if (includeAttachmentsLink) {
+            linksBuilder.add("attachments", Json.createObjectBuilder()
+                    .add("href", "/attachments/" + traceId));
+        }
+        byte[] responseBody = Json.createObjectBuilder()
+                .add("status", "accepted")
+                .add("traceId", traceId)
+                .add("_links", linksBuilder)
+                .build()
+                .toString()
+                .getBytes(StandardCharsets.UTF_8);
+
+        response.setStatus(202);
+        response.getHeaders().put(HttpHeader.LOCATION, buildStatusLocationUri(request, traceId));
+        response.getHeaders().put(HttpHeader.CONTENT_TYPE, "application/json");
+        response.getHeaders().put(HttpHeader.CONTENT_LENGTH, responseBody.length);
+        response.write(true, ByteBuffer.wrap(responseBody), callback);
     }
 }

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/StatusEndpointHandler.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/StatusEndpointHandler.java
@@ -81,22 +81,12 @@ public final class StatusEndpointHandler extends AbstractManagementHandler {
         String path = sanitized.path();
 
         // The path segment after the status prefix is the traceId
-        if (!path.startsWith(STATUS_PATH_PREFIX) || path.length() <= STATUS_PATH_PREFIX.length()) {
-            ProblemDetail.badRequest("Missing traceId in path. Expected: /status/{traceId}")
-                    .sendResponse(response, callback);
+        Optional<String> extractedTraceId = RequestUtils.extractUuidPathParameter(
+                path, STATUS_PATH_PREFIX, "traceId", response, callback);
+        if (extractedTraceId.isEmpty()) {
             return;
         }
-
-        String traceId = path.substring(STATUS_PATH_PREFIX.length());
-
-        // Validate UUID format
-        try {
-            UUID.fromString(traceId);
-        } catch (IllegalArgumentException e) {
-            ProblemDetail.badRequest("Invalid traceId format. Expected UUID.")
-                    .sendResponse(response, callback);
-            return;
-        }
+        String traceId = extractedTraceId.get();
 
         // Query status store
         Optional<RequestStatusEntry> entry;

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/StatusEndpointHandler.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/StatusEndpointHandler.java
@@ -34,7 +34,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 
 /**
  * Built-in handler for the {@code /status/{traceId}} management endpoint.

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/server/JettyServerManager.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/server/JettyServerManager.java
@@ -89,17 +89,37 @@ public class JettyServerManager {
             LOGGER.info(RestApiLogMessages.INFO.SERVER_STARTED, getPort());
         } catch (IOException e) {
             LOGGER.error(e, RestApiLogMessages.ERROR.SERVER_START_FAILED, port, e.getMessage());
-            server = null;
+            cleanupFailedServer();
             throw new IllegalStateException("Failed to start Jetty server on port " + port, e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             LOGGER.error(e, RestApiLogMessages.ERROR.SERVER_START_FAILED, port, e.getMessage());
-            server = null;
+            cleanupFailedServer();
             throw new IllegalStateException("Jetty server start interrupted on port " + port, e);
         } catch (Exception e) {
             LOGGER.error(e, RestApiLogMessages.ERROR.SERVER_START_FAILED, port, e.getMessage());
-            server = null;
+            cleanupFailedServer();
             throw new IllegalStateException("Failed to start Jetty server on port " + port, e);
+        }
+    }
+
+    /**
+     * Best-effort stop of a partially-started server so a failed {@code start()}
+     * (e.g. bind failure) does not leak connector threads or sockets.
+     */
+    @SuppressWarnings("java:S2147") // Jetty LifeCycle.stop() declares 'throws Exception'
+    private void cleanupFailedServer() {
+        if (server == null) {
+            return;
+        }
+        try {
+            server.stop();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            LOGGER.debug("Ignoring failure while stopping partially-started server: %s", e.getMessage());
+        } finally {
+            server = null;
         }
     }
 

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/validation/JsonSchemaValidator.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/validation/JsonSchemaValidator.java
@@ -16,6 +16,7 @@
  */
 package de.cuioss.nifi.rest.validation;
 
+import de.cuioss.nifi.rest.RestApiLogMessages;
 import de.cuioss.tools.logging.CuiLogger;
 import dev.harrel.jsonschema.Validator;
 import dev.harrel.jsonschema.ValidatorFactory;
@@ -72,13 +73,13 @@ public class JsonSchemaValidator {
 
     private static String resolveSchemaContent(String routeName, String schemaSource) {
         if (schemaSource.strip().startsWith("{")) {
-            LOGGER.info("Registered inline JSON Schema for route '%s'", routeName);
+            LOGGER.info(RestApiLogMessages.INFO.SCHEMA_REGISTERED_INLINE, routeName);
             return schemaSource;
         }
         try {
             Path schemaPath = Path.of(schemaSource).normalize();
             String content = Files.readString(schemaPath, StandardCharsets.UTF_8);
-            LOGGER.info("Registered JSON Schema for route '%s' from %s", routeName, schemaPath);
+            LOGGER.info(RestApiLogMessages.INFO.SCHEMA_REGISTERED_FROM_FILE, routeName, schemaPath);
             return content;
         } catch (InvalidPathException e) {
             throw new IllegalStateException(

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/RestApiGatewayProcessorTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/RestApiGatewayProcessorTest.java
@@ -127,17 +127,20 @@ class RestApiGatewayProcessorTest {
             runner.setProperty(RestApiGatewayConstants.Properties.JWT_ISSUER_CONFIG_SERVICE, CS_ID);
             runner.setProperty(RestApiGatewayConstants.Properties.LISTENING_PORT, "0");
 
-            runner.run(1, false, true);
+            try {
+                runner.run(1, false, true);
 
-            var processor = (RestApiGatewayProcessor) runner.getProcessor();
-            assertFalse(processor.serverManager.isRunning(),
-                    "Embedded server must not start when no routes are configured");
-            assertEquals(
-                    java.util.Set.of(RestApiGatewayConstants.Relationships.FAILURE,
-                            RestApiGatewayConstants.Relationships.ATTACHMENTS),
-                    processor.getRelationships(),
-                    "Only the built-in relationships must remain without routes");
-            runner.stop();
+                var processor = (RestApiGatewayProcessor) runner.getProcessor();
+                assertFalse(processor.serverManager.isRunning(),
+                        "Embedded server must not start when no routes are configured");
+                assertEquals(
+                        Set.of(RestApiGatewayConstants.Relationships.FAILURE,
+                                RestApiGatewayConstants.Relationships.ATTACHMENTS),
+                        processor.getRelationships(),
+                        "Only the built-in relationships must remain without routes");
+            } finally {
+                runner.stop();
+            }
         }
     }
 

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/RestApiGatewayProcessorTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/RestApiGatewayProcessorTest.java
@@ -114,6 +114,34 @@ class RestApiGatewayProcessorTest {
     }
 
     @Nested
+    @DisplayName("Empty Route Configuration")
+    class EmptyRouteConfiguration {
+
+        @Test
+        @DisplayName("Should clear relationships and skip server start when no routes are configured")
+        void shouldHandleScheduleWithoutRoutes() throws Exception {
+            var runner = TestRunners.newTestRunner(RestApiGatewayProcessor.class);
+            var configService = new TestJwtIssuerConfigService();
+            runner.addControllerService(CS_ID, configService);
+            runner.enableControllerService(configService);
+            runner.setProperty(RestApiGatewayConstants.Properties.JWT_ISSUER_CONFIG_SERVICE, CS_ID);
+            runner.setProperty(RestApiGatewayConstants.Properties.LISTENING_PORT, "0");
+
+            runner.run(1, false, true);
+
+            var processor = (RestApiGatewayProcessor) runner.getProcessor();
+            assertFalse(processor.serverManager.isRunning(),
+                    "Embedded server must not start when no routes are configured");
+            assertEquals(
+                    java.util.Set.of(RestApiGatewayConstants.Relationships.FAILURE,
+                            RestApiGatewayConstants.Relationships.ATTACHMENTS),
+                    processor.getRelationships(),
+                    "Only the built-in relationships must remain without routes");
+            runner.stop();
+        }
+    }
+
+    @Nested
     @DisplayName("Property Descriptors")
     class PropertyDescriptors {
 

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/GatewayRequestHandlerTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/GatewayRequestHandlerTest.java
@@ -359,6 +359,41 @@ class GatewayRequestHandlerTest {
                 smallServer.stop();
             }
         }
+
+        @Test
+        @DisplayName("Should reject unauthenticated oversized POST with 401 before reading the body")
+        void shouldRejectUnauthenticatedOversizedPostBeforeBodyRead() throws Exception {
+            // Auth runs before body buffering: an unauthenticated client must get
+            // 401 and must NOT trigger BODY_TOO_LARGE for its oversized payload
+            var smallHandler = new GatewayRequestHandler(
+                    toHandlers(List.of(RouteConfiguration.builder().name("data").path("/api/data")
+                            .method("POST").build()), queue, 10),
+                    mockConfigService, 10); // 10 bytes max
+
+            Server smallServer = new Server();
+            ServerConnector connector = new ServerConnector(smallServer);
+            connector.setPort(0);
+            smallServer.addConnector(connector);
+            smallServer.setHandler(smallHandler);
+            smallServer.start();
+
+            int smallPort = connector.getLocalPort();
+            try {
+                var response = httpClient.send(
+                        HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + smallPort + "/api/data"))
+                                .header("Content-Type", "application/json")
+                                .POST(HttpRequest.BodyPublishers.ofString("a]".repeat(100)))
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
+
+                assertEquals(401, response.statusCode());
+                assertEquals(0L, smallHandler.getGatewaySecurityEvents().getCount(EventType.BODY_TOO_LARGE),
+                        "Body size must not be evaluated for unauthenticated requests");
+                assertEquals(1L, smallHandler.getGatewaySecurityEvents().getCount(EventType.MISSING_BEARER_TOKEN));
+            } finally {
+                smallServer.stop();
+            }
+        }
     }
 
     @Nested

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/GatewayRequestHandlerTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/GatewayRequestHandlerTest.java
@@ -436,15 +436,15 @@ class GatewayRequestHandlerTest {
         }
 
         @Test
-        @DisplayName("Should return 401 step-up when scopes are missing")
-        void shouldReturn401StepUpWhenScopesMissing() throws Exception {
+        @DisplayName("Should return 403 with insufficient_scope challenge when scopes are missing")
+        void shouldReturn403WhenScopesMissing() throws Exception {
             // data route requires READ scope
             var response = httpClient.send(
                     requestBuilder("/api/data").GET().build(),
                     HttpResponse.BodyHandlers.ofString());
 
-            // Step-up auth: 401 with insufficient_scope when scopes are missing
-            assertEquals(401, response.statusCode());
+            // RFC 6750 §3.1: insufficient_scope -> 403 with the WWW-Authenticate challenge
+            assertEquals(403, response.statusCode());
             assertTrue(response.headers().firstValue("WWW-Authenticate")
                     .orElse("").contains("insufficient_scope"));
             assertEquals(1L, handler.getGatewaySecurityEvents().getCount(EventType.AUTHZ_SCOPE_DENIED));

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/server/JettyServerManagerTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/server/JettyServerManagerTest.java
@@ -124,6 +124,32 @@ class JettyServerManagerTest {
         void shouldReturnNegativePortWhenNotRunning() {
             assertEquals(-1, manager.getPort());
         }
+
+        @Test
+        @DisplayName("Should clean up after failed start and allow retry")
+        void shouldCleanUpAfterFailedStartAndAllowRetry() {
+            // Arrange — occupy a port so the second manager's bind fails
+            var blocker = new JettyServerManager();
+            try {
+                blocker.start(0, echoHandler());
+                int occupiedPort = blocker.getPort();
+
+                var handler = echoHandler();
+                assertThrows(IllegalStateException.class,
+                        () -> manager.start(occupiedPort, handler),
+                        "Starting on an occupied port must fail");
+
+                // The partially-started server must be cleaned up...
+                assertFalse(manager.isRunning(), "Manager must not report running after failed start");
+                assertEquals(-1, manager.getPort());
+
+                // ...and a subsequent start on a free port must succeed
+                manager.start(0, echoHandler());
+                assertTrue(manager.isRunning());
+            } finally {
+                blocker.stop();
+            }
+        }
     }
 
     @Nested


### PR DESCRIPTION
Cluster 3 of the project-analysis fixes (see `doc/findings-project-analysis.adoc` on branch `claude/project-analysis-fixes-2qj5ff`): `nifi-cuioss-rest-processors`.

## Changes

### Major
- **Broken failure path (C3-1):** in `onTrigger`'s `catch (ProcessException)`, the partially-built FlowFile was neither removed nor transferred before the error FlowFile was transferred — session commit threw `FlowFileHandlingException` and rolled back the error FlowFile, so the `failure` relationship could never receive anything. The partial FlowFile is now removed first.
- **IPv6 loopback detection (C3-2):** `RequestUtils.isLoopbackRequest` compared the remote address string against `"::1"`, but Jetty 12 renders IPv6 addresses bracketed/normalized (`[0:0:0:0:0:0:0:1]`) so the check never matched — `LOCAL_ONLY`'s loopback bypass silently failed on IPv6 connections (e.g. the UI management proxy connecting to `localhost`). Now uses `InetAddress.isLoopbackAddress()` on the remote socket address.

### Minor
- **Auth before body buffering (C3-4):** the dispatcher now authenticates before reading the request body, so unauthenticated clients can't make the server buffer up to `maxRequestSize` bytes.
- **RFC 6750 §3.1 (C3-5):** `insufficient_scope` returns **403** (was 401), keeping the `WWW-Authenticate` challenge; roles already returned 403. The unit test codifying the old behavior was updated.
- **Attachment counter leak (C3-3):** in-memory attachment counters are evicted when the parent is unknown or its attachment window has closed.
- **Server-start leak (C3-10):** `JettyServerManager` best-effort-stops a partially-started server on `start()` failure (bind errors no longer leak connector threads/sockets).
- **Dead header plumbing (C3-7):** sanitized request headers (Authorization excluded upstream) are now mapped to `http.header.*` FlowFile attributes — `HEADER_PREFIX` and the headers carried through the queue were previously unused.
- **Stale relationships (C3-6):** a schedule with no routes now clears relationships from a previous schedule.
- **No-null-return (C3-9):** `buildSchemaValidator` returns `Optional`.
- **CUI logging (C3-8):** `JsonSchemaValidator` INFO logs use `RestApiLogMessages` LogRecords (REST-19/REST-20).
- **De-duplication (C3-11):** `parseCommaSeparated` consolidated into `AuthorizationRequirements` (was 3 copies); 202-Accepted + Location-URI building and `/status/`+`/attachments/` UUID path extraction unified in `RequestUtils`.

## Verification
- All 521 module tests green (`nifi-cuioss-rest-processors`) plus 245 in common.
- `./mvnw -Ppre-commit clean install -DskipTests` then `./mvnw clean install` — BUILD SUCCESS.
- Gateway integration tests + E2E run in CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183YX76Sshkxm4A9EaFpE2M

---
_Generated by [Claude Code](https://claude.ai/code/session_0183YX76Sshkxm4A9EaFpE2M)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced 202 “accepted” responses with standardized status links and optional attachments links.
  * Added explicit log events for inline and file-based JSON schema registration.
* **Bug Fixes**
  * Prevented stale dynamic routing when no routes are configured; improved schema-validator availability handling.
  * Improved error handling so failures are routed correctly; strengthened attachment counter eviction/rollback.
  * Tightened request path/UUID validation and header-to-attribute mapping.
  * Missing required scopes now returns **403 Forbidden** (insufficient_scope).
* **Documentation**
  * Updated gateway pipeline and error/metrics references to match the new **403** behavior.
* **Tests / Chores**
  * Added/updated tests for empty routing, auth/body-size behavior, and failed-startup cleanup; enabled Lombok annotation processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->