### PR TITLE
fix(ui-js): management-table cell indices, disabled-route visibility, attribute-injection XSS, and frontend/E2E audit findings

### DIFF
--- a/e-2-e-playwright/fixtures/test-fixtures.js
+++ b/e-2-e-playwright/fixtures/test-fixtures.js
@@ -70,7 +70,10 @@ export const accessibilityTest = test.extend({
     page: async ({ accessibilityPage }, use, _testInfo) => {
         await use(accessibilityPage);
 
-        // Run accessibility check after each test
+        // Run accessibility check after each test.
+        // NOTE: This per-test axe scan is ADVISORY ONLY — violations are logged
+        // but never fail the test. Enforced WCAG compliance lives in
+        // tests/accessibility-wcag-compliance.spec.js.
         await test.step("Accessibility check", async () => {
             try {
                 const results = await new AxeBuilder({
@@ -87,12 +90,17 @@ export const accessibilityTest = test.extend({
                                 `${v.id}: ${v.description} (${v.nodes.length} elements)`,
                         )
                         .join("\n");
-                     
-                    console.warn("Accessibility issues found:\n" + summary);
+
+                    testLogger.warn(
+                        "A11y",
+                        "Accessibility issues found (advisory):\n" + summary,
+                    );
                 }
             } catch (error) {
-                 
-                console.warn("Accessibility check failed:", error.message);
+                testLogger.warn(
+                    "A11y",
+                    `Accessibility check failed: ${error.message}`,
+                );
             }
         });
     },

--- a/e-2-e-playwright/package.json
+++ b/e-2-e-playwright/package.json
@@ -11,7 +11,6 @@
     "playwright:test": "NODE_EXTRA_CA_CERTS=../integration-testing/src/main/docker/certificates/localhost.crt playwright test",
     "playwright:test:headed": "playwright test --headed",
     "playwright:test:ui": "playwright test --ui",
-    "playwright:report": "playwright show-report",
     "playwright:codegen": "playwright codegen",
     "test": "NODE_EXTRA_CA_CERTS=../integration-testing/src/main/docker/certificates/localhost.crt node utils/run-tests-with-precheck.js",
     "test:self": "playwright test tests/self-*.spec.js --reporter=list",

--- a/e-2-e-playwright/playwright.config.cjs
+++ b/e-2-e-playwright/playwright.config.cjs
@@ -13,8 +13,6 @@ const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'https://localhost:9095/nifi
  */
 const TARGET_DIR = process.env.PLAYWRIGHT_OUTPUT_DIR || path.join(__dirname, 'target');
 const TEST_RESULTS_DIR = process.env.TEST_RESULTS_DIR || path.join(TARGET_DIR, 'test-results');
-const SCREENSHOTS_DIR = path.join(TEST_RESULTS_DIR, 'screenshots');
-const VIDEOS_DIR = path.join(TEST_RESULTS_DIR, 'videos');
 
 /** Shared Chrome launch options for all projects */
 const CHROME_OPTIONS = {
@@ -66,9 +64,6 @@ module.exports = defineConfig({
   outputDir: TEST_RESULTS_DIR,
   /* Preserve output from test runs */
   preserveOutput: 'always',
-  /* Screenshot and video directories */
-  screenshotsDir: SCREENSHOTS_DIR,
-  videosDir: VIDEOS_DIR,
   /* Shared settings for all projects */
   use: {
     baseURL: BASE_URL,

--- a/e-2-e-playwright/tests/06-verify-gateway-tabs.spec.js
+++ b/e-2-e-playwright/tests/06-verify-gateway-tabs.spec.js
@@ -1879,7 +1879,7 @@ test.describe("REST API Gateway Tabs", () => {
         await cancelBtn.click();
     });
 
-    test("should not display disabled-test route from external config", async ({
+    test("should display disabled-test route from external config with Disabled status", async ({
         customUIFrame,
     }) => {
         // Navigate to Endpoint Configuration tab
@@ -1895,10 +1895,12 @@ test.describe("REST API Gateway Tabs", () => {
         const summaryTable = endpointConfigPanel.locator(".route-summary-table");
         await expect(summaryTable).toBeVisible({ timeout: 15000 });
 
-        // Disabled route should not appear in the table
+        // Disabled routes stay listed (otherwise they could never be
+        // re-enabled or deleted via the UI) and show the Disabled status
         const disabledRow = summaryTable.locator(
             'tbody tr[data-route-name="disabled-test"]',
         );
-        await expect(disabledRow).toHaveCount(0);
+        await expect(disabledRow).toHaveCount(1);
+        await expect(disabledRow.locator(".status-disabled")).toBeVisible();
     });
 });

--- a/e-2-e-playwright/tests/accessibility-wcag-compliance.spec.js
+++ b/e-2-e-playwright/tests/accessibility-wcag-compliance.spec.js
@@ -158,7 +158,6 @@ test.describe("WCAG 2.1 Level AA Compliance", () => {
                             .locator(component.selector)
                             .count()) > 0;
                     expect(tabsExist).toBe(true);
-                    return; // Skip detailed check for tabs
                 }
 
                 // For configForm, check if it's visible (default tab)
@@ -167,24 +166,25 @@ test.describe("WCAG 2.1 Level AA Compliance", () => {
                         .locator(component.selector)
                         .isVisible();
                     expect(configFormVisible).toBe(true);
-
-                    // Run accessibility check — let failures propagate
-                    const helper =
-                        await ensureValidAccessibilityHelper(testInfo);
-                    const result = await helper.checkComponent(
-                        component.selector,
-                        component.name,
-                    );
-
-                    if (!result.passed) {
-                        testLogger.warn(
-                            "A11y",
-                            `${component.name} issues: ${JSON.stringify(result, null, 2)}`,
-                        );
-                    }
-
-                    expect(result.passed).toBe(true);
                 }
+
+                // Run the axe component scan for every component —
+                // let failures propagate
+                const helper =
+                    await ensureValidAccessibilityHelper(testInfo);
+                const result = await helper.checkComponent(
+                    component.selector,
+                    component.name,
+                );
+
+                if (!result.passed) {
+                    testLogger.warn(
+                        "A11y",
+                        `${component.name} issues: ${JSON.stringify(result, null, 2)}`,
+                    );
+                }
+
+                expect(result.passed).toBe(true);
             });
         }
     });
@@ -290,7 +290,17 @@ test.describe("WCAG 2.1 Level AA Compliance", () => {
                     i++
                 ) {
                     await page.keyboard.press("Tab");
-                    await page.waitForTimeout(100); // Small delay for focus to settle
+                    // Condition-based wait: focus must have settled on a
+                    // non-body element before the next Tab press
+                    await expect
+                        .poll(() =>
+                            customUIFrame.evaluate(
+                                () =>
+                                    document.activeElement !== null &&
+                                    document.activeElement !== document.body,
+                            ),
+                        )
+                        .toBe(true);
                 }
             }
         });
@@ -393,9 +403,13 @@ test.describe("WCAG 2.1 Level AA Compliance", () => {
                 .first();
             if (await validateButton.isVisible()) {
                 await validateButton.click();
-                await page.waitForTimeout(500);
 
+                // Condition-based wait: give the validation result time to
+                // render; the error is optional, so a missed appearance is fine
                 const errorMessage = customUIFrame.locator(".validation-error").first();
+                await errorMessage
+                    .waitFor({ state: "visible", timeout: 5000 })
+                    .catch(() => {});
                 if (await errorMessage.isVisible()) {
                     const contrast = await errorMessage.evaluate((el) => {
                         const styles = window.getComputedStyle(el);

--- a/e-2-e-playwright/tests/accessibility-wcag-compliance.spec.js
+++ b/e-2-e-playwright/tests/accessibility-wcag-compliance.spec.js
@@ -143,18 +143,22 @@ test.describe("WCAG 2.1 Level AA Compliance", () => {
     });
 
     test("Component-level accessibility checks", async ({ page }, testInfo) => {
-        // Get the custom UI frame once
-        const customUIFrame = await navigateToJWTAuthenticatorUI(
-            page,
-            testInfo,
-        );
+        // Open the custom UI so the helper can attach to its frame
+        await navigateToJWTAuthenticatorUI(page, testInfo);
 
         for (const [key, component] of Object.entries(A11Y_CONFIG.components)) {
             await test.step(`Check ${component.name} accessibility`, async () => {
+                // Acquire the helper FIRST: it may re-navigate and re-create
+                // the frame, which would detach any frame reference captured
+                // earlier. All locators below must use the helper's live
+                // frame context (helper.page).
+                const helper =
+                    await ensureValidAccessibilityHelper(testInfo);
+
                 // For the tabs component, it should always be visible
                 if (key === "tabs") {
                     const tabsExist =
-                        (await customUIFrame
+                        (await helper.page
                             .locator(component.selector)
                             .count()) > 0;
                     expect(tabsExist).toBe(true);
@@ -162,7 +166,7 @@ test.describe("WCAG 2.1 Level AA Compliance", () => {
 
                 // For configForm, check if it's visible (default tab)
                 if (key === "configForm") {
-                    const configFormVisible = await customUIFrame
+                    const configFormVisible = await helper.page
                         .locator(component.selector)
                         .isVisible();
                     expect(configFormVisible).toBe(true);
@@ -170,8 +174,6 @@ test.describe("WCAG 2.1 Level AA Compliance", () => {
 
                 // Run the axe component scan for every component —
                 // let failures propagate
-                const helper =
-                    await ensureValidAccessibilityHelper(testInfo);
                 const result = await helper.checkComponent(
                     component.selector,
                     component.name,

--- a/e-2-e-playwright/tests/accessibility-wcag-compliance.spec.js
+++ b/e-2-e-playwright/tests/accessibility-wcag-compliance.spec.js
@@ -405,10 +405,12 @@ test.describe("WCAG 2.1 Level AA Compliance", () => {
                 await validateButton.click();
 
                 // Condition-based wait: give the validation result time to
-                // render; the error is optional, so a missed appearance is fine
+                // render; the error is optional, so a missed appearance is fine.
+                // Short timeout — when validation succeeds no error appears and
+                // this would otherwise block for the full duration every run.
                 const errorMessage = customUIFrame.locator(".validation-error").first();
                 await errorMessage
-                    .waitFor({ state: "visible", timeout: 5000 })
+                    .waitFor({ state: "visible", timeout: 500 })
                     .catch(() => {});
                 if (await errorMessage.isVisible()) {
                     const contrast = await errorMessage.evaluate((el) => {

--- a/e-2-e-playwright/utils/accessibility-helper.js
+++ b/e-2-e-playwright/utils/accessibility-helper.js
@@ -653,7 +653,13 @@ export const a11yUtils = {
      */
     async waitForA11yReady(page) {
         await page.waitForLoadState("networkidle");
-        await page.waitForTimeout(500); // Allow for dynamic content
+        // Condition-based wait: the custom UI reveals its tab container once
+        // initialisation completes (app.js hides the loading indicator). Fall
+        // through silently when the context is not the custom UI frame.
+        await page
+            .locator("#jwt-validator-tabs")
+            .waitFor({ state: "visible", timeout: 5000 })
+            .catch(() => {});
     },
 
     /**

--- a/e-2-e-playwright/utils/auth-service.js
+++ b/e-2-e-playwright/utils/auth-service.js
@@ -181,14 +181,15 @@ export class AuthService {
         const authSuccess = mainCanvasVisible || logoutVisible || usernameVisible;
 
         if (!authSuccess) {
-          // Wait a bit more and try again
-          await this.page.waitForTimeout(2000);
-
-          const retryMainCanvas = await this.page.locator(CONSTANTS.SELECTORS.MAIN_CANVAS).isVisible().catch(() => false);
-          const retryLogout = await this.page.getByRole('button', { name: /log out|logout/i }).isVisible().catch(() => false);
-          const retryUsername = await this.page.locator(`text=${CONSTANTS.AUTH.USERNAME}`).isVisible().catch(() => false);
-
-          const retrySuccess = retryMainCanvas || retryLogout || retryUsername;
+          // Condition-based wait: poll for any auth indicator to become visible
+          // instead of a fixed sleep followed by a single re-check
+          const waitForIndicator = (locator) =>
+            locator.waitFor({ state: 'visible', timeout: 5000 }).then(() => true);
+          const retrySuccess = await Promise.any([
+            waitForIndicator(this.page.locator(CONSTANTS.SELECTORS.MAIN_CANVAS).first()),
+            waitForIndicator(this.page.getByRole('button', { name: /log out|logout/i }).first()),
+            waitForIndicator(this.page.locator(`text=${CONSTANTS.AUTH.USERNAME}`).first())
+          ]).catch(() => false);
 
           if (!retrySuccess) {
             throw new Error('Authentication indicators not found after retry');

--- a/e-2-e-playwright/utils/auth-service.js
+++ b/e-2-e-playwright/utils/auth-service.js
@@ -184,9 +184,10 @@ export class AuthService {
           // Condition-based wait: a single locator.or() chain waits for any
           // auth indicator to become visible without leaving the losing
           // waits running in the background (unlike Promise.any)
-          const retrySuccess = await this.page.locator(CONSTANTS.SELECTORS.MAIN_CANVAS).first()
-            .or(this.page.getByRole('button', { name: /log out|logout/i }).first())
-            .or(this.page.locator(`text=${CONSTANTS.AUTH.USERNAME}`).first())
+          const retrySuccess = await this.page.locator(CONSTANTS.SELECTORS.MAIN_CANVAS)
+            .or(this.page.getByRole('button', { name: /log out|logout/i }))
+            .or(this.page.locator(`text=${CONSTANTS.AUTH.USERNAME}`))
+            .first()
             .waitFor({ state: 'visible', timeout: 5000 })
             .then(() => true)
             .catch(() => false);

--- a/e-2-e-playwright/utils/auth-service.js
+++ b/e-2-e-playwright/utils/auth-service.js
@@ -181,15 +181,15 @@ export class AuthService {
         const authSuccess = mainCanvasVisible || logoutVisible || usernameVisible;
 
         if (!authSuccess) {
-          // Condition-based wait: poll for any auth indicator to become visible
-          // instead of a fixed sleep followed by a single re-check
-          const waitForIndicator = (locator) =>
-            locator.waitFor({ state: 'visible', timeout: 5000 }).then(() => true);
-          const retrySuccess = await Promise.any([
-            waitForIndicator(this.page.locator(CONSTANTS.SELECTORS.MAIN_CANVAS).first()),
-            waitForIndicator(this.page.getByRole('button', { name: /log out|logout/i }).first()),
-            waitForIndicator(this.page.locator(`text=${CONSTANTS.AUTH.USERNAME}`).first())
-          ]).catch(() => false);
+          // Condition-based wait: a single locator.or() chain waits for any
+          // auth indicator to become visible without leaving the losing
+          // waits running in the background (unlike Promise.any)
+          const retrySuccess = await this.page.locator(CONSTANTS.SELECTORS.MAIN_CANVAS).first()
+            .or(this.page.getByRole('button', { name: /log out|logout/i }).first())
+            .or(this.page.locator(`text=${CONSTANTS.AUTH.USERNAME}`).first())
+            .waitFor({ state: 'visible', timeout: 5000 })
+            .then(() => true)
+            .catch(() => false);
 
           if (!retrySuccess) {
             throw new Error('Authentication indicators not found after retry');

--- a/e-2-e-playwright/utils/constants.js
+++ b/e-2-e-playwright/utils/constants.js
@@ -14,13 +14,15 @@ export const PAGE_TYPES = {
 
 /**
  * Authentication constants
- * 
- * ⚠️  WARNING: DO NOT CHANGE THESE VALUES WITHOUT PRIOR USER CONSULTATION
- * These credentials must match the NiFi instance configuration
+ *
+ * ⚠️  WARNING: DO NOT CHANGE THESE DEFAULTS WITHOUT PRIOR USER CONSULTATION
+ * These credentials must match the NiFi instance configuration (throwaway
+ * docker/Keycloak test realm). Overridable via environment variables,
+ * mirroring how the service URLs are handled.
  */
 export const AUTH = {
-  USERNAME: 'testUser',
-  PASSWORD: 'drowssap'
+  USERNAME: process.env.PLAYWRIGHT_TEST_USERNAME || 'testUser',
+  PASSWORD: process.env.PLAYWRIGHT_TEST_PASSWORD || 'drowssap'
 };
 
 /**
@@ -38,8 +40,8 @@ export const KEYCLOAK_CONFIG = {
  * 'user' role — missing the 'read' role required by the processor.
  */
 export const LIMITED_USER_CONFIG = {
-  USERNAME: 'limitedUser',
-  PASSWORD: 'drowssap',
+  USERNAME: process.env.PLAYWRIGHT_LIMITED_USERNAME || 'limitedUser',
+  PASSWORD: process.env.PLAYWRIGHT_LIMITED_PASSWORD || 'drowssap',
 };
 
 /**
@@ -50,9 +52,9 @@ export const LIMITED_USER_CONFIG = {
 export const OTHER_REALM_CONFIG = {
   REALM: 'other_realm',
   CLIENT_ID: 'other_client',
-  CLIENT_SECRET: 'otherClientSecretValue123456789',
-  USERNAME: 'otherUser',
-  PASSWORD: 'drowssap',
+  CLIENT_SECRET: process.env.PLAYWRIGHT_OTHER_REALM_CLIENT_SECRET || 'otherClientSecretValue123456789',
+  USERNAME: process.env.PLAYWRIGHT_OTHER_REALM_USERNAME || 'otherUser',
+  PASSWORD: process.env.PLAYWRIGHT_OTHER_REALM_PASSWORD || 'drowssap',
   TOKEN_ENDPOINT: (process.env.PLAYWRIGHT_KEYCLOAK_URL || 'https://localhost:9085') + '/realms/other_realm/protocol/openid-connect/token'
 };
 

--- a/e-2-e-playwright/utils/processor.js
+++ b/e-2-e-playwright/utils/processor.js
@@ -415,6 +415,10 @@ export class ProcessorService {
       attempts++;
       if (attempts < maxAttempts) {
         testLogger.info('Processor',`[Processor] Waiting before retry ${attempts}/${maxAttempts}`);
+        // Polling interval between frame-detection attempts. There is no single
+        // observable condition to wait on here — the surrounding retry loop IS the
+        // condition (frame appears, loads, and passes the stability check), so a
+        // short pacing sleep between iterations is intentional.
         await this.page.waitForTimeout(500);
       }
     }

--- a/e-2-e-playwright/utils/run-tests-with-precheck.js
+++ b/e-2-e-playwright/utils/run-tests-with-precheck.js
@@ -4,6 +4,12 @@
  * @file Run Tests with Pre-check
  * Ensures self-tests pass before running actual tests
  * @version 1.0.0
+ *
+ * NOTE: This script duplicates the gating that playwright.config.cjs already
+ * enforces via project `dependencies` (auth-setup -> self-tests -> functional/
+ * accessibility). It is kept because the `test` and `test:jwt` npm scripts and
+ * the docs reference it — it additionally provides an explicit fail-fast run
+ * of the self-tests with friendlier console output before the main suite.
  */
 
 import { spawn } from 'child_process';

--- a/nifi-cuioss-ui/eslint.config.js
+++ b/nifi-cuioss-ui/eslint.config.js
@@ -37,12 +37,11 @@ export default [
             '@stylistic': stylistic
         },
         languageOptions: {
-            ecmaVersion: 2020,
+            ecmaVersion: 2022,
             sourceType: 'module',
             globals: {
                 ...globals.browser,
                 ...globals.node,
-                ...globals.jest,
                 globalThis: 'readonly'
             }
         },
@@ -87,8 +86,36 @@ export default [
         }
     },
     {
+        // Production webapp source: console is forbidden — use the `log` utility
+        // from utils.js instead. The only sanctioned exceptions (below) are
+        // utils.js itself (it implements the log wrapper) and nifi-common-init.js
+        // (a classic non-module script that cannot import utils.js).
+        files: ['src/main/webapp/js/**/*.js'],
+        rules: {
+            'no-console': 'error'
+        }
+    },
+    {
+        files: [
+            'src/main/webapp/js/utils.js',
+            'src/main/webapp/js/nifi-common-init.js'
+        ],
+        rules: {
+            'no-console': ['error', {
+                allow: ['debug', 'info', 'warn', 'error']
+            }]
+        }
+    },
+    {
         files: ['src/test/js/**/*.js'],
         ...jest.configs['flat/recommended'],
+        languageOptions: {
+            ...(jest.configs['flat/recommended'].languageOptions ?? {}),
+            globals: {
+                ...(jest.configs['flat/recommended'].languageOptions?.globals ?? {}),
+                ...globals.jest
+            }
+        },
         rules: {
             ...jest.configs['flat/recommended'].rules,
             'jest/expect-expect': 'error',

--- a/nifi-cuioss-ui/package-lock.json
+++ b/nifi-cuioss-ui/package-lock.json
@@ -16,13 +16,10 @@
         "@testing-library/jest-dom": "^6.4.0",
         "babel-jest": "^30.4.1",
         "eslint": "^10.5.0",
-        "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-jest": "^29.15.2",
-        "eslint-plugin-prettier": "^5.5.6",
         "globals": "^17.7.0",
         "jest": "^30.4.2",
         "jest-environment-jsdom": "^30.4.1",
-        "prettier": "^3.8.4",
         "stylelint": "^17.13.0",
         "stylelint-config-standard": "^40.0.0",
         "stylelint-order": "^8.1.1"
@@ -6147,22 +6144,6 @@
         }
       }
     },
-    "node_modules/eslint-config-prettier": {
-      "version": "10.1.8",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
-      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "eslint-config-prettier": "bin/cli.js"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint-config-prettier"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.0.0"
-      }
-    },
     "node_modules/eslint-plugin-jest": {
       "version": "29.15.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.3.tgz",
@@ -6189,37 +6170,6 @@
           "optional": true
         },
         "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-prettier": {
-      "version": "5.5.6",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.6.tgz",
-      "integrity": "sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.1",
-        "synckit": "^0.11.13"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint-plugin-prettier"
-      },
-      "peerDependencies": {
-        "@types/eslint": ">=8.0.0",
-        "eslint": ">=8.0.0",
-        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
-        "prettier": ">=3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/eslint": {
-          "optional": true
-        },
-        "eslint-config-prettier": {
           "optional": true
         }
       }
@@ -6524,13 +6474,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-diff": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -9462,35 +9405,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/prettier-linter-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
-      "integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-diff": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/pretty-format": {

--- a/nifi-cuioss-ui/package.json
+++ b/nifi-cuioss-ui/package.json
@@ -2,7 +2,7 @@
   "name": "nifi-cuioss-ui",
   "version": "1.0.0",
   "type": "module",
-  "description": "Provides custom UI components for NiFi CU Boulder CUIOSS extensions.",
+  "description": "Provides custom UI components for the CUIOSS NiFi extensions.",
   "main": "src/main/webapp/js/app.js",
   "scripts": {
     "lint": "eslint .",
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/CU-Boulder-OIT/nifi-cuioss.git"
+    "url": "https://github.com/cuioss/nifi-extensions.git"
   },
   "keywords": [
     "NiFi",
@@ -24,12 +24,12 @@
     "JWT",
     "CUIOSS"
   ],
-  "author": "OIT-CSS",
+  "author": "CUIOSS",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/CU-Boulder-OIT/nifi-cuioss/issues"
+    "url": "https://github.com/cuioss/nifi-extensions/issues"
   },
-  "homepage": "https://github.com/CU-Boulder-OIT/nifi-cuioss#readme",
+  "homepage": "https://github.com/cuioss/nifi-extensions#readme",
   "devDependencies": {
     "@babel/core": "^8.0.1",
     "@babel/preset-env": "^8.0.2",
@@ -38,13 +38,10 @@
     "@testing-library/jest-dom": "^6.4.0",
     "babel-jest": "^30.4.1",
     "eslint": "^10.5.0",
-    "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-jest": "^29.15.2",
-    "eslint-plugin-prettier": "^5.5.6",
     "globals": "^17.7.0",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
-    "prettier": "^3.8.4",
     "stylelint": "^17.13.0",
     "stylelint-config-standard": "^40.0.0",
     "stylelint-order": "^8.1.1"
@@ -90,9 +87,6 @@
     "resetMocks": true,
     "clearMocks": true,
     "restoreMocks": true,
-    "moduleNameMapper": {
-      "^nf.Common$": "<rootDir>/src/test/js/mocks/nf-common.js"
-    },
     "setupFiles": [
       "<rootDir>/src/test/js/jest.setup-fetch.js"
     ],

--- a/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/service/JwtValidationService.java
+++ b/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/service/JwtValidationService.java
@@ -334,9 +334,8 @@ public class JwtValidationService {
             return tokenContent;
         }
 
-        @Nullable
         public String getIssuer() {
-            return tokenContent != null ? tokenContent.getIssuer() : null;
+            return tokenContent != null ? tokenContent.getIssuer() : "";
         }
 
         public boolean isAuthorized() {

--- a/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/JwtVerificationServlet.java
+++ b/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/JwtVerificationServlet.java
@@ -271,7 +271,7 @@ public class JwtVerificationServlet extends HttpServlet {
                 .add(JSON_KEY_VALID, result.isValid())
                 .add("error", result.getError() != null ? result.getError() : "");
 
-        if (result.getIssuer() != null) {
+        if (!result.getIssuer().isEmpty()) {
             builder.add(JSON_KEY_ISSUER, result.getIssuer());
         }
 

--- a/nifi-cuioss-ui/src/main/webapp/js/api.js
+++ b/nifi-cuioss-ui/src/main/webapp/js/api.js
@@ -554,12 +554,14 @@ export const resolveJwtConfigServiceId = async (processorId) => {
 // Backward-compatible aliases
 /** @deprecated Use getComponentProperties instead */
 export const getProcessorProperties = async (processorId) => {
+    assertValidUuid(processorId, 'Processor ID');
     await getProxyContextPath();
     return request('GET', nifiApiUrl(`/nifi-api/processors/${processorId}`));
 };
 
 /** @deprecated Use updateComponentProperties instead */
 export const updateProcessorProperties = async (processorId, properties) => {
+    assertValidUuid(processorId, 'Processor ID');
     await getProxyContextPath();
     const proc = await request('GET', nifiApiUrl(`/nifi-api/processors/${processorId}`));
     return request('PUT', nifiApiUrl(`/nifi-api/processors/${processorId}`), {

--- a/nifi-cuioss-ui/src/main/webapp/js/api.js
+++ b/nifi-cuioss-ui/src/main/webapp/js/api.js
@@ -209,6 +209,7 @@ const request = async (method, url, body = null, { componentId } = {}) => {
  * @returns {Promise<{type: string, componentClass: string, apiPath: string, propsPath: string[]}>}
  */
 const detectComponentType = async (componentId) => {
+    assertValidUuid(componentId);
     const cached = _componentInfoCache.get(componentId);
     if (cached) return cached;
 
@@ -257,6 +258,7 @@ export const verifyToken = (token) =>
  * @returns {Promise<Object>}  NiFi REST API response
  */
 export const getComponentProperties = async (componentId) => {
+    assertValidUuid(componentId);
     await getProxyContextPath();
     const info = await detectComponentType(componentId);
     const data = await request('GET', nifiApiUrl(`${info.apiPath}/${componentId}`));
@@ -276,6 +278,7 @@ export const getComponentProperties = async (componentId) => {
  * @returns {Promise<Object>}  updated component response
  */
 export const updateComponentProperties = async (componentId, properties) => {
+    assertValidUuid(componentId);
     await getProxyContextPath();
     const info = await detectComponentType(componentId);
 

--- a/nifi-cuioss-ui/src/main/webapp/js/app.js
+++ b/nifi-cuioss-ui/src/main/webapp/js/app.js
@@ -236,7 +236,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initTabs();
     initCollapsibles();
     applyI18nToDom();
-    initComponents();
+    initComponents().catch((e) => log.error('Component initialisation failed:', e));
     log.info('Component UI ready');
 });
 

--- a/nifi-cuioss-ui/src/main/webapp/js/endpoint-tester.js
+++ b/nifi-cuioss-ui/src/main/webapp/js/endpoint-tester.js
@@ -213,6 +213,8 @@ const loadRoutes = async (container) => {
     }
 };
 
+const DEFAULT_METHODS = ['GET', 'POST', 'PUT', 'DELETE'];
+
 const updateMethodsForRoute = (container) => {
     const selector = container.querySelector('.route-selector');
     const methodSelector = container.querySelector('.method-selector');
@@ -220,15 +222,13 @@ const updateMethodsForRoute = (container) => {
 
     if (!selected) return;
 
-    const methods = selected.dataset.methods;
-    if (methods) {
-        const allowed = methods.split(',').filter(Boolean);
-        if (allowed.length > 0) {
-            methodSelector.innerHTML = allowed.map((m) =>
-                `<option value="${escapeAttr(m)}">${escapeHtml(m)}</option>`
-            ).join('');
-        }
-    }
+    const allowed = (selected.dataset.methods || '').split(',').filter(Boolean);
+    // Routes without a methods restriction accept the default method set —
+    // rebuild the dropdown so no stale restriction from a previous route remains.
+    const methods = allowed.length > 0 ? allowed : DEFAULT_METHODS;
+    methodSelector.innerHTML = methods.map((m) =>
+        `<option value="${escapeAttr(m)}">${escapeHtml(m)}</option>`
+    ).join('');
 };
 
 const updateBodyVisibility = (container) => {
@@ -296,8 +296,9 @@ const displayResponse = (container, result) => {
     // Headers
     const headersEl = display.querySelector('.response-headers');
     const responseHeaders = result.headers || {};
+    // No escaping needed — textContent assignment never interprets HTML
     const headerLines = Object.entries(responseHeaders)
-        .map(([k, v]) => `${escapeHtml(k)}: ${escapeHtml(v)}`)
+        .map(([k, v]) => `${k}: ${v}`)
         .join('\n');
     headersEl.textContent = headerLines || t('tester.response.no.headers');
 

--- a/nifi-cuioss-ui/src/main/webapp/js/issuer-config.js
+++ b/nifi-cuioss-ui/src/main/webapp/js/issuer-config.js
@@ -182,6 +182,7 @@ const buildIssuerFields = (form, fields, idx, properties, issuerName = '*') => {
     addField({ container: fields, idx, name: 'jwks-url', label: t('issuer.form.jwks.url.label'),
         placeholder: t('issuer.form.jwks.url.placeholder'),
         value: properties?.['jwks-url'], extraClass: 'jwks-type-url',
+        hidden: jwksType !== 'url',
         helpKey: 'contexthelp.issuer.jwks.url', propertyKey: `issuer.${iName}.jwks-url`,
         currentValue: properties?.['jwks-url'] });
     addField({ container: fields, idx, name: 'jwks-file', label: t('issuer.form.jwks.file.label'),
@@ -297,7 +298,7 @@ const addIssuerForm = (container, issuerName, properties, componentId) => {
 
     const removeBtn = document.createElement('button');
     removeBtn.className = 'remove-issuer-button';
-    removeBtn.title = 'Delete this issuer configuration';
+    removeBtn.title = t('issuer.remove.title');
     removeBtn.innerHTML = `<i class="fa fa-trash"></i> ${t('common.btn.remove')}`;
     header.appendChild(removeBtn);
 
@@ -571,10 +572,10 @@ const createIssuerTableRow = (name, props, ctx, issuersContainer, origin = 'pers
         <td><span class="method-badge">${typeBadgeHtml}</span></td>
         <td>${sanitizeHtml(issuerUri)}</td>
         <td>
-            <button class="edit-issuer-button" title="Edit issuer">
+            <button class="edit-issuer-button" title="${t('issuer.table.edit.title')}">
                 <i class="fa fa-pencil"></i> ${t('common.btn.edit')}</button>
             <button class="remove-issuer-gw-button"
-                    title="Delete issuer">
+                    title="${t('issuer.table.remove.title')}">
                 <i class="fa fa-trash"></i> ${t('common.btn.remove')}</button>
         </td>`;
 

--- a/nifi-cuioss-ui/src/main/webapp/js/metrics.js
+++ b/nifi-cuioss-ui/src/main/webapp/js/metrics.js
@@ -144,11 +144,13 @@ export const init = (container, isGateway = false,
 
     // Initial load + periodic refresh (gateway only)
     refreshMetrics();
+    // Re-init (tab re-render) must not stack or leak a previous interval,
+    // regardless of the new isGateway/refreshIntervalMs values
+    if (metricsInterval) {
+        clearInterval(metricsInterval);
+        metricsInterval = null;
+    }
     if (isGateway && refreshIntervalMs > 0) {
-        // Re-init (tab re-render) must not stack a second interval
-        if (metricsInterval) {
-            clearInterval(metricsInterval);
-        }
         metricsInterval = setInterval(refreshMetrics, refreshIntervalMs);
     }
 };

--- a/nifi-cuioss-ui/src/main/webapp/js/metrics.js
+++ b/nifi-cuioss-ui/src/main/webapp/js/metrics.js
@@ -106,12 +106,19 @@ const buildGatewayTemplate = () => `
 // Public API
 // ---------------------------------------------------------------------------
 
+/** Default auto-refresh interval for gateway metrics (ms). */
+const DEFAULT_REFRESH_INTERVAL_MS = 10000;
+
 /**
  * Initialise the Metrics tab inside the given container element.
  * @param {HTMLElement} container  the #metrics pane
  * @param {boolean} [isGateway=false]  whether to show gateway metrics
+ * @param {Object} [options]  optional settings
+ * @param {number} [options.refreshIntervalMs=10000]  auto-refresh interval for
+ *     gateway metrics; pass 0 to disable periodic refresh (injection point for tests)
  */
-export const init = (container, isGateway = false) => {
+export const init = (container, isGateway = false,
+    { refreshIntervalMs = DEFAULT_REFRESH_INTERVAL_MS } = {}) => {
     if (!container || container.querySelector('#jwt-metrics-content')) return;
     _isGateway = isGateway;
 
@@ -137,8 +144,8 @@ export const init = (container, isGateway = false) => {
 
     // Initial load + periodic refresh (gateway only)
     refreshMetrics();
-    if (typeof jest === 'undefined' && isGateway) {
-        metricsInterval = setInterval(refreshMetrics, 10000);
+    if (isGateway && refreshIntervalMs > 0) {
+        metricsInterval = setInterval(refreshMetrics, refreshIntervalMs);
     }
 };
 
@@ -320,12 +327,24 @@ const exportAsCsv = (data) => {
         filename: `gateway-metrics-${Date.now()}.csv` };
 };
 
+/**
+ * Escape a Prometheus label value per the exposition format:
+ * backslash, double-quote, and line feed must be backslash-escaped.
+ * (HTML entity escaping would corrupt the exported metrics.)
+ * @param {string} value  raw label value
+ * @returns {string}
+ */
+const escapePrometheusLabel = (value) => String(value)
+    .replaceAll('\\', '\\\\')
+    .replaceAll('"', '\\"')
+    .replaceAll('\n', '\\n');
+
 /** Format a single Prometheus counter section. */
 const formatPrometheusSection = (metricName, helpText, counters, labelName) => {
     let output = `# HELP ${metricName} ${helpText}\n`;
     output += `# TYPE ${metricName} counter\n`;
     for (const [key, value] of Object.entries(counters)) {
-        output += `${metricName}{${labelName}="${sanitizeHtml(key)}"} ${value}\n`;
+        output += `${metricName}{${labelName}="${escapePrometheusLabel(key)}"} ${value}\n`;
     }
     return output + '\n';
 };

--- a/nifi-cuioss-ui/src/main/webapp/js/metrics.js
+++ b/nifi-cuioss-ui/src/main/webapp/js/metrics.js
@@ -145,6 +145,10 @@ export const init = (container, isGateway = false,
     // Initial load + periodic refresh (gateway only)
     refreshMetrics();
     if (isGateway && refreshIntervalMs > 0) {
+        // Re-init (tab re-render) must not stack a second interval
+        if (metricsInterval) {
+            clearInterval(metricsInterval);
+        }
         metricsInterval = setInterval(refreshMetrics, refreshIntervalMs);
     }
 };

--- a/nifi-cuioss-ui/src/main/webapp/js/nifi-common-init.js
+++ b/nifi-cuioss-ui/src/main/webapp/js/nifi-common-init.js
@@ -1,5 +1,10 @@
 'use strict';
 
+// NOTE: This file is a classic (non-module) script loaded before the module
+// bundle, so it cannot import the `log` utility from utils.js. The raw
+// console.warn calls below are a documented exception to the CLAUDE.md
+// "no raw console.log — use the log utility from utils.js" rule.
+
 // In production, NiFi provides the nf.Common object
 // Map it to nfCommon for compatibility with our code
 if (globalThis.nf !== undefined && globalThis.nf.Common) {

--- a/nifi-cuioss-ui/src/main/webapp/js/rest-endpoint-config.js
+++ b/nifi-cuioss-ui/src/main/webapp/js/rest-endpoint-config.js
@@ -12,7 +12,7 @@ import { getComponentId } from './api.js';
 import * as api from './api.js';
 import {
     sanitizeHtml, displayUiError, displayUiSuccess, confirmRemoveRoute, t,
-    buildOriginBadge
+    buildOriginBadge, log
 } from './utils.js';
 import { createMethodChipInput } from './method-chip-input.js';
 import { createAuthModeChipInput } from './auth-mode-chip-input.js';
@@ -81,6 +81,8 @@ export const init = async (element) => {
         const text = textarea.value;
         navigator.clipboard.writeText(text).then(() => {
             showCopyFeedback(exportSection);
+        }).catch((err) => {
+            log.error('Failed to copy properties to clipboard:', err);
         });
     });
 
@@ -583,11 +585,11 @@ const saveManagementEndpoint = async ({
  */
 const updateManagementTableRow = (row, enabled, authModeValue, rolesValue, scopesValue) => {
     const cells = row.querySelectorAll('td');
-    // cells: 0=name, 1=path, 2=enabled, 3=authmode, 4=actions
+    // cells: 0=name, 1=path, 2=methods, 3=enabled, 4=authmode, 5=actions
     const enabledClass = enabled ? 'status-enabled' : 'status-disabled';
     const enabledText = enabled ? t('common.status.enabled') : t('common.status.disabled');
-    cells[2].innerHTML = `<span class="${enabledClass}">${enabledText}</span>`;
-    cells[3].innerHTML = formatAuthModeBadges(authModeValue);
+    cells[3].innerHTML = `<span class="${enabledClass}">${enabledText}</span>`;
+    cells[4].innerHTML = formatAuthModeBadges(authModeValue);
     row.dataset.mgmtEnabled = String(enabled);
     row.dataset.mgmtAuthMode = authModeValue;
     row.dataset.mgmtRoles = rolesValue;
@@ -630,16 +632,14 @@ const loadExistingConfig = async (container, routesContainer, componentId) => {
         };
         await loadGatewayConfig();
 
-        const connectedRels = await api.getConnectedRelationships(componentId);
-
         if (gwRoutes) {
             // Convert /config route array to route map with source info
             const routes = convertGatewayRoutesToMap(gwRoutes);
-            renderRouteSummaryTable(routesContainer, routes, componentId, connectedRels);
+            renderRouteSummaryTable(routesContainer, routes, componentId);
         } else {
             // Fallback: parse routes from NiFi processor properties only
             const routes = parseRouteProperties(props);
-            renderRouteSummaryTable(routesContainer, routes, componentId, connectedRels);
+            renderRouteSummaryTable(routesContainer, routes, componentId);
         }
     } catch {
         renderRouteSummaryTable(routesContainer, {}, componentId);
@@ -690,7 +690,7 @@ const buildGatewayRouteEntry = (route) => {
 const convertGatewayRoutesToMap = (gwRoutes) => {
     const routes = {};
     for (const route of gwRoutes) {
-        if (!route.name || !route.enabled) continue;
+        if (!route.name) continue;
         routes[route.name] = buildGatewayRouteEntry(route);
     }
     return routes;
@@ -705,9 +705,8 @@ const convertGatewayRoutesToMap = (gwRoutes) => {
  * @param {HTMLElement} container  the .routes-container element
  * @param {Object} routes  parsed route map {name: {path, methods, enabled, ...}}
  * @param {string} componentId  NiFi processor component ID
- * @param {Set<string>} [connectedRels]  set of relationship names wired on the NiFi canvas
  */
-const renderRouteSummaryTable = (container, routes, componentId, connectedRels) => {
+const renderRouteSummaryTable = (container, routes, componentId) => {
     // Remove any existing table
     const existing = container.querySelector('.route-summary-table');
     if (existing) existing.remove();
@@ -738,11 +737,9 @@ const renderRouteSummaryTable = (container, routes, componentId, connectedRels) 
     } else {
         for (const name of routeNames) {
             const routeProps = routes[name];
-            const outcome = routeProps?.['success-outcome']?.trim() || name;
-            const connected = !connectedRels || connectedRels.has(outcome);
             const source = routeProps?._source;
             const origin = (source === 'external' || source === 'both') ? 'external' : 'persisted';
-            const row = createTableRow(name, routeProps, componentId, container, origin, connected);
+            const row = createTableRow(name, routeProps, componentId, container, origin);
             tbody.appendChild(row);
         }
     }
@@ -759,10 +756,9 @@ const renderRouteSummaryTable = (container, routes, componentId, connectedRels) 
  * @param {string} componentId  NiFi processor component ID
  * @param {HTMLElement} routesContainer  the .routes-container element
  * @param {'persisted'|'modified'|'new'|'external'} origin  the route origin state
- * @param {boolean} [connected=true]  whether the route's relationship is wired on the NiFi canvas
  * @returns {HTMLTableRowElement}
  */
-const createTableRow = (name, props, componentId, routesContainer, origin = 'persisted', connected = false) => {
+const createTableRow = (name, props, componentId, routesContainer, origin = 'persisted') => {
     const row = document.createElement('tr');
     row.dataset.routeName = name;
     row.dataset.origin = origin;
@@ -802,8 +798,8 @@ const createTableRow = (name, props, componentId, routesContainer, origin = 'per
     // External routes can be edited (saves as NiFi override) but not deleted (config file owns them)
     const actionsHtml = isExternalOnly
         ? `<button class="edit-route-button" title="${sanitizeHtml(t('route.source.external.edit.tooltip'))}"><i class="fa fa-pencil"></i> ${t('common.btn.edit')}</button>`
-        : `<button class="edit-route-button" title="Edit route"><i class="fa fa-pencil"></i> ${t('common.btn.edit')}</button>
-            <button class="remove-route-button" title="Delete route"><i class="fa fa-trash"></i> ${t('common.btn.remove')}</button>`;
+        : `<button class="edit-route-button" title="${t('route.table.edit.title')}"><i class="fa fa-pencil"></i> ${t('common.btn.edit')}</button>
+            <button class="remove-route-button" title="${t('route.table.remove.title')}"><i class="fa fa-trash"></i> ${t('common.btn.remove')}</button>`;
 
     row.innerHTML = `
         <td>${sanitizeHtml(name)}${originBadge}</td>
@@ -962,7 +958,7 @@ const buildEditorHeader = (idx, rn, routeName, enabledVal) => {
     enabledCheckbox.id = `route-enabled-${idx}`;
     enabledCheckbox.className = 'route-enabled';
     if (enabledVal) enabledCheckbox.checked = true;
-    enabledCheckbox.setAttribute('aria-label', 'Route Enabled');
+    enabledCheckbox.setAttribute('aria-label', t('route.form.enabled.aria'));
     enabledLabel.appendChild(enabledCheckbox);
     enabledLabel.append(` ${t('route.form.enabled')}`);
     const enabledHelp = createContextHelp({
@@ -1215,7 +1211,7 @@ const buildFlowFileFields = (section, idx, rn, properties,
     flowfileCheckbox.id = `create-flowfile-${idx}`;
     flowfileCheckbox.className = 'create-flowfile-checkbox';
     if (createFlowFileVal) flowfileCheckbox.checked = true;
-    flowfileCheckbox.setAttribute('aria-label', 'Create FlowFile');
+    flowfileCheckbox.setAttribute('aria-label', t('route.form.create.flowfile'));
     flowfileLabel.appendChild(flowfileCheckbox);
     flowfileLabel.append(` ${t('route.form.create.flowfile')}`);
 
@@ -1231,8 +1227,6 @@ const buildFlowFileFields = (section, idx, rn, properties,
 
     const existingNames = collectExistingConnectionNames(
         routesContainer, routeName);
-    const datalistOptions = existingNames
-        .map((n) => `<option value="${sanitizeHtml(n)}">`).join('');
 
     const outcomeContainer = document.createElement('div');
     outcomeContainer.className =
@@ -1264,7 +1258,13 @@ const buildFlowFileFields = (section, idx, rn, properties,
 
     const datalist = document.createElement('datalist');
     datalist.id = `connection-names-${idx}`;
-    datalist.innerHTML = datalistOptions;
+    // Build options via DOM APIs — connection names are user-controlled and must
+    // not be interpolated into HTML attribute strings (attribute injection/XSS).
+    for (const n of existingNames) {
+        const opt = document.createElement('option');
+        opt.value = n;
+        datalist.appendChild(opt);
+    }
     outcomeContainer.appendChild(datalist);
     section.appendChild(outcomeContainer);
 
@@ -1327,16 +1327,18 @@ const buildSchemaFields = (section, idx, rn, properties, hasSchema) => {
             <input type="text" id="field-schema-file-${idx}" name="schema-file"
                    class="field-schema-file form-input route-config-field"
                    placeholder="${t('route.form.schema.file.placeholder')}"
-                   value="${sanitizeHtml(fileVal)}"
                    aria-label="Schema file path">
         </div>
         <div class="schema-inline-input${mode === 'inline' ? '' : ' hidden'}">
             <textarea id="field-schema-inline-${idx}" name="schema-inline"
                       class="field-schema-inline form-input route-config-field"
                       placeholder="${t('route.form.schema.inline.placeholder')}"
-                      rows="5" aria-label="Inline JSON Schema"
-            >${sanitizeHtml(inlineVal)}</textarea>
+                      rows="5" aria-label="Inline JSON Schema"></textarea>
         </div>`;
+    // Set user-controlled schema values via DOM APIs after parsing — never
+    // interpolate them into HTML attribute strings (attribute injection/XSS).
+    schemaContainer.querySelector('.field-schema-file').value = fileVal;
+    schemaContainer.querySelector('.field-schema-inline').value = inlineVal;
     section.appendChild(schemaContainer);
 
     const fileRadio = schemaContainer.querySelector('.schema-mode-file');

--- a/nifi-cuioss-ui/src/main/webapp/js/utils.js
+++ b/nifi-cuioss-ui/src/main/webapp/js/utils.js
@@ -127,6 +127,9 @@ export const TRANSLATIONS = {
         'issuer.table.issuer.uri': 'Issuer URI',
         'issuer.table.actions': 'Actions',
         'issuer.table.empty': 'No issuers configured. Click "Add Issuer" to create one.',
+        'issuer.table.edit.title': 'Edit issuer',
+        'issuer.table.remove.title': 'Delete issuer',
+        'issuer.remove.title': 'Delete this issuer configuration',
 
         // -- token verifier --
         'token.input.label': 'Enter Token',
@@ -160,10 +163,13 @@ export const TRANSLATIONS = {
         'route.table.enabled': 'Enabled',
         'route.table.actions': 'Actions',
         'route.table.empty': 'No routes configured. Click "Add Route" to create one.',
+        'route.table.edit.title': 'Edit route',
+        'route.table.remove.title': 'Delete route',
         'route.form.name.label': 'Route Name',
         'route.form.name.placeholder': 'e.g., health-check',
         'route.form.name.title': 'Unique identifier for this route configuration.',
         'route.form.enabled': 'Enabled',
+        'route.form.enabled.aria': 'Route Enabled',
         'route.form.path.label': 'Path',
         'route.form.path.placeholder': '/api/resource (required)',
         'route.form.roles.label': 'Required Roles',
@@ -541,6 +547,9 @@ export const TRANSLATIONS = {
         'issuer.table.issuer.uri': 'Issuer URI',
         'issuer.table.actions': 'Aktionen',
         'issuer.table.empty': 'Keine Issuer konfiguriert. Klicken Sie auf \u201eIssuer hinzuf\u00fcgen\u201c, um einen zu erstellen.',
+        'issuer.table.edit.title': 'Issuer bearbeiten',
+        'issuer.table.remove.title': 'Issuer l\u00f6schen',
+        'issuer.remove.title': 'Diese Issuer-Konfiguration l\u00f6schen',
 
         // -- token verifier --
         'token.input.label': 'Token eingeben',
@@ -574,10 +583,13 @@ export const TRANSLATIONS = {
         'route.table.enabled': 'Aktiviert',
         'route.table.actions': 'Aktionen',
         'route.table.empty': 'Keine Routen konfiguriert. Klicken Sie auf \u201eRoute hinzuf\u00fcgen\u201c, um eine zu erstellen.',
+        'route.table.edit.title': 'Route bearbeiten',
+        'route.table.remove.title': 'Route l\u00f6schen',
         'route.form.name.label': 'Route Name',
         'route.form.name.placeholder': 'z.B. health-check',
         'route.form.name.title': 'Eindeutiger Bezeichner f\u00fcr diese Route-Konfiguration.',
         'route.form.enabled': 'Aktiviert',
+        'route.form.enabled.aria': 'Route aktiviert',
         'route.form.path.label': 'Pfad',
         'route.form.path.placeholder': '/api/resource (erforderlich)',
         'route.form.roles.label': 'Erforderliche Rollen',
@@ -921,13 +933,13 @@ export const buildOriginBadge = (origin) => {
 // ---------------------------------------------------------------------------
 
 /**
- * Format a number with locale-aware thousands separator.
+ * Format a number with locale-aware thousands separator (browser locale).
  * @param {number|null|undefined} n
  * @returns {string}
  */
 export const formatNumber = (n) => {
     if (n == null) return '';
-    return new Intl.NumberFormat('en-US').format(n);
+    return new Intl.NumberFormat(browserLang).format(n);
 };
 
 /**

--- a/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/service/JwtValidationServiceTest.java
+++ b/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/service/JwtValidationServiceTest.java
@@ -109,14 +109,14 @@ class JwtValidationServiceTest {
         }
 
         @Test
-        @DisplayName("Should return null issuer when no token content is available")
-        void shouldReturnNullIssuerWhenNotAvailable() {
+        @DisplayName("Should return empty issuer when no token content is available")
+        void shouldReturnEmptyIssuerWhenNotAvailable() {
             JwtValidationService.TokenValidationResult result =
                     JwtValidationService.TokenValidationResult.failure("error");
 
             String issuer = result.getIssuer();
 
-            assertNull(issuer, "Issuer should be null when not available");
+            assertEquals("", issuer, "Issuer should be empty when not available");
         }
 
         @Test

--- a/nifi-cuioss-ui/src/test/js/api.test.js
+++ b/nifi-cuioss-ui/src/test/js/api.test.js
@@ -139,9 +139,9 @@ describe('getProcessorProperties', () => {
     test('sends GET with processor ID using absolute path', async () => {
         mockJsonResponse({ revision: { version: 1 }, properties: {} });
 
-        const result = await getProcessorProperties('proc-123');
+        const result = await getProcessorProperties('44444444-4444-4444-4444-444444444444');
 
-        expect(globalThis.fetch.mock.calls[0][0]).toBe('/nifi-api/processors/proc-123');
+        expect(globalThis.fetch.mock.calls[0][0]).toBe('/nifi-api/processors/44444444-4444-4444-4444-444444444444');
         expect(result.revision.version).toBe(1);
     });
 });
@@ -153,23 +153,23 @@ describe('getProcessorProperties', () => {
 describe('updateProcessorProperties', () => {
     test('fetches current revision then sends PUT', async () => {
         // First call: GET current processor
-        mockJsonResponse({ revision: { version: 3 }, component: { id: 'proc-123' } });
+        mockJsonResponse({ revision: { version: 3 }, component: { id: '44444444-4444-4444-4444-444444444444' } });
         // Second call: PUT update
         mockJsonResponse({ revision: { version: 4 } });
 
-        const result = await updateProcessorProperties('proc-123', {
+        const result = await updateProcessorProperties('44444444-4444-4444-4444-444444444444', {
             'issuer.keycloak.issuer': 'https://auth.example.com'
         });
 
         expect(globalThis.fetch).toHaveBeenCalledTimes(2);
 
         // First call: GET
-        expect(globalThis.fetch.mock.calls[0][0]).toBe('/nifi-api/processors/proc-123');
+        expect(globalThis.fetch.mock.calls[0][0]).toBe('/nifi-api/processors/44444444-4444-4444-4444-444444444444');
         expect(globalThis.fetch.mock.calls[0][1].method).toBe('GET');
 
         // Second call: PUT
         const [putUrl, putOpts] = globalThis.fetch.mock.calls[1];
-        expect(putUrl).toBe('/nifi-api/processors/proc-123');
+        expect(putUrl).toBe('/nifi-api/processors/44444444-4444-4444-4444-444444444444');
         expect(putOpts.method).toBe('PUT');
         const putBody = JSON.parse(putOpts.body);
         expect(putBody.revision.version).toBe(3);
@@ -191,7 +191,7 @@ describe('detectComponentType', () => {
             componentClass: 'de.cuioss.nifi.processors.auth.MultiIssuerJWTTokenAuthenticator'
         });
 
-        const info = await detectComponentType('comp-123');
+        const info = await detectComponentType('11111111-1111-1111-1111-111111111111');
 
         expect(info.type).toBe('PROCESSOR');
         expect(info.componentClass).toBe(
@@ -206,10 +206,10 @@ describe('detectComponentType', () => {
     test('should send explicit componentId as X-Processor-Id header', async () => {
         mockJsonResponse({ type: 'PROCESSOR', componentClass: 'SomeProcessor' });
 
-        await detectComponentType('my-explicit-id');
+        await detectComponentType('22222222-2222-2222-2222-222222222222');
 
         const headers = globalThis.fetch.mock.calls[0][1].headers;
-        expect(headers['X-Processor-Id']).toBe('my-explicit-id');
+        expect(headers['X-Processor-Id']).toBe('22222222-2222-2222-2222-222222222222');
     });
 
     test('should detect controller service type via WAR servlet', async () => {
@@ -218,7 +218,7 @@ describe('detectComponentType', () => {
             componentClass: 'de.cuioss.nifi.jwt.config.StandardJwtIssuerConfigService'
         });
 
-        const info = await detectComponentType('cs-456');
+        const info = await detectComponentType('33333333-3333-3333-3333-333333333333');
 
         expect(info.type).toBe('CONTROLLER_SERVICE');
         expect(info.componentClass).toBe(
@@ -231,8 +231,8 @@ describe('detectComponentType', () => {
     test('should cache detection result per component ID', async () => {
         mockJsonResponse({ type: 'PROCESSOR', componentClass: 'SomeProcessor' });
 
-        await detectComponentType('comp-123');
-        const cached = await detectComponentType('comp-123');
+        await detectComponentType('11111111-1111-1111-1111-111111111111');
+        const cached = await detectComponentType('11111111-1111-1111-1111-111111111111');
 
         expect(globalThis.fetch).toHaveBeenCalledTimes(1);
         expect(cached.type).toBe('PROCESSOR');
@@ -245,16 +245,16 @@ describe('detectComponentType', () => {
             componentClass: 'ServiceB'
         });
 
-        const infoA = await detectComponentType('id-aaa');
-        const infoB = await detectComponentType('id-bbb');
+        const infoA = await detectComponentType('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+        const infoB = await detectComponentType('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
 
         expect(globalThis.fetch).toHaveBeenCalledTimes(2);
         expect(infoA.type).toBe('PROCESSOR');
         expect(infoB.type).toBe('CONTROLLER_SERVICE');
 
         // Both should be cached independently
-        const cachedA = await detectComponentType('id-aaa');
-        const cachedB = await detectComponentType('id-bbb');
+        const cachedA = await detectComponentType('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+        const cachedB = await detectComponentType('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
         expect(globalThis.fetch).toHaveBeenCalledTimes(2);
         expect(cachedA.type).toBe('PROCESSOR');
         expect(cachedB.type).toBe('CONTROLLER_SERVICE');
@@ -263,7 +263,13 @@ describe('detectComponentType', () => {
     test('should propagate errors from component-info endpoint', async () => {
         mockErrorResponse(500, 'Server Error');
 
-        await expect(detectComponentType('comp-123')).rejects.toThrow('HTTP 500');
+        await expect(detectComponentType('11111111-1111-1111-1111-111111111111')).rejects.toThrow('HTTP 500');
+    });
+
+    test('should reject non-UUID component IDs', async () => {
+        await expect(detectComponentType('../../admin'))
+            .rejects.toThrow('Invalid Component ID');
+        expect(globalThis.fetch).not.toHaveBeenCalled();
     });
 });
 
@@ -273,7 +279,7 @@ describe('detectComponentType', () => {
 
 describe('getComponentProperties', () => {
     test('should extract processor properties via propsPath', async () => {
-        globalThis.jwtAuthConfig = { processorId: 'proc-123' };
+        globalThis.jwtAuthConfig = { processorId: '44444444-4444-4444-4444-444444444444' };
         // Detection call
         mockJsonResponse({ type: 'PROCESSOR', componentClass: 'SomeProcessor' });
         // Properties call — NiFi REST API response structure
@@ -282,15 +288,15 @@ describe('getComponentProperties', () => {
             component: { config: { properties: { 'key1': 'val1' } } }
         });
 
-        const result = await getComponentProperties('proc-123');
+        const result = await getComponentProperties('44444444-4444-4444-4444-444444444444');
 
         expect(result.properties).toEqual({ 'key1': 'val1' });
         expect(result.revision.version).toBe(1);
-        expect(globalThis.fetch.mock.calls[1][0]).toBe('/nifi-api/processors/proc-123');
+        expect(globalThis.fetch.mock.calls[1][0]).toBe('/nifi-api/processors/44444444-4444-4444-4444-444444444444');
     });
 
     test('should extract CS properties via propsPath', async () => {
-        globalThis.jwtAuthConfig = { processorId: 'cs-456' };
+        globalThis.jwtAuthConfig = { processorId: '33333333-3333-3333-3333-333333333333' };
         // Detection call
         mockJsonResponse({ type: 'CONTROLLER_SERVICE', componentClass: 'SomeCS' });
         // Properties call — CS response structure
@@ -299,20 +305,26 @@ describe('getComponentProperties', () => {
             component: { properties: { 'csKey': 'csVal' } }
         });
 
-        const result = await getComponentProperties('cs-456');
+        const result = await getComponentProperties('33333333-3333-3333-3333-333333333333');
 
         expect(result.properties).toEqual({ 'csKey': 'csVal' });
-        expect(globalThis.fetch.mock.calls[1][0]).toBe('/nifi-api/controller-services/cs-456');
+        expect(globalThis.fetch.mock.calls[1][0]).toBe('/nifi-api/controller-services/33333333-3333-3333-3333-333333333333');
     });
 
     test('should return empty properties when path yields null', async () => {
-        globalThis.jwtAuthConfig = { processorId: 'proc-123' };
+        globalThis.jwtAuthConfig = { processorId: '44444444-4444-4444-4444-444444444444' };
         mockJsonResponse({ type: 'PROCESSOR', componentClass: 'SomeProcessor' });
         mockJsonResponse({ revision: { version: 1 }, component: {} });
 
-        const result = await getComponentProperties('proc-123');
+        const result = await getComponentProperties('44444444-4444-4444-4444-444444444444');
 
         expect(result.properties).toEqual({});
+    });
+
+    test('should reject non-UUID component IDs', async () => {
+        await expect(getComponentProperties('not-a-uuid'))
+            .rejects.toThrow('Invalid Component ID');
+        expect(globalThis.fetch).not.toHaveBeenCalled();
     });
 });
 
@@ -322,20 +334,20 @@ describe('getComponentProperties', () => {
 
 describe('updateComponentProperties', () => {
     test('should use config.properties path for PROCESSOR type', async () => {
-        globalThis.jwtAuthConfig = { processorId: 'proc-123' };
+        globalThis.jwtAuthConfig = { processorId: '44444444-4444-4444-4444-444444444444' };
         // Detection
         mockJsonResponse({ type: 'PROCESSOR', componentClass: 'SomeProcessor' });
         // GET current (processor not running)
-        mockJsonResponse({ revision: { version: 5 }, component: { id: 'proc-123', state: 'STOPPED' } });
+        mockJsonResponse({ revision: { version: 5 }, component: { id: '44444444-4444-4444-4444-444444444444', state: 'STOPPED' } });
         // PUT update
         mockJsonResponse({ revision: { version: 6 } });
 
-        await updateComponentProperties('proc-123', { 'key': 'value' });
+        await updateComponentProperties('44444444-4444-4444-4444-444444444444', { 'key': 'value' });
 
         // 3 fetch calls: detect + GET + PUT
         expect(globalThis.fetch).toHaveBeenCalledTimes(3);
         const [putUrl, putOpts] = globalThis.fetch.mock.calls[2];
-        expect(putUrl).toBe('/nifi-api/processors/proc-123');
+        expect(putUrl).toBe('/nifi-api/processors/44444444-4444-4444-4444-444444444444');
         expect(putOpts.method).toBe('PUT');
         const putBody = JSON.parse(putOpts.body);
         expect(putBody.revision.version).toBe(5);
@@ -345,15 +357,15 @@ describe('updateComponentProperties', () => {
     });
 
     test('should use properties path for CONTROLLER_SERVICE type', async () => {
-        globalThis.jwtAuthConfig = { processorId: 'cs-456' };
+        globalThis.jwtAuthConfig = { processorId: '33333333-3333-3333-3333-333333333333' };
         // Detection
         mockJsonResponse({ type: 'CONTROLLER_SERVICE', componentClass: 'SomeCS' });
         // GET current
-        mockJsonResponse({ revision: { version: 2 }, component: { id: 'cs-456' } });
+        mockJsonResponse({ revision: { version: 2 }, component: { id: '33333333-3333-3333-3333-333333333333' } });
         // PUT update
         mockJsonResponse({ revision: { version: 3 } });
 
-        await updateComponentProperties('cs-456', { 'csKey': 'csVal' });
+        await updateComponentProperties('33333333-3333-3333-3333-333333333333', { 'csKey': 'csVal' });
 
         expect(globalThis.fetch).toHaveBeenCalledTimes(3);
         const putBody = JSON.parse(globalThis.fetch.mock.calls[2][1].body);
@@ -449,6 +461,12 @@ describe('updateComponentProperties', () => {
         const autoTermCall = globalThis.fetch.mock.calls[7];
         const autoTermBody = JSON.parse(autoTermCall[1].body);
         expect(autoTermBody.component.config.autoTerminatedRelationships).toEqual(['old-rel']);
+    });
+
+    test('should reject non-UUID component IDs', async () => {
+        await expect(updateComponentProperties('not-a-uuid', { 'key': 'value' }))
+            .rejects.toThrow('Invalid Component ID');
+        expect(globalThis.fetch).not.toHaveBeenCalled();
     });
 });
 
@@ -815,10 +833,10 @@ describe('CSRF token handling', () => {
             get: () => '__Secure-Request-Token=test-csrf-token',
             configurable: true
         });
-        globalThis.jwtAuthConfig = { processorId: 'comp-123' };
+        globalThis.jwtAuthConfig = { processorId: '11111111-1111-1111-1111-111111111111' };
         mockJsonResponse({ type: 'PROCESSOR', componentClass: 'Test' });
 
-        await detectComponentType('comp-123');
+        await detectComponentType('11111111-1111-1111-1111-111111111111');
 
         const headers = globalThis.fetch.mock.calls[0][1].headers;
         expect(headers['Request-Token']).toBeUndefined();

--- a/nifi-cuioss-ui/src/test/js/endpoint-tester.test.js
+++ b/nifi-cuioss-ui/src/test/js/endpoint-tester.test.js
@@ -111,6 +111,31 @@ describe('endpoint-tester', () => {
         expect(options).toEqual(['GET']);
     });
 
+    it('should reset methods to defaults when switching to an unrestricted route', async () => {
+        api.fetchGatewayApi.mockResolvedValue({
+            ...SAMPLE_CONFIG,
+            routes: [
+                { name: 'health', path: '/api/health', methods: ['GET'], requiredRoles: [], requiredScopes: [] },
+                { name: 'open', path: '/api/open', methods: [], requiredRoles: [], requiredScopes: [] }
+            ]
+        });
+
+        await init(container);
+
+        const routeSelector = container.querySelector('.route-selector');
+        const methodSelector = container.querySelector('.method-selector');
+
+        // Initially the restricted health route limits methods to GET
+        expect(Array.from(methodSelector.options).map((o) => o.value)).toEqual(['GET']);
+
+        // Switching to the unrestricted route must restore the default set
+        routeSelector.selectedIndex = 1;
+        routeSelector.dispatchEvent(new Event('change'));
+
+        const options = Array.from(methodSelector.options).map((o) => o.value);
+        expect(options).toEqual(['GET', 'POST', 'PUT', 'DELETE']);
+    });
+
     it('should toggle body editor based on method', async () => {
         await init(container);
 
@@ -317,6 +342,23 @@ describe('endpoint-tester', () => {
 
         const headers = container.querySelector('.response-headers');
         expect(headers.textContent).toContain('Content-Type');
+    });
+
+    it('should not double-escape header names or values', async () => {
+        api.sendGatewayTestRequest.mockResolvedValue({
+            status: 200,
+            headers: { 'X-Custom': 'a&b <c>' },
+            body: '{}'
+        });
+
+        await init(container);
+
+        container.querySelector('.send-request-button').click();
+        await new Promise((r) => setTimeout(r, 10));
+
+        const headers = container.querySelector('.response-headers');
+        // textContent renders literally — no &amp; / &lt; artifacts
+        expect(headers.textContent).toContain('X-Custom: a&b <c>');
     });
 
     it('should show body editor for POST method', async () => {

--- a/nifi-cuioss-ui/src/test/js/jest.setup-fetch.js
+++ b/nifi-cuioss-ui/src/test/js/jest.setup-fetch.js
@@ -1,9 +1,4 @@
-// Provide a global fetch mock for Jest (jsdom does not include fetch)
-globalThis.fetch = jest.fn(() =>
-    Promise.resolve({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve({}),
-        text: () => Promise.resolve('')
-    })
-);
+// Provide a global fetch mock for Jest (jsdom does not include fetch).
+// No default implementation — `resetMocks: true` would strip it before every
+// test anyway; tests set up their own responses.
+globalThis.fetch = jest.fn();

--- a/nifi-cuioss-ui/src/test/js/metrics.test.js
+++ b/nifi-cuioss-ui/src/test/js/metrics.test.js
@@ -126,6 +126,22 @@ describe('metrics — gateway mode', () => {
         document.body.innerHTML = '';
     });
 
+    it('should auto-refresh periodically using the injectable interval', async () => {
+        init(container, true, { refreshIntervalMs: 20 });
+        await new Promise((r) => setTimeout(r, 100));
+
+        // Initial load plus at least one interval-driven refresh
+        expect(api.fetchGatewayApi.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    it('should not auto-refresh when the interval is disabled', async () => {
+        init(container, true, { refreshIntervalMs: 0 });
+        await new Promise((r) => setTimeout(r, 60));
+
+        // Only the initial load — no interval registered
+        expect(api.fetchGatewayApi).toHaveBeenCalledTimes(1);
+    });
+
     it('should render gateway template with three sections', async () => {
         init(container, true);
         await new Promise((r) => setTimeout(r, 50));

--- a/nifi-cuioss-ui/src/test/js/mocks/nf-common.js
+++ b/nifi-cuioss-ui/src/test/js/mocks/nf-common.js
@@ -1,8 +1,0 @@
-// Mock for nf.Common used in NiFi framework shim
-module.exports = {
-    formatValue: (v) => v,
-    substringAfterLast: (str, sep) => {
-        const idx = str.lastIndexOf(sep);
-        return idx >= 0 ? str.substring(idx + sep.length) : str;
-    }
-};

--- a/nifi-cuioss-ui/src/test/js/rest-endpoint-config.test.js
+++ b/nifi-cuioss-ui/src/test/js/rest-endpoint-config.test.js
@@ -82,9 +82,6 @@ describe('rest-endpoint-config', () => {
             onConfirm();
             return Promise.resolve(true);
         });
-        // Default: all relationships appear connected (bootstrapped on NiFi canvas)
-        api.getConnectedRelationships.mockResolvedValue(new Set(['health', 'data', 'api-data']));
-
         // Reset location (URL set via @jest-environment-options docblock)
         history.replaceState({}, '', '/nifi-jwt-ui/?id=test-processor-id');
 
@@ -878,6 +875,55 @@ describe('rest-endpoint-config', () => {
         expect(fileInput.value).toBe('./conf/schemas/my-schema.json');
     });
 
+    it('should not allow a malicious schema file path to break out of the value attribute', async () => {
+        const payload = 'x" autofocus onfocus="alert(1)';
+        const propsWithEvilSchema = {
+            ...SAMPLE_PROPERTIES,
+            'restapi.health.schema': payload
+        };
+        api.getComponentProperties.mockResolvedValue({
+            properties: propsWithEvilSchema,
+            revision: { version: 1 }
+        });
+
+        await init(container);
+
+        const healthRow = container.querySelector('tr[data-route-name="health"]');
+        healthRow.querySelector('.edit-route-button').click();
+
+        const form = container.querySelector('.route-form');
+        const fileInput = form.querySelector('.field-schema-file');
+        // The full payload must land in the input's value, not in new attributes
+        expect(fileInput.value).toBe(payload);
+        expect(fileInput.hasAttribute('onfocus')).toBe(false);
+        expect(fileInput.hasAttribute('autofocus')).toBe(false);
+        expect(form.querySelector('[onfocus]')).toBeNull();
+    });
+
+    it('should not allow a malicious connection name to break out of the datalist option attribute', async () => {
+        const payload = 'x" onfocus="alert(1)';
+        const propsWithEvilOutcome = {
+            ...SAMPLE_PROPERTIES,
+            'restapi.data.success-outcome': payload
+        };
+        api.getComponentProperties.mockResolvedValue({
+            properties: propsWithEvilOutcome,
+            revision: { version: 1 }
+        });
+
+        await init(container);
+
+        // Edit the other route so the datalist collects the evil connection name
+        const healthRow = container.querySelector('tr[data-route-name="health"]');
+        healthRow.querySelector('.edit-route-button').click();
+
+        const form = container.querySelector('.route-form');
+        const options = Array.from(form.querySelectorAll('datalist option'));
+        // The full payload must be the option's value, not attribute spillover
+        expect(options.some((o) => o.value === payload)).toBe(true);
+        expect(form.querySelector('datalist option[onfocus]')).toBeNull();
+    });
+
     it('should show inline mode for inline JSON schema', async () => {
         api.getComponentProperties.mockResolvedValue({
             properties: PROPERTIES_WITH_SCHEMA,
@@ -1209,8 +1255,6 @@ describe('rest-endpoint-config', () => {
     });
 
     it('should show origin badge for all persisted routes regardless of connection', async () => {
-        // Only 'health' is connected; 'data' is not
-        api.getConnectedRelationships.mockResolvedValue(new Set(['health']));
         api.getComponentProperties.mockResolvedValue({
             properties: SAMPLE_PROPERTIES,
             revision: { version: 1 }
@@ -2164,8 +2208,15 @@ describe('rest-endpoint-config', () => {
 
         // Row should be visible again with updated status
         expect(row.classList.contains('hidden')).toBe(false);
-        const enabledCell = row.querySelectorAll('td')[2];
+        // cells: 0=name, 1=path, 2=methods, 3=enabled, 4=authmode, 5=actions
+        const enabledCell = row.querySelectorAll('td')[3];
         expect(enabledCell.querySelector('.status-disabled')).not.toBeNull();
+        // Methods column must be left untouched by the save
+        const methodsCell = row.querySelectorAll('td')[2];
+        expect(methodsCell.querySelector('.method-badge')).not.toBeNull();
+        // Auth-mode column must carry the updated badges
+        const authModeCell = row.querySelectorAll('td')[4];
+        expect(authModeCell.querySelector('.authmode-badge')).not.toBeNull();
     });
 
     it('should close previous management editor when opening another', async () => {
@@ -2206,8 +2257,9 @@ describe('rest-endpoint-config', () => {
         await tick();
 
         // Row should be updated with enabled status
+        // cells: 0=name, 1=path, 2=methods, 3=enabled, 4=authmode, 5=actions
         expect(configRow.classList.contains('hidden')).toBe(false);
-        const enabledCell = configRow.querySelectorAll('td')[2];
+        const enabledCell = configRow.querySelectorAll('td')[3];
         expect(enabledCell.querySelector('.status-enabled')).not.toBeNull();
     });
 
@@ -2488,7 +2540,7 @@ describe('rest-endpoint-config', () => {
             expect(rows.length).toBe(2); // health and data from SAMPLE_PROPERTIES
         });
 
-        it('should not display disabled-test external routes', async () => {
+        it('should display disabled external routes with Disabled status', async () => {
             api.getComponentProperties.mockResolvedValue({
                 properties: SAMPLE_PROPERTIES,
                 revision: { version: 1 }
@@ -2506,9 +2558,10 @@ describe('rest-endpoint-config', () => {
             await init(container);
             await tick();
 
-            // Disabled routes are filtered out by convertGatewayRoutesToMap
+            // Disabled routes must stay visible so they can be re-enabled/deleted
             const dataRow = container.querySelector('tr[data-route-name="data"]');
-            expect(dataRow).toBeNull();
+            expect(dataRow).not.toBeNull();
+            expect(dataRow.querySelector('.status-disabled')).not.toBeNull();
         });
     });
 


### PR DESCRIPTION
Clusters 5+6 of the project-analysis fixes (see `doc/findings-project-analysis.adoc` on branch `claude/project-analysis-fixes-2qj5ff`): `nifi-cuioss-ui` frontend (JS + Jest) and `e-2-e-playwright` hygiene.

## Changes

### Major
- **C5-1 — Management table writes to wrong cells:** `updateManagementTableRow` wrote the Enabled badge into the Methods column (`cells[2]`) and the auth-mode badges into the Enabled column (`cells[3]`); the real Auth Mode column was never updated. Now writes `cells[3]`/`cells[4]`; the tests that encoded the bug were fixed and additionally assert the Methods column stays untouched.
- **C5-2 — Disabled routes vanish from the UI:** `convertGatewayRoutesToMap` skipped disabled routes entirely, so they disappeared from the summary table and could never be re-enabled or deleted via the UI. Only unnamed routes are skipped now.
- **C5-3 — Attribute-injection XSS:** `sanitizeHtml` does not escape double quotes but was used inside double-quoted HTML attributes with user-controlled data (schema paths, connection names). Values are now set via the DOM API (`input.value`, `option.value`); regression tests prove `x" autofocus onfocus="alert(1)` payloads land inertly in `.value`.

### Minor (frontend, C5-4..C5-21)
- Double-escaped header rendering fixed (`textContent` only); stale method restrictions reset when switching to unrestricted routes; `jwks-url` field hidden for non-URL issuer types; floating `initComponents()` promise gets `.catch`; `metrics.js` no longer branches on `typeof jest` (injectable refresh interval); Prometheus label values escaped per exposition format instead of HTML-escaped; clipboard write failure logged; dead `connected` parameter plumbing removed; documented `console.warn` exception for the classic-script bootstrap; hardcoded English strings routed through `t()` with EN+DE keys; `formatNumber` uses the browser locale; `assertValidUuid` applied consistently in `api.js`; unused prettier packages removed; dead `nf.Common` moduleNameMapper+mock removed; `jest.setup-fetch.js` simplified to `jest.fn()`; ESLint tightened (ecmaVersion 2022, jest globals only for tests, `no-console: error` for production sources); package metadata fixed to `cuioss/nifi-extensions`.

### Minor (Playwright E2E, C6-1..C6-7)
- Non-existent `screenshotsDir`/`videosDir` config options removed; dead `playwright:report` script removed; fixed-duration sleeps replaced with condition-based waits (auth indicators, tab visibility, `expect.poll` on focus) — the one remaining sleep is a documented retry-loop pacing delay; per-test axe advisory check logs via `testLogger` and is documented as advisory-only; the accessibility components loop now axe-scans every component including tabs; test credentials overridable via `PLAYWRIGHT_*` environment variables; `run-tests-with-precheck.js` kept (referenced by npm scripts and docs) with a comment documenting the overlap with Playwright project dependencies.

## Verification
- `nifi-cuioss-ui`: 12 Jest suites, 520/520 tests green, coverage thresholds met; `npm run lint` 0 errors.
- `e-2-e-playwright`: `npm run lint` 0 errors.
- `./mvnw -Ppre-commit clean install -DskipTests` then `./mvnw clean install` — BUILD SUCCESS (399 UI Java tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183YX76Sshkxm4A9EaFpE2M

---
_Generated by [Claude Code](https://claude.ai/code/session_0183YX76Sshkxm4A9EaFpE2M)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved UI localization/labels for issuer, route, and accessibility controls.
  * Issuer form now conditionally shows the JWKS URL field only for URL-based JWKS.
  * Added/extended gateway metrics auto-refresh interval configuration.

* **Bug Fixes**
  * Strengthened Playwright reliability with polling-based waits and advisory-only accessibility reporting.
  * UUID validation added for component/processor API entry points; safer UI initialization error handling.
  * Improved endpoint tester behavior (default methods), safer response header rendering, and reduced security/escaping risks across forms.

* **Tests**
  * Expanded accessibility, refresh, validation, and security-focused UI coverage.

* **Chores**
  * Updated lint/test setup and Playwright artifact/script defaults; credentials now read from environment variables with fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->