### PR TITLE
chore: update cui-http to 2.0.0 and adopt the stricter HTTP client API

### DIFF
--- a/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/config/IssuerConfigurationParserTest.java
+++ b/nifi-cuioss-common/src/test/java/de/cuioss/nifi/jwt/config/IssuerConfigurationParserTest.java
@@ -504,6 +504,27 @@ class IssuerConfigurationParserTest {
         @Test
         @DisplayName("Should allow non-HTTPS JWKS URL when requirement is disabled")
         void shouldAllowHttpJwksUrlWhenHttpsNotRequired() {
+            // cui-http 2.0.0 refuses to build a cleartext HTTP handler and the token-sheriff
+            // JWKS loader offers no opt-in, so an https:// JWKS URL is required even when the
+            // NiFi-level "Require HTTPS for JWKS URLs" guard and private-address checks are
+            // both lifted. The plaintext-HTTP rejection is covered by the loopback tests below.
+            Map<String, String> properties = new HashMap<>();
+            properties.put("issuer.test.name", "TestIssuer");
+            properties.put("issuer.test.jwks-url", "https://localhost:8080/jwks");
+            properties.put(JwtAttributes.Properties.Validation.REQUIRE_HTTPS_FOR_JWKS, "false");
+            properties.put(JwtAttributes.Properties.Validation.JWKS_ALLOW_PRIVATE_NETWORK_ADDRESSES, "true");
+
+            List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, null);
+
+            assertEquals(1, configs.size(), "JWKS URL should pass when both restrictions are lifted");
+        }
+
+        @Test
+        @DisplayName("Should reject plaintext HTTP JWKS URL even when the HTTPS requirement is disabled")
+        void shouldRejectHttpJwksUrlEvenWhenHttpsNotRequired() {
+            // Even with the NiFi-level HTTPS requirement disabled, cui-http 2.0.0 refuses to
+            // build a plaintext HTTP handler (no allowInsecureHttp opt-in is exposed by the
+            // token-sheriff JWKS loader), so the issuer configuration fails closed.
             Map<String, String> properties = new HashMap<>();
             properties.put("issuer.test.name", "TestIssuer");
             properties.put("issuer.test.jwks-url", "http://localhost:8080/jwks");
@@ -512,7 +533,8 @@ class IssuerConfigurationParserTest {
 
             List<IssuerConfig> configs = IssuerConfigurationParser.parseIssuerConfigs(properties, null);
 
-            assertEquals(1, configs.size(), "HTTP JWKS URL should pass when both restrictions are lifted");
+            assertTrue(configs.isEmpty(), "Plaintext HTTP JWKS URL must not yield an issuer configuration");
+            LogAsserts.assertLogMessagePresentContaining(TestLogLevel.ERROR, "Error creating issuer configuration");
         }
 
         @Test

--- a/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/JwksValidationServlet.java
+++ b/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/JwksValidationServlet.java
@@ -432,6 +432,10 @@ public class JwksValidationServlet extends HttpServlet {
             throws IOException, InterruptedException {
         HttpHandler httpHandler = HttpHandler.builder()
                 .uri(jwksUrl)
+                // The admin-facing validation endpoint deliberately supports plain http
+                // JWKS URLs (see validateUrlScheme); cui-http 2.0.0 requires opting in
+                // explicitly for any http:// target. SSRF protection above still applies.
+                .allowInsecureHttp(true)
                 .connectionTimeoutSeconds(5)
                 .readTimeoutSeconds(10)
                 .build();

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <version.cui.test.value.objects>2.1.3</version.cui.test.value.objects>
         <version.cui.test.mockwebserver>1.5.0</version.cui.test.mockwebserver>
         <version.cui.java.tools>2.7.0</version.cui.java.tools>
-        <version.cui.http>1.4.1</version.cui.http>
+        <version.cui.http>2.0.0</version.cui.http>
         <version.token-sheriff>0.9.0</version.token-sheriff>
         <version.cui.test.keycloak.integration>1.3.0</version.cui.test.keycloak.integration>
         <version.jjwt>0.13.0</version.jjwt>


### PR DESCRIPTION
## Summary

Supersedes #418 (which only bumped the version and left the build red). cui-http `2.0.0` introduced a breaking change: `HttpHandler.builder()...build()` now **refuses to build a plaintext HTTP handler** unless the caller opts in with `allowInsecureHttp(true)`:

> `Refusing to build a plaintext HTTP handler for http://…; HTTPS is required. Call allowInsecureHttp(true) to permit cleartext HTTP, or use an https:// URI.`

## Changes

- **`pom.xml`** — bump `version.cui.http` `1.4.1` → `2.0.0`.
- **`JwksValidationServlet`** — the admin-facing JWKS validation endpoint deliberately supports plain `http` URLs (see `validateUrlScheme`), so it now opts in with `allowInsecureHttp(true)`. Existing SSRF / private-address protection is unchanged.
- **`IssuerConfigurationParserTest`** — the token-sheriff `0.9.0` JWKS loader (latest release) exposes no `allowInsecureHttp` opt-in, so an `http://` JWKS URL can no longer be loaded even when *Require HTTPS for JWKS URLs* is disabled. The parser already fails closed (the loader throws, the config is dropped, and the error is logged). The "https not required" case now uses a valid `https` URL, and a dedicated test asserts the plaintext-HTTP rejection is logged.

## Verification

- `clean install` — green
- `verify -Psonar` (quality gate) — green
- `-Ppre-commit clean install` — green (no reformatting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZ36gbTCQKAEP9gN2fAYze

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZ36gbTCQKAEP9gN2fAYze)_

## Summary by Sourcery

Update HTTP client dependency and align JWKS handling with stricter HTTPS requirements while preserving intended admin validation behavior.

Bug Fixes:
- Ensure plaintext HTTP JWKS URLs are rejected and logged as configuration errors even when HTTPS is not required.

Enhancements:
- Update cui-http dependency to version 2.0.0 and adapt the admin JWKS validation endpoint to explicitly allow insecure HTTP when appropriate.

Build:
- Bump cui-http library version from 1.4.1 to 2.0.0 in the Maven build configuration.

Tests:
- Adjust issuer configuration parsing tests to require HTTPS JWKS URLs by default and add coverage for plaintext HTTP rejection with error logging.