### PR TITLE
chore(plan): sync plan-marshall config schema and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ jest_stdout.log
 # Runtime state (plans, run-configuration, lessons-learned, memory, logs — managed by plan-marshall)
 .plan/*
 !.plan/marshal.json
-!.plan/project-structure.json
 !.plan/project-architecture/
 .plan/local/worktrees/
+!.plan/plugin-doctor.yml
+!.plan/project-structure.json
+

--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -12,7 +12,14 @@
       "effort": "level-3",
       "init_without_asking": true,
       "deep_lane": "auto",
-      "escalation": "auto"
+      "escalation": "auto",
+      "auto_route_recipe": true,
+      "auto_route_recipe_threshold": 0.6,
+      "lane_selection": "ask",
+      "lane_prune_thresholds": {
+        "confidence_complete": 95,
+        "linear_change_max_deliverables": 1
+      }
     },
     "phase-2-refine": {
       "confidence_threshold": 95,
@@ -24,11 +31,13 @@
     "phase-3-outline": {
       "plan_without_asking": false,
       "qgate": "auto",
-      "effort": "level-4"
+      "effort": "level-4",
+      "q_gate_validation": "once"
     },
     "phase-4-plan": {
       "execute_without_asking": true,
-      "effort": "level-3"
+      "effort": "level-3",
+      "q_gate_validation": "once"
     },
     "phase-5-execute": {
       "commit_and_push": true,
@@ -42,12 +51,22 @@
         "default:verify:quality-gate": {},
         "default:verify:module-tests": {},
         "default:verify:integration-tests": {},
-        "default:verify:e2e": {}
+        "default:verify:e2e": {},
+        "default:verify:coverage": {}
       },
       "effort": {
         "default": "level-4",
         "verification-feedback": "level-3"
-      }
+      },
+      "cost_size_token_table": {
+        "XS": "5K",
+        "S": "25K",
+        "M": "60K",
+        "L": "130K",
+        "XL": "260K",
+        "XXL": "520K"
+      },
+      "per_envelope_budget_tokens": "400K"
     },
     "phase-6-finalize": {
       "max_iterations": 3,
@@ -63,7 +82,9 @@
           "auto_rebase_threshold": "no_overlap_only"
         },
         "default:pre-push-quality-gate": {},
-        "default:finalize-step-simplify": {},
+        "default:finalize-step-simplify": {
+          "simplify": "auto"
+        },
         "default:push": {},
         "default:create-pr": {},
         "default:ci-verify": {},
@@ -74,16 +95,32 @@
           "re_review_await_timeout_seconds": 600,
           "re_review_on_timeout": "ask"
         },
-        "default:sonar-roundtrip": {},
+        "default:sonar-roundtrip": {
+          "touched_file_cleanup": "new_code_only",
+          "do_transition": false,
+          "ce_wait_timeout_seconds": 600
+        },
         "default:lessons-capture": {},
         "default:branch-cleanup": {
           "pr_merge_strategy": "squash",
           "final_merge_without_asking": false,
-          "auto_rebase_threshold": "no_overlap_only"
+          "auto_rebase_threshold": "no_overlap_only",
+          "merge_queue_wait_budget_seconds": 1800,
+          "merge_hold_window": "full_window_release_at_waits",
+          "merge_hold_budget_seconds": 3600,
+          "use_merge_queue": false,
+          "admin_merge_on_stuck_state": false
         },
         "default:record-metrics": {},
         "default:finalize-step-print-phase-breakdown": {},
-        "default:archive-plan": {}
+        "default:archive-plan": {},
+        "default:finalize-step-security-audit": {
+          "security_audit": "auto"
+        },
+        "default:architecture-refresh": {},
+        "default:finalize-step-preference-emitter": {
+          "preference_min_recurrence": 2
+        }
       },
       "effort": {
         "default": "level-3",
@@ -138,6 +175,13 @@
           "build_class": "verify"
         }
       ]
+    }
+  },
+  "credentials_config": {
+    "plan-marshall:workflow-integration-sonar": {
+      "url": "https://sonarcloud.io",
+      "organization": "cuioss-github",
+      "project_key": "cuioss_nifi-extensions"
     }
   },
   "project": {
@@ -215,13 +259,6 @@
       "archived_plans_days": 5,
       "lessons_superseded_days": 0,
       "temp_on_maintenance": true
-    }
-  },
-  "credentials_config": {
-    "plan-marshall:workflow-integration-sonar": {
-      "url": "https://sonarcloud.io",
-      "organization": "cuioss-github",
-      "project_key": "cuioss_nifi-extensions"
     }
   }
 }


### PR DESCRIPTION
Adopt new plan-marshall phase config keys (recipe auto-routing, lane selection, q-gate validation, cost/token envelopes, new finalize steps such as security-audit and architecture-refresh) and update the `.gitignore` allowlist for `plugin-doctor.yml`.

Config/gitignore migration only — no production code changes.