### PR TITLE
fix(ui): guard JwksValidationServlet processor-ID lookup with identifier allow-list

### DIFF
--- a/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/JwksValidationServlet.java
+++ b/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/JwksValidationServlet.java
@@ -358,8 +358,14 @@ public class JwksValidationServlet extends HttpServlet {
             return false;
         }
 
+        // Defense-in-depth: the X-Processor-Id header is UUID-validated by
+        // ProcessorIdValidationFilter in production, but this servlet also uses the value
+        // directly as a component lookup key. Reject any value that is not a valid
+        // processor identifier (mirrors the guard the other JWT servlets apply) and fall
+        // back to the safe default rather than passing it to the config reader.
         String processorId = req.getHeader(PROCESSOR_ID_HEADER);
-        if (processorId == null || processorId.isBlank()) {
+        if (processorId == null || processorId.isBlank()
+                || !ProcessorIdHeaderValidator.isValidIdentifier(processorId)) {
             return false;
         }
 

--- a/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/JwksValidationServlet.java
+++ b/nifi-cuioss-ui/src/main/java/de/cuioss/nifi/ui/servlets/JwksValidationServlet.java
@@ -362,10 +362,10 @@ public class JwksValidationServlet extends HttpServlet {
         // ProcessorIdValidationFilter in production, but this servlet also uses the value
         // directly as a component lookup key. Reject any value that is not a valid
         // processor identifier (mirrors the guard the other JWT servlets apply) and fall
-        // back to the safe default rather than passing it to the config reader.
+        // back to the safe default rather than passing it to the config reader. The
+        // allow-list check also covers null/blank/empty (isValidIdentifier returns false).
         String processorId = req.getHeader(PROCESSOR_ID_HEADER);
-        if (processorId == null || processorId.isBlank()
-                || !ProcessorIdHeaderValidator.isValidIdentifier(processorId)) {
+        if (!ProcessorIdHeaderValidator.isValidIdentifier(processorId)) {
             return false;
         }
 

--- a/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/JwksValidationServletTest.java
+++ b/nifi-cuioss-ui/src/test/java/de/cuioss/nifi/ui/servlets/JwksValidationServletTest.java
@@ -831,6 +831,49 @@ class JwksValidationServletTest {
         }
 
         @Test
+        @DisplayName("Should force SSRF-safe default when X-Processor-Id is not a valid identifier")
+        void maliciousProcessorIdForcesSsrfSafeDefault() throws Exception {
+            // Arrange — config WOULD allow private addresses, but the request carries a
+            // traversal-style X-Processor-Id header. The servlet-level identifier guard must
+            // reject it and fall back to the safe default (allowPrivateAddresses=false), so
+            // the loopback JWKS URL stays blocked by SSRF protection (valid=false), rather
+            // than being reached as a component lookup key.
+            String processorId = UUID.randomUUID().toString();
+            Map<String, String> props = Map.of(
+                    "jwt.validation.jwks.allow.private.network.addresses", "true");
+            var details = new ComponentDetails.Builder()
+                    .id(processorId)
+                    .type("JwtAuthenticationProcessor")
+                    .properties(props)
+                    .build();
+            NiFiWebConfigurationContext mockCtx = createNiceMock(NiFiWebConfigurationContext.class);
+            expect(mockCtx.getComponentDetails(anyObject(NiFiWebRequestContext.class)))
+                    .andReturn(details).anyTimes();
+            replay(mockCtx);
+
+            // SSRF protection blocks the loopback address before any HTTP fetch, so no mock
+            // response is enqueued (enqueuing one would leak into sibling tests' shared queue).
+            try (var serverHandle = EmbeddedServletTestSupport.startServer(ctx -> {
+                     ctx.setAttribute("nifi-web-configuration-context", mockCtx);
+                     var holder = new ServletHolder(
+                             new JwksValidationServlet());
+                     ctx.addServlet(holder, URL_ENDPOINT);
+                 })) {
+                serverHandle.spec()
+                        .contentType("application/json")
+                        .header("X-Processor-Id", "../../../etc/passwd")
+                        .body("""
+                                {"jwksUrl":"https://127.0.0.1/.well-known/jwks.json","processorId":"%s"}"""
+                                .formatted(processorId))
+                        .when()
+                        .post(URL_ENDPOINT)
+                        .then()
+                        .statusCode(200)
+                        .body("valid", equalTo(false));
+            }
+        }
+
+        @Test
         @DisplayName("Should reject oversized JWKS URL response end-to-end via servlet")
         void shouldRejectOversizedResponseEndToEnd() throws Exception {
             // Arrange — mock config allowing private addresses


### PR DESCRIPTION
## Summary

Follow-up to #429. `JwksValidationServlet` was the only JWT servlet that used the externally-sourced `X-Processor-Id` header as a component lookup key (`resolveAllowPrivateAddresses`) **without** a servlet-level identifier check — it relied solely on the `ProcessorIdValidationFilter` UUID gate for that path.

This adds the same defense-in-depth guard the other three JWT servlets apply (via `ProcessorIdHeaderValidator.isValidIdentifier`): an invalid processor identifier now falls back to the SSRF-safe default (`allowPrivateAddresses=false`) instead of being passed to the config reader.

## Why

Symmetric defense-in-depth across all four JWT servlets. Not a live vulnerability (the UUID filter guards the path in production), but removes reliance on a single layer and matches the pattern established in #429.

## Testing

- New regression test: a traversal-style `X-Processor-Id` forces the safe default so a loopback JWKS URL stays SSRF-blocked (`valid=false`).
- `JwksValidationServletTest`: 71/71 pass.
- Full reactor `clean install`: green.
- Integration tests (`-Pintegration-tests`): 195/195 pass.