### PR TITLE
fix(build): drop unsafe OpenRewrite UseMapOf recipe from pre-commit profile

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -88,7 +88,7 @@
         "default:push": {},
         "default:create-pr": {},
         "default:ci-verify": {},
-        "default:automated-review": {
+        "plan-marshall:automatic-review": {
           "review_bot_buffer_seconds": 180,
           "re_review_on_loopback": false,
           "re_review_on_branch_cleanup": true,

--- a/pom.xml
+++ b/pom.xml
@@ -713,7 +713,10 @@
                                 <recipe>org.openrewrite.java.migrate.util.OptionalNotPresentToIsEmpty</recipe>
                                 <recipe>org.openrewrite.java.migrate.util.ReplaceStreamCollectWithToList</recipe>
                                 <recipe>org.openrewrite.java.migrate.util.UseLocaleOf</recipe>
-                                <recipe>org.openrewrite.java.migrate.util.UseMapOf</recipe>
+                                <!-- UseMapOf intentionally omitted: it rewrites HashMap.put() chains into
+                                     Map.of(...), which throws on null values/keys and duplicate keys, has
+                                     unspecified iteration order, and previously rewrote unrelated files
+                                     during whole-repo pre-commit runs. -->
                                 <recipe>org.openrewrite.java.OrderImports</recipe>
                                 <recipe>org.openrewrite.java.RemoveUnusedImports</recipe>
                                 <recipe>org.openrewrite.java.ShortenFullyQualifiedTypeReferences</recipe>


### PR DESCRIPTION
## What

Remove `org.openrewrite.java.migrate.util.UseMapOf` from the `pre-commit` Maven profile, and align `.plan/marshal.json` (rename the stale `default:automated-review` finalize step to the canonical `plan-marshall:automatic-review`).

## Why

`UseMapOf` rewrites `new HashMap<>()`+`.put()` chains into `Map.of(...)` (wrapped in `new HashMap<>(Map.of(...))` when the map is later mutated). `Map.of()`:
- throws `NullPointerException` on null values/keys,
- throws `IllegalArgumentException` on duplicate keys,
- has unspecified iteration order.

So the transform silently introduces runtime failures in edge cases. Because `-Ppre-commit` runs OpenRewrite over the whole tree, a recent run rewrote 7 unrelated files (`TokenClaimMapper` + 6 tests). The remaining pre-commit recipes are safe formatting / import / license-header cleanups.

The `marshal.json` change fixes a stale finalize step id (`default:automated-review` has no backing standards file and hard-blocks finalize loadability); it is renamed to `plan-marshall:automatic-review` with its review-bot params preserved.

## Scope

Two-line-ish config change — no Java source or test changes.