### PR TITLE
chore(release): prepare release 0.5.0

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -113,9 +113,13 @@ git diff --quiet HEAD -- README.adoc || git add README.adoc   # stage only if Ni
 git commit -m "chore(release): prepare release <version>"
 git push -u origin chore/release_<version>
 gh pr create --repo cuioss/nifi-extensions --base main \
+  --label "skip-bot-review" \
   --title "chore(release): prepare release <version>" \
   --body "Bump current-version to <version>, next-version to <next>-SNAPSHOT. Triggers the automated Release workflow on merge."
 ```
+
+The release PR is a mechanical version bump (`project.yml` + optional README badge) — no
+code review is necessary, so it carries the **`skip-bot-review`** label to skip bot review.
 
 Use the project commit convention: `Co-Authored-By: Claude <noreply@anthropic.com>` (no
 model name / no "Generated with Claude Code" footer).

--- a/.github/project.yml
+++ b/.github/project.yml
@@ -2,8 +2,8 @@ name: nifi-extensions
 description: CUI NiFi processor extensions with Keycloak OIDC authentication
 
 release:
-  current-version: 0.4.0
-  next-version: 0.5.0-SNAPSHOT
+  current-version: 0.5.0
+  next-version: 0.6.0-SNAPSHOT
   create-github-release: true
 
 maven-build:


### PR DESCRIPTION
Bump current-version to 0.5.0, next-version to 0.6.0-SNAPSHOT. Triggers the automated Release workflow on merge.

Carries the `skip-bot-review` label: this is a mechanical version bump (project.yml only; NiFi badge unchanged at 2.10.0), so no bot code review is necessary.