### PR TITLE
chore(steward): reconcile marshal.json after upgrade to 0.1.1114

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -78,15 +78,25 @@
       "drop_review_on_scope_gate": false,
       "steps": {
         "default:finalize-step-sync-baseline": {
-          "auto_rebase_threshold": "no_overlap_only"
+          "auto_rebase_threshold": "no_overlap_only",
+          "lane": "minimal"
         },
-        "default:pre-push-quality-gate": {},
+        "default:pre-push-quality-gate": {
+          "lane": "minimal"
+        },
         "default:pre-submission-self-review": {
-          "drop_review_on_scope_gate": false
+          "drop_review_on_scope_gate": false,
+          "lane": "auto"
         },
-        "default:finalize-step-simplify": {},
-        "default:finalize-step-security-audit": {},
-        "default:push": {},
+        "default:finalize-step-simplify": {
+          "lane": "auto"
+        },
+        "default:finalize-step-security-audit": {
+          "lane": "full"
+        },
+        "default:push": {
+          "lane": "minimal"
+        },
         "plan-marshall:automatic-review": {
           "review_bot_buffer_seconds": 180,
           "re_review_on_loopback": false,
@@ -99,16 +109,24 @@
           "review_completion_poll_timeout_seconds": 600,
           "lane": "ask"
         },
-        "default:create-pr": {},
-        "default:ci-verify": {},
-        "default:architecture-refresh": {},
+        "default:create-pr": {
+          "lane": "minimal"
+        },
+        "default:ci-verify": {
+          "lane": "minimal"
+        },
+        "default:architecture-refresh": {
+          "lane": "minimal"
+        },
         "default:sonar-roundtrip": {
           "touched_file_cleanup": "new_code_only",
           "do_transition": false,
           "ce_wait_timeout_seconds": 600,
           "lane": "ask"
         },
-        "default:lessons-capture": {},
+        "default:lessons-capture": {
+          "lane": "minimal"
+        },
         "default:adr-propose": {
           "lane": "off"
         },
@@ -121,14 +139,22 @@
           "merge_hold_budget_seconds": 3600,
           "use_merge_queue": false,
           "admin_merge_on_stuck_state": false,
-          "pre_merge_comment_barrier": "fail_into_loopback"
+          "pre_merge_comment_barrier": "fail_into_loopback",
+          "lane": "minimal"
         },
         "default:finalize-step-preference-emitter": {
-          "preference_min_recurrence": 2
+          "preference_min_recurrence": 2,
+          "lane": "minimal"
         },
-        "default:record-metrics": {},
-        "default:finalize-step-print-phase-breakdown": {},
-        "default:archive-plan": {}
+        "default:record-metrics": {
+          "lane": "minimal"
+        },
+        "default:finalize-step-print-phase-breakdown": {
+          "lane": "minimal"
+        },
+        "default:archive-plan": {
+          "lane": "minimal"
+        }
       },
       "effort": {
         "default": "level-3",
@@ -271,7 +297,7 @@
       "lessons_superseded_days": 0,
       "temp_on_maintenance": true
     },
-    "provisioned_version": "0.1.1111",
+    "provisioned_version": "0.1.1114",
     "config_seed_fingerprint": "37df1a33"
   }
 }

--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -73,7 +73,6 @@
       "finalize_without_asking": true,
       "loop_back_without_asking": false,
       "self_review": "auto",
-      "qgate": "auto",
       "simplify": "auto",
       "checks_wait_timeout_seconds": 600,
       "drop_review_on_scope_gate": false,
@@ -83,15 +82,10 @@
         },
         "default:pre-push-quality-gate": {},
         "default:pre-submission-self-review": {
-          "self_review": "auto",
           "drop_review_on_scope_gate": false
         },
-        "default:finalize-step-simplify": {
-          "simplify": "auto"
-        },
-        "default:finalize-step-security-audit": {
-          "security_audit": "auto"
-        },
+        "default:finalize-step-simplify": {},
+        "default:finalize-step-security-audit": {},
         "default:push": {},
         "plan-marshall:automatic-review": {
           "review_bot_buffer_seconds": 180,
@@ -100,7 +94,10 @@
           "re_review_await_timeout_seconds": 600,
           "re_review_on_timeout": "ask",
           "review_rate_window_await": false,
-          "review_rate_window_timeout_seconds": 3600
+          "review_rate_window_timeout_seconds": 3600,
+          "enabled_bots": "coderabbit,sourcery,gemini",
+          "review_completion_poll_timeout_seconds": 600,
+          "lane": "ask"
         },
         "default:create-pr": {},
         "default:ci-verify": {},
@@ -108,9 +105,13 @@
         "default:sonar-roundtrip": {
           "touched_file_cleanup": "new_code_only",
           "do_transition": false,
-          "ce_wait_timeout_seconds": 600
+          "ce_wait_timeout_seconds": 600,
+          "lane": "ask"
         },
         "default:lessons-capture": {},
+        "default:adr-propose": {
+          "lane": "off"
+        },
         "default:branch-cleanup": {
           "pr_merge_strategy": "squash",
           "final_merge_without_asking": false,
@@ -270,7 +271,7 @@
       "lessons_superseded_days": 0,
       "temp_on_maintenance": true
     },
-    "provisioned_version": "0.1.1101",
-    "config_seed_fingerprint": "d30886a0"
+    "provisioned_version": "0.1.1111",
+    "config_seed_fingerprint": "37df1a33"
   }
 }


### PR DESCRIPTION
## Summary

Reconcile `.plan/marshal.json` after the marshall-steward upgrade to plan-marshall **0.1.1114**.

## Changes

- Regenerated the executor (Stage 1) and reconciled config via `sync-defaults` + `steps-sort` (Stage 2).
- Materialized `phase-6-finalize` step **lane** assignments (15 steps: minimal/auto/full) and re-stamped provisioning fields.
- Executor + config verified fresh via `generate_executor preflight` (Stage 3); no content drift.

No behavioral code changes — configuration reconcile only.

## Notes

- Ships two commits: the earlier `0.1.1111` reconcile plus this `0.1.1114` reconcile.
- Labelled `skip-bot-review` — this label fully suppresses only CodeRabbit; Sourcery/Gemini are not label-suppressible on this repo.
