### PR TITLE
fix(e2e): poll issuer names after save to avoid re-render race

### DIFF
--- a/e-2-e-playwright/tests/01-verify-configuration-tab.spec.js
+++ b/e-2-e-playwright/tests/01-verify-configuration-tab.spec.js
@@ -219,27 +219,19 @@ test.describe("Configuration Tab", () => {
         // Verify the issuer "delete-me-issuer" is removed. Removal is async
         // (confirm dialog → API update → re-render); a one-shot read of the input
         // values raced that re-render and saw the stale value, so poll until no
-        // input field carries the removed issuer name.
+        // input field carries the removed issuer name. evaluateAll reads every
+        // input's value in one atomic browser round-trip — a separate count() +
+        // per-index inputValue() sequence can hit a detached element mid-loop
+        // during the re-render and hang until the per-action timeout.
         await expect
             .poll(
-                async () => {
-                    const inputs = customUIFrame.locator(
-                        'input[placeholder="e.g., keycloak"]',
-                    );
-                    const n = await inputs.count();
-                    for (let i = 0; i < n; i++) {
-                        if (
-                            (await inputs.nth(i).inputValue()) ===
-                            "delete-me-issuer"
-                        ) {
-                            return true;
-                        }
-                    }
-                    return false;
-                },
+                () =>
+                    customUIFrame
+                        .locator('input[placeholder="e.g., keycloak"]')
+                        .evaluateAll((inputs) => inputs.map((input) => input.value)),
                 { timeout: 15000 },
             )
-            .toBe(false);
+            .not.toContain("delete-me-issuer");
     });
 
     test("should edit an existing issuer configuration", async ({

--- a/e-2-e-playwright/tests/01-verify-configuration-tab.spec.js
+++ b/e-2-e-playwright/tests/01-verify-configuration-tab.spec.js
@@ -374,17 +374,27 @@ test.describe("Configuration Tab", () => {
         const secondSuccess = secondForm.locator(".success-message");
         await expect(secondSuccess).toBeVisible({ timeout: 10000 });
 
+        // Reads are async relative to the success message (confirm → API update →
+        // re-render), so poll rather than reading input values once — a single-shot
+        // read right after the success message can race the re-render and see a
+        // stale/detached input, hanging inputValue() until timeout.
+        const readIssuerNames = async () => {
+            const inputs = customUIFrame.locator(
+                'input[placeholder="e.g., keycloak"]',
+            );
+            const n = await inputs.count();
+            const out = [];
+            for (let i = 0; i < n; i++) {
+                out.push(await inputs.nth(i).inputValue());
+            }
+            return out;
+        };
+
         // Verify both issuer names are visible
-        const allNameInputs = customUIFrame.locator(
-            'input[placeholder="e.g., keycloak"]',
-        );
-        const names = [];
-        const nameCount = await allNameInputs.count();
-        for (let i = 0; i < nameCount; i++) {
-            names.push(await allNameInputs.nth(i).inputValue());
-        }
-        expect(names).toContain("issuer-one");
-        expect(names).toContain("issuer-two");
+        await expect
+            .poll(async () => await readIssuerNames(), { timeout: 15000 })
+            .toContain("issuer-one");
+        expect(await readIssuerNames()).toContain("issuer-two");
 
         // Remove first added issuer (issuer-one) via its own Remove button
         await firstForm.getByRole("button", { name: "Remove" }).click();
@@ -403,17 +413,6 @@ test.describe("Configuration Tab", () => {
         // Verify only issuer-two remains among the added issuers. Removal is async
         // (confirm → API update → re-render), so poll rather than reading input
         // values once (which raced the re-render and still saw issuer-one).
-        const readIssuerNames = async () => {
-            const inputs = customUIFrame.locator(
-                'input[placeholder="e.g., keycloak"]',
-            );
-            const n = await inputs.count();
-            const out = [];
-            for (let i = 0; i < n; i++) {
-                out.push(await inputs.nth(i).inputValue());
-            }
-            return out;
-        };
         await expect
             .poll(async () => (await readIssuerNames()).includes("issuer-one"), {
                 timeout: 15000,

--- a/e-2-e-playwright/tests/01-verify-configuration-tab.spec.js
+++ b/e-2-e-playwright/tests/01-verify-configuration-tab.spec.js
@@ -237,7 +237,7 @@ test.describe("Configuration Tab", () => {
                     }
                     return false;
                 },
-                { timeout: 10000 },
+                { timeout: 15000 },
             )
             .toBe(false);
     });

--- a/e-2-e-playwright/tests/01-verify-configuration-tab.spec.js
+++ b/e-2-e-playwright/tests/01-verify-configuration-tab.spec.js
@@ -377,24 +377,20 @@ test.describe("Configuration Tab", () => {
         // Reads are async relative to the success message (confirm → API update →
         // re-render), so poll rather than reading input values once — a single-shot
         // read right after the success message can race the re-render and see a
-        // stale/detached input, hanging inputValue() until timeout.
-        const readIssuerNames = async () => {
-            const inputs = customUIFrame.locator(
-                'input[placeholder="e.g., keycloak"]',
-            );
-            const n = await inputs.count();
-            const out = [];
-            for (let i = 0; i < n; i++) {
-                out.push(await inputs.nth(i).inputValue());
-            }
-            return out;
-        };
+        // stale/detached input, hanging inputValue() until timeout. evaluateAll reads
+        // every input's value in one atomic browser round-trip, so a re-render mid-read
+        // can't detach an element between the count() and the per-index inputValue().
+        const readIssuerNames = () =>
+            customUIFrame
+                .locator('input[placeholder="e.g., keycloak"]')
+                .evaluateAll((inputs) => inputs.map((input) => input.value));
 
-        // Verify both issuer names are visible
+        // Verify both issuer names are visible — check both within one poll so a
+        // second issuer rendering slightly after the first can't fail an unpolled
+        // single-shot read.
         await expect
             .poll(async () => await readIssuerNames(), { timeout: 15000 })
-            .toContain("issuer-one");
-        expect(await readIssuerNames()).toContain("issuer-two");
+            .toEqual(expect.arrayContaining(["issuer-one", "issuer-two"]));
 
         // Remove first added issuer (issuer-one) via its own Remove button
         await firstForm.getByRole("button", { name: "Remove" }).click();


### PR DESCRIPTION
## Summary

The `should manage multiple issuers simultaneously` Playwright test failed
reproducibly (twice in a row) in CI on PR #440's e2e-tests check, with:

```
TimeoutError: locator.inputValue: Timeout 10000ms exceeded.
```

## Root cause

Right after the second issuer's save success message becomes visible, the
test read `inputValue()` on all issuer-name inputs in a single-shot loop.
Saving is asynchronous (API update → re-render), so the read could race a
still-detaching/re-rendering input and hang until the Playwright action
timeout. The removal step further down in the same test already guards
against this exact race with `expect.poll()` (see its comment: "Removal is
async ... so poll rather than reading input values once"), but that fix was
never applied to the earlier post-save name check.

## Fix

Hoisted the existing `readIssuerNames` poll helper above the first usage
and applied `expect.poll()` to the post-save name check, mirroring the
already-fixed removal-verification pattern.

## Test plan

- [x] ESLint passes on the modified file
- [ ] CI `e2e-tests` check passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Enhanced verification for deleting issuers in the Configuration tab by switching to a single snapshot read of all issuer name fields after confirmation.
  - Increased the post-removal/presence wait time to reduce flaky behavior.
  - Improved multi-issuer management coverage by polling until the expected set of issuer names appears, improving reliability with asynchronous UI updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->