### PR TITLE
fix(ci): add merge_group trigger to build/e2e/integration-tests workflows

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,6 +8,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,6 +8,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,6 +17,8 @@ on:
     branches: [main, "feature/*", "fix/*", "chore/*", "release/*", "dependabot/**"]
   pull_request:
     branches: [main]
+  merge_group:
+    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

The main-branch merge queue (enabled via marshall-steward earlier today)
was configured without a `merge_group:` trigger on the three caller
workflows. Its required status checks (`build / conclusion`,
`integration-tests / conclusion`, `e2e-tests / conclusion`) never fired
on a merge-queue commit, so every enqueued PR sat in `AWAITING_CHECKS`
indefinitely — the queue ruleset had to be temporarily removed to unblock
merging #441/#443.

## Changes

- Added `merge_group: {branches: [main]}` to `maven.yml`, `e2e-tests.yml`,
  `integration-tests.yml`.
- The reusable workflows already special-case `merge_group` (see the
  `check-changes` job's "Skipped on merge_group" comment and the `gate`
  job's push-vs-other-event branch), so only the trigger declaration was
  missing on the caller side.

## Follow-up

Once this merges, the `plan-marshall-merge-queue` ruleset will be
re-created via `ci repo merge-queue enable` to restore the merge queue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * End-to-end and integration tests now run automatically for merge queue updates targeting the main branch.
* **Build and Validation**
  * Maven workflows now support merge queue events, helping validate changes before they are merged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->