### PR TITLE
fix(e2e): remove e2e-modify-test route via NiFi REST API in gateway-tabs afterAll

### DIFF
--- a/e-2-e-playwright/tests/06-verify-gateway-tabs.spec.js
+++ b/e-2-e-playwright/tests/06-verify-gateway-tabs.spec.js
@@ -13,6 +13,7 @@ import {
 import { CONSTANTS } from "../utils/constants.js";
 import { getValidAccessToken } from "../utils/keycloak-token-service.js";
 import { assertNoAuthError } from "../utils/test-assertions.js";
+import { ProcessorApiManager } from "../utils/processor-api-manager.js";
 
 /**
  * Remove a persisted route by name if it is present in the summary table.
@@ -52,6 +53,18 @@ test.describe("REST API Gateway Tabs", () => {
 
     test.beforeEach(async ({ page }, testInfo) => {
         await takeStartScreenshot(page, testInfo);
+    });
+
+    // Authoritative end-of-test cleanup for the serial block: after all tests run,
+    // remove the persisted e2e-modify-test route by clearing its
+    // restapi.e2e-modify-test.* properties on the RestApiGatewayProcessor directly
+    // via the NiFi REST API. Idempotent — tolerates the already-clean case, leaves
+    // the gateway RUNNING, and introduces no fixed sleep (N64). Reuses the block's
+    // worker-scoped shared page. The removeRouteIfPresent pre-clean calls inside the
+    // tests remain as UI-side defense-in-depth.
+    test.afterAll(async ({ _sharedPage }) => {
+        const processorManager = new ProcessorApiManager(_sharedPage);
+        await processorManager.removeGatewayRouteProperties("e2e-modify-test");
     });
 
     test("should display gateway-specific tabs in custom UI", async ({
@@ -1047,9 +1060,10 @@ test.describe("REST API Gateway Tabs", () => {
             `tbody tr[data-route-name="${routeName}"]`,
         );
         await expect(savedRow).toHaveAttribute("data-origin", "persisted");
-        // No end-cleanup: a just-edited ("modified") route's delete is handled differently by
-        // the UI; the idempotent removeRouteIfPresent at the top of this test removes any
-        // leftover e2e-modify-test on the next run, so residual state cannot accumulate.
+        // End-of-test cleanup is handled by the describe-block afterAll hook, which
+        // clears the restapi.e2e-modify-test.* properties via the NiFi REST API — the
+        // authoritative route removal. The removeRouteIfPresent pre-clean above stays
+        // as UI-side defense-in-depth.
     });
 
     test("should display endpoint tester with route selector and controls", async ({

--- a/e-2-e-playwright/tests/06-verify-gateway-tabs.spec.js
+++ b/e-2-e-playwright/tests/06-verify-gateway-tabs.spec.js
@@ -64,7 +64,15 @@ test.describe("REST API Gateway Tabs", () => {
     // tests remain as UI-side defense-in-depth.
     test.afterAll(async ({ _sharedPage }) => {
         const processorManager = new ProcessorApiManager(_sharedPage);
-        await processorManager.removeGatewayRouteProperties("e2e-modify-test");
+        const cleaned =
+            await processorManager.removeGatewayRouteProperties("e2e-modify-test");
+        // Fail the suite when cleanup did not succeed: a residual route or a
+        // gateway left not-RUNNING must surface as a test failure rather than be
+        // silently swallowed by discarding the boolean result.
+        expect(
+            cleaned,
+            "afterAll cleanup of the e2e-modify-test route failed — the gateway may retain residual restapi.e2e-modify-test.* properties or be left not RUNNING",
+        ).toBe(true);
     });
 
     test("should display gateway-specific tabs in custom UI", async ({

--- a/e-2-e-playwright/utils/processor-api-manager.js
+++ b/e-2-e-playwright/utils/processor-api-manager.js
@@ -1032,7 +1032,11 @@ export class ProcessorApiManager {
    * PUT is accepted (no fixed sleep, N64).
    * @param {string} processorId - target processor id
    * @param {number} [timeoutMs] - overall wait budget in milliseconds
-   * @returns {Promise<object|null>} the last-fetched processor details, or null if it vanished
+   * @returns {Promise<object|null>} the settled processor details, or null if it
+   *   vanished OR the settle timed out. A null return is the caller's signal that
+   *   the processor is NOT safely stopped — never treat a timeout as settled, or a
+   *   subsequent config PUT can still fail with 'Cannot modify configuration while
+   *   the Processor is running' (the PR #445 failure mode).
    */
   async _waitForProcessorSettled(processorId, timeoutMs = TIMEOUTS.MEDIUM) {
     const deadline = Date.now() + timeoutMs;
@@ -1045,8 +1049,12 @@ export class ProcessorApiManager {
       await new Promise(resolve => setTimeout(resolve, 250));
       details = await this.getProcessorDetails(processorId);
     }
+    // Timed out without reaching a physically STOPPED, thread-idle state. Return
+    // null (NOT the last-fetched details) so the caller's `if (!settled)` guard
+    // treats a timeout as a failed settle rather than proceeding to mutate a
+    // still-running processor.
     testLogger.warn('Processor', `Timed out waiting for processor ${processorId} to settle`);
-    return details;
+    return null;
   }
 
   /**
@@ -1168,7 +1176,7 @@ export class ProcessorApiManager {
     if (!settled) {
       testLogger.warn(
         'Processor',
-        `removeGatewayRouteProperties('${routeName}'): gateway processor ${gatewayId} vanished while settling`
+        `removeGatewayRouteProperties('${routeName}'): gateway processor ${gatewayId} did not settle (vanished or timed out) — not safe to mutate config`
       );
       return false;
     }

--- a/e-2-e-playwright/utils/processor-api-manager.js
+++ b/e-2-e-playwright/utils/processor-api-manager.js
@@ -1078,36 +1078,89 @@ export class ProcessorApiManager {
 
   /**
    * PUT the processor config, recovering from a stale-revision 409 by
-   * re-reading the live revision once — never guessing version+1 (N64).
+   * re-reading the live revision once — never guessing version+1 (N64). On a 409
+   * the retry payload is REBUILT from the freshly-read component.config instead of
+   * replaying the pre-conflict DTO: a concurrent edit landing between the first PUT
+   * and the retry can add new restapi.{route}.* keys or grow the
+   * autoTerminatedRelationships set, and replaying the stale DTO would leave the new
+   * keys behind or clobber the newer relationship set. The rebuild re-derives the
+   * route prefix from the keys it was asked to clear (the same restapi.{routeName}.
+   * prefix removeGatewayRouteProperties computed before the first attempt), null-maps
+   * every key live under that prefix in the fresh state, and unions the fresh
+   * auto-terminated set with the requested relationships. After the rebuilt retry the
+   * live config is re-read and confirmed free of every key under the route prefix
+   * before returning true.
    * @param {string} processorId - target processor id
    * @param {number} version - revision version to attempt first
-   * @param {object} config - partial config DTO (e.g. properties mapped to null, autoTerminatedRelationships)
-   * @returns {Promise<boolean>} true when NiFi accepted the config update
+   * @param {object} config - partial config DTO (properties mapped to null, autoTerminatedRelationships)
+   * @returns {Promise<boolean>} true when NiFi accepted the config update and the route keys are gone
    */
   async _updateProcessorConfigWithFreshRevision(processorId, version, config) {
-    const attempt = rev =>
+    const attempt = (rev, body) =>
       this.makeApiCall(`/nifi-api/processors/${processorId}`, {
         method: 'PUT',
         body: {
           revision: { version: rev },
           component: {
             id: processorId,
-            config
+            config: body
           }
         }
       });
 
-    let result = await attempt(version);
+    let result = await attempt(version, config);
     if (result.ok) return true;
+    if (result.status !== 409) return false;
 
-    if (result.status === 409) {
-      const fresh = await this.getProcessorDetails(processorId);
-      const freshVersion = fresh?.revision?.version;
-      if (freshVersion === undefined || freshVersion === null) return false;
-      result = await attempt(freshVersion);
-      return result.ok;
+    // Stale-revision conflict: re-read the live revision AND the live config, then
+    // rebuild the clear payload from that fresh state so a concurrent edit cannot
+    // leave new route keys behind or clobber a newer auto-terminated set.
+    const fresh = await this.getProcessorDetails(processorId);
+    const freshVersion = fresh?.revision?.version;
+    if (freshVersion === undefined || freshVersion === null) return false;
+
+    // Re-derive the route prefix from the keys we were asked to clear — they all
+    // share the restapi.{routeName}. prefix, mirroring how removeGatewayRouteProperties
+    // computed matchedKeys before the first attempt.
+    const requestedKeys = Object.keys(config.properties || {});
+    let prefix = '';
+    if (requestedKeys.length > 0 && requestedKeys[0].startsWith('restapi.')) {
+      const rest = requestedKeys[0].slice('restapi.'.length);
+      const dot = rest.indexOf('.');
+      if (dot > 0) prefix = `restapi.${rest.slice(0, dot)}.`;
     }
-    return false;
+
+    const freshConfig = fresh.component?.config || {};
+    const freshProps = freshConfig.properties || {};
+
+    // Null-map the originally requested keys plus every key under the route prefix
+    // that is live in the FRESH state (catches keys a concurrent edit added).
+    const rebuiltProps = {};
+    for (const key of requestedKeys) rebuiltProps[key] = null;
+    if (prefix) {
+      for (const key of Object.keys(freshProps)) {
+        if (key.startsWith(prefix)) rebuiltProps[key] = null;
+      }
+    }
+
+    // Union the fresh auto-terminated set with the requested relationships so a
+    // newer set is preserved rather than clobbered.
+    const autoTerminated = new Set(freshConfig.autoTerminatedRelationships || []);
+    for (const rel of config.autoTerminatedRelationships || []) autoTerminated.add(rel);
+
+    result = await attempt(freshVersion, {
+      properties: rebuiltProps,
+      autoTerminatedRelationships: [...autoTerminated]
+    });
+    if (!result.ok) return false;
+
+    // Confirm the retry actually cleared the route before reporting success.
+    if (prefix) {
+      const after = await this.getProcessorDetails(processorId);
+      const liveProps = after?.component?.config?.properties || {};
+      if (Object.keys(liveProps).some(key => key.startsWith(prefix))) return false;
+    }
+    return true;
   }
 
   /**
@@ -1150,6 +1203,29 @@ export class ProcessorApiManager {
       testLogger.info(
         'Processor',
         `removeGatewayRouteProperties('${routeName}'): no properties matching '${prefix}' — already clean`
+      );
+      // Already clean, but the cleanup contract requires a RUNNING gateway. A clean
+      // gateway that is STOPPED (or in any non-RUNNING physical state) must be
+      // started and confirmed RUNNING before we report success — otherwise later
+      // suites inherit a stopped gateway. Reuse the same state-check / start /
+      // confirm pattern the non-empty-matchedKeys path applies at the end.
+      const cleanPhysicalState =
+        (details.physicalState || details.component?.state || '').toUpperCase();
+      if (cleanPhysicalState === 'RUNNING') {
+        return true;
+      }
+      const started = await this.setProcessorRunStatusById(gatewayId, 'RUNNING');
+      const running = started && (await this._waitForProcessorRunning(gatewayId));
+      if (!running) {
+        testLogger.warn(
+          'Processor',
+          `removeGatewayRouteProperties('${routeName}'): already clean but gateway ${gatewayId} could not be confirmed RUNNING`
+        );
+        return false;
+      }
+      testLogger.info(
+        'Processor',
+        `removeGatewayRouteProperties('${routeName}'): already clean; started gateway ${gatewayId} and confirmed RUNNING`
       );
       return true;
     }

--- a/e-2-e-playwright/utils/processor-api-manager.js
+++ b/e-2-e-playwright/utils/processor-api-manager.js
@@ -1081,21 +1081,20 @@ export class ProcessorApiManager {
    * re-reading the live revision once — never guessing version+1 (N64). On a 409
    * the retry payload is REBUILT from the freshly-read component.config instead of
    * replaying the pre-conflict DTO: a concurrent edit landing between the first PUT
-   * and the retry can add new restapi.{route}.* keys or grow the
+   * and the retry can add new keys under routePrefix or grow the
    * autoTerminatedRelationships set, and replaying the stale DTO would leave the new
-   * keys behind or clobber the newer relationship set. The rebuild re-derives the
-   * route prefix from the keys it was asked to clear (the same restapi.{routeName}.
-   * prefix removeGatewayRouteProperties computed before the first attempt), null-maps
-   * every key live under that prefix in the fresh state, and unions the fresh
+   * keys behind or clobber the newer relationship set. The rebuild null-maps every
+   * key live under routePrefix in the fresh state, and unions the fresh
    * auto-terminated set with the requested relationships. After the rebuilt retry the
-   * live config is re-read and confirmed free of every key under the route prefix
+   * live config is re-read and confirmed free of every key under routePrefix
    * before returning true.
    * @param {string} processorId - target processor id
    * @param {number} version - revision version to attempt first
    * @param {object} config - partial config DTO (properties mapped to null, autoTerminatedRelationships)
+   * @param {string} routePrefix - the restapi.{routeName}. prefix being cleared
    * @returns {Promise<boolean>} true when NiFi accepted the config update and the route keys are gone
    */
-  async _updateProcessorConfigWithFreshRevision(processorId, version, config) {
+  async _updateProcessorConfigWithFreshRevision(processorId, version, config, routePrefix) {
     const attempt = (rev, body) =>
       this.makeApiCall(`/nifi-api/processors/${processorId}`, {
         method: 'PUT',
@@ -1119,28 +1118,15 @@ export class ProcessorApiManager {
     const freshVersion = fresh?.revision?.version;
     if (freshVersion === undefined || freshVersion === null) return false;
 
-    // Re-derive the route prefix from the keys we were asked to clear — they all
-    // share the restapi.{routeName}. prefix, mirroring how removeGatewayRouteProperties
-    // computed matchedKeys before the first attempt.
-    const requestedKeys = Object.keys(config.properties || {});
-    let prefix = '';
-    if (requestedKeys.length > 0 && requestedKeys[0].startsWith('restapi.')) {
-      const rest = requestedKeys[0].slice('restapi.'.length);
-      const dot = rest.indexOf('.');
-      if (dot > 0) prefix = `restapi.${rest.slice(0, dot)}.`;
-    }
-
     const freshConfig = fresh.component?.config || {};
     const freshProps = freshConfig.properties || {};
 
-    // Null-map the originally requested keys plus every key under the route prefix
+    // Null-map the originally requested keys plus every key under routePrefix
     // that is live in the FRESH state (catches keys a concurrent edit added).
     const rebuiltProps = {};
-    for (const key of requestedKeys) rebuiltProps[key] = null;
-    if (prefix) {
-      for (const key of Object.keys(freshProps)) {
-        if (key.startsWith(prefix)) rebuiltProps[key] = null;
-      }
+    for (const key of Object.keys(config.properties || {})) rebuiltProps[key] = null;
+    for (const key of Object.keys(freshProps)) {
+      if (key.startsWith(routePrefix)) rebuiltProps[key] = null;
     }
 
     // Union the fresh auto-terminated set with the requested relationships so a
@@ -1155,12 +1141,9 @@ export class ProcessorApiManager {
     if (!result.ok) return false;
 
     // Confirm the retry actually cleared the route before reporting success.
-    if (prefix) {
-      const after = await this.getProcessorDetails(processorId);
-      const liveProps = after?.component?.config?.properties || {};
-      if (Object.keys(liveProps).some(key => key.startsWith(prefix))) return false;
-    }
-    return true;
+    const after = await this.getProcessorDetails(processorId);
+    const liveProps = after?.component?.config?.properties || {};
+    return !Object.keys(liveProps).some(key => key.startsWith(routePrefix));
   }
 
   /**
@@ -1272,10 +1255,15 @@ export class ProcessorApiManager {
     autoTerminated.add(routeName);
 
     const version = settled.revision?.version ?? 0;
-    const updated = await this._updateProcessorConfigWithFreshRevision(gatewayId, version, {
-      properties: clearMap,
-      autoTerminatedRelationships: [...autoTerminated]
-    });
+    const updated = await this._updateProcessorConfigWithFreshRevision(
+      gatewayId,
+      version,
+      {
+        properties: clearMap,
+        autoTerminatedRelationships: [...autoTerminated]
+      },
+      prefix
+    );
 
     // Always try to leave the provisioned gateway RUNNING again, even on failure.
     await this.setProcessorRunStatusById(gatewayId, 'RUNNING');

--- a/e-2-e-playwright/utils/processor-api-manager.js
+++ b/e-2-e-playwright/utils/processor-api-manager.js
@@ -1023,8 +1023,13 @@ export class ProcessorApiManager {
   }
 
   /**
-   * Poll a processor until it reports a stable state: not RUNNING and no active
-   * threads. Mirrors the settle loop in removeProcessorById (no fixed sleep, N64).
+   * Poll a processor until its PHYSICAL state is STOPPED with no active threads.
+   * The physicalState field is authoritative here: a start requested while the
+   * processor is INVALID parks it in a pending-start limbo where runStatus
+   * reports 'Invalid' (not 'Running') and component.state reports STOPPED, yet
+   * NiFi still rejects config mutations with 'Cannot modify configuration while
+   * the Processor is running'. Only physicalState === 'STOPPED' guarantees the
+   * PUT is accepted (no fixed sleep, N64).
    * @param {string} processorId - target processor id
    * @param {number} [timeoutMs] - overall wait budget in milliseconds
    * @returns {Promise<object|null>} the last-fetched processor details, or null if it vanished
@@ -1034,10 +1039,9 @@ export class ProcessorApiManager {
     let details = await this.getProcessorDetails(processorId);
     while (Date.now() < deadline) {
       if (!details) return null;
-      const runStatus =
-        details.status?.aggregateSnapshot?.runStatus || details.component?.state || '';
+      const physicalState = (details.physicalState || details.component?.state || '').toUpperCase();
       const activeThreads = details.status?.aggregateSnapshot?.activeThreadCount ?? 0;
-      if (runStatus.toUpperCase() !== 'RUNNING' && activeThreads === 0) return details;
+      if (physicalState === 'STOPPED' && activeThreads === 0) return details;
       await new Promise(resolve => setTimeout(resolve, 250));
       details = await this.getProcessorDetails(processorId);
     }
@@ -1046,7 +1050,7 @@ export class ProcessorApiManager {
   }
 
   /**
-   * Poll a processor until it reports a RUNNING run-status.
+   * Poll a processor until its physical state is RUNNING.
    * @param {string} processorId - target processor id
    * @param {number} [timeoutMs] - overall wait budget in milliseconds
    * @returns {Promise<boolean>} true once the processor is RUNNING, false on timeout
@@ -1055,9 +1059,9 @@ export class ProcessorApiManager {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
       const details = await this.getProcessorDetails(processorId);
-      const runStatus =
-        details?.status?.aggregateSnapshot?.runStatus || details?.component?.state || '';
-      if (runStatus.toUpperCase() === 'RUNNING') return true;
+      const physicalState =
+        (details?.physicalState || details?.component?.state || '').toUpperCase();
+      if (physicalState === 'RUNNING') return true;
       await new Promise(resolve => setTimeout(resolve, 250));
     }
     testLogger.warn('Processor', `Timed out waiting for processor ${processorId} to reach RUNNING`);
@@ -1065,15 +1069,14 @@ export class ProcessorApiManager {
   }
 
   /**
-   * PUT the processor config with the given properties map, recovering from a
-   * stale-revision 409 by re-reading the live revision once — never guessing
-   * version+1 (N64).
+   * PUT the processor config, recovering from a stale-revision 409 by
+   * re-reading the live revision once — never guessing version+1 (N64).
    * @param {string} processorId - target processor id
    * @param {number} version - revision version to attempt first
-   * @param {Object<string, null>} properties - property keys mapped to null (clears them)
-   * @returns {Promise<boolean>} true when NiFi accepted the property update
+   * @param {object} config - partial config DTO (e.g. properties mapped to null, autoTerminatedRelationships)
+   * @returns {Promise<boolean>} true when NiFi accepted the config update
    */
-  async _updateProcessorPropertiesWithFreshRevision(processorId, version, properties) {
+  async _updateProcessorConfigWithFreshRevision(processorId, version, config) {
     const attempt = rev =>
       this.makeApiCall(`/nifi-api/processors/${processorId}`, {
         method: 'PUT',
@@ -1081,7 +1084,7 @@ export class ProcessorApiManager {
           revision: { version: rev },
           component: {
             id: processorId,
-            config: { properties }
+            config
           }
         }
       });
@@ -1103,8 +1106,11 @@ export class ProcessorApiManager {
    * Remove all restapi.{routeName}.* properties from the RestApiGatewayProcessor
    * via the REST API. Idempotent: returns true as a no-op when the gateway
    * processor is absent from the canvas or carries no matching properties. When
-   * properties do match, the processor is stopped (only if RUNNING), polled to a
-   * settled state, its config PUT with each matched key mapped to null, then
+   * properties do match, the processor is stopped (whenever physicalState is not
+   * STOPPED — this also cancels an INVALID pending-start limbo), polled to a
+   * physically STOPPED state, its config PUT with each matched key mapped to
+   * null AND the route's dynamic relationship auto-terminated (else the stale
+   * relationship keeps the processor INVALID and the restart deadlocks), then
    * restarted and confirmed RUNNING — all without a fixed sleep (N64). Stale
    * revisions on the PUT are recovered by re-reading the live revision (N64).
    * @param {string} routeName - route whose restapi.{routeName}.* properties to clear
@@ -1145,14 +1151,19 @@ export class ProcessorApiManager {
       `removeGatewayRouteProperties('${routeName}'): clearing ${matchedKeys.length} property(ies): ${matchedKeys.join(', ')}`
     );
 
-    // Stop the gateway before mutating its config, but only when it is RUNNING.
-    const initialState =
-      details.status?.aggregateSnapshot?.runStatus || details.component?.state || '';
-    if (initialState.toUpperCase() === 'RUNNING') {
+    // Stop the gateway before mutating its config. Judge by physicalState, not
+    // runStatus: a start requested while the processor is INVALID parks it in a
+    // pending-start limbo ('physicalState: STARTING', runStatus 'Invalid') that
+    // still rejects config PUTs with 'Cannot modify configuration while the
+    // Processor is running' — the exact failure that sank the PR #445 UI
+    // cleanup. An explicit STOPPED cancels the pending start.
+    const initialPhysicalState =
+      (details.physicalState || details.component?.state || '').toUpperCase();
+    if (initialPhysicalState !== 'STOPPED') {
       await this.setProcessorRunStatusById(gatewayId, 'STOPPED');
     }
 
-    // Poll to a stable (non-RUNNING, no active threads) state before the PUT.
+    // Poll to a physically STOPPED (no active threads) state before the PUT.
     const settled = await this._waitForProcessorSettled(gatewayId);
     if (!settled) {
       testLogger.warn(
@@ -1162,16 +1173,25 @@ export class ProcessorApiManager {
       return false;
     }
 
-    // Map each matched key to null so NiFi clears it, then PUT the fresh revision.
+    // Map each matched key to null so NiFi clears it. The processor recomputes
+    // its dynamic route relationships only in onScheduled, so clearing the
+    // properties alone leaves a stale '{routeName}' relationship that keeps the
+    // processor INVALID ('not connected and not auto-terminated') and deadlocks
+    // the restart. Auto-terminate that relationship in the same PUT — the same
+    // thing the route-editor UI does on route deletion; the entry becomes a
+    // harmless leftover once onScheduled drops the relationship.
     const clearMap = {};
     for (const key of matchedKeys) clearMap[key] = null;
+    const autoTerminated = new Set(
+      settled.component?.config?.autoTerminatedRelationships || []
+    );
+    autoTerminated.add(routeName);
 
     const version = settled.revision?.version ?? 0;
-    const updated = await this._updateProcessorPropertiesWithFreshRevision(
-      gatewayId,
-      version,
-      clearMap
-    );
+    const updated = await this._updateProcessorConfigWithFreshRevision(gatewayId, version, {
+      properties: clearMap,
+      autoTerminatedRelationships: [...autoTerminated]
+    });
 
     // Always try to leave the provisioned gateway RUNNING again, even on failure.
     await this.setProcessorRunStatusById(gatewayId, 'RUNNING');

--- a/e-2-e-playwright/utils/processor-api-manager.js
+++ b/e-2-e-playwright/utils/processor-api-manager.js
@@ -1021,6 +1021,184 @@ export class ProcessorApiManager {
     }
     return false;
   }
+
+  /**
+   * Poll a processor until it reports a stable state: not RUNNING and no active
+   * threads. Mirrors the settle loop in removeProcessorById (no fixed sleep, N64).
+   * @param {string} processorId - target processor id
+   * @param {number} [timeoutMs] - overall wait budget in milliseconds
+   * @returns {Promise<object|null>} the last-fetched processor details, or null if it vanished
+   */
+  async _waitForProcessorSettled(processorId, timeoutMs = TIMEOUTS.MEDIUM) {
+    const deadline = Date.now() + timeoutMs;
+    let details = await this.getProcessorDetails(processorId);
+    while (Date.now() < deadline) {
+      if (!details) return null;
+      const runStatus =
+        details.status?.aggregateSnapshot?.runStatus || details.component?.state || '';
+      const activeThreads = details.status?.aggregateSnapshot?.activeThreadCount ?? 0;
+      if (runStatus.toUpperCase() !== 'RUNNING' && activeThreads === 0) return details;
+      await new Promise(resolve => setTimeout(resolve, 250));
+      details = await this.getProcessorDetails(processorId);
+    }
+    testLogger.warn('Processor', `Timed out waiting for processor ${processorId} to settle`);
+    return details;
+  }
+
+  /**
+   * Poll a processor until it reports a RUNNING run-status.
+   * @param {string} processorId - target processor id
+   * @param {number} [timeoutMs] - overall wait budget in milliseconds
+   * @returns {Promise<boolean>} true once the processor is RUNNING, false on timeout
+   */
+  async _waitForProcessorRunning(processorId, timeoutMs = TIMEOUTS.MEDIUM) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const details = await this.getProcessorDetails(processorId);
+      const runStatus =
+        details?.status?.aggregateSnapshot?.runStatus || details?.component?.state || '';
+      if (runStatus.toUpperCase() === 'RUNNING') return true;
+      await new Promise(resolve => setTimeout(resolve, 250));
+    }
+    testLogger.warn('Processor', `Timed out waiting for processor ${processorId} to reach RUNNING`);
+    return false;
+  }
+
+  /**
+   * PUT the processor config with the given properties map, recovering from a
+   * stale-revision 409 by re-reading the live revision once — never guessing
+   * version+1 (N64).
+   * @param {string} processorId - target processor id
+   * @param {number} version - revision version to attempt first
+   * @param {Object<string, null>} properties - property keys mapped to null (clears them)
+   * @returns {Promise<boolean>} true when NiFi accepted the property update
+   */
+  async _updateProcessorPropertiesWithFreshRevision(processorId, version, properties) {
+    const attempt = rev =>
+      this.makeApiCall(`/nifi-api/processors/${processorId}`, {
+        method: 'PUT',
+        body: {
+          revision: { version: rev },
+          component: {
+            id: processorId,
+            config: { properties }
+          }
+        }
+      });
+
+    let result = await attempt(version);
+    if (result.ok) return true;
+
+    if (result.status === 409) {
+      const fresh = await this.getProcessorDetails(processorId);
+      const freshVersion = fresh?.revision?.version;
+      if (freshVersion === undefined || freshVersion === null) return false;
+      result = await attempt(freshVersion);
+      return result.ok;
+    }
+    return false;
+  }
+
+  /**
+   * Remove all restapi.{routeName}.* properties from the RestApiGatewayProcessor
+   * via the REST API. Idempotent: returns true as a no-op when the gateway
+   * processor is absent from the canvas or carries no matching properties. When
+   * properties do match, the processor is stopped (only if RUNNING), polled to a
+   * settled state, its config PUT with each matched key mapped to null, then
+   * restarted and confirmed RUNNING — all without a fixed sleep (N64). Stale
+   * revisions on the PUT are recovered by re-reading the live revision (N64).
+   * @param {string} routeName - route whose restapi.{routeName}.* properties to clear
+   * @returns {Promise<boolean>} true on success (including the idempotent no-op cases)
+   */
+  async removeGatewayRouteProperties(routeName) {
+    const gatewayId = await this.getGatewayProcessorId();
+    if (!gatewayId) {
+      testLogger.info(
+        'Processor',
+        `removeGatewayRouteProperties('${routeName}'): gateway processor not on canvas — nothing to clean`
+      );
+      return true;
+    }
+
+    const details = await this.getProcessorDetails(gatewayId);
+    if (!details) {
+      testLogger.warn(
+        'Processor',
+        `removeGatewayRouteProperties('${routeName}'): could not fetch gateway processor ${gatewayId} details`
+      );
+      return false;
+    }
+
+    const prefix = `restapi.${routeName}.`;
+    const currentProps = details.component?.config?.properties || {};
+    const matchedKeys = Object.keys(currentProps).filter(key => key.startsWith(prefix));
+    if (matchedKeys.length === 0) {
+      testLogger.info(
+        'Processor',
+        `removeGatewayRouteProperties('${routeName}'): no properties matching '${prefix}' — already clean`
+      );
+      return true;
+    }
+
+    testLogger.info(
+      'Processor',
+      `removeGatewayRouteProperties('${routeName}'): clearing ${matchedKeys.length} property(ies): ${matchedKeys.join(', ')}`
+    );
+
+    // Stop the gateway before mutating its config, but only when it is RUNNING.
+    const initialState =
+      details.status?.aggregateSnapshot?.runStatus || details.component?.state || '';
+    if (initialState.toUpperCase() === 'RUNNING') {
+      await this.setProcessorRunStatusById(gatewayId, 'STOPPED');
+    }
+
+    // Poll to a stable (non-RUNNING, no active threads) state before the PUT.
+    const settled = await this._waitForProcessorSettled(gatewayId);
+    if (!settled) {
+      testLogger.warn(
+        'Processor',
+        `removeGatewayRouteProperties('${routeName}'): gateway processor ${gatewayId} vanished while settling`
+      );
+      return false;
+    }
+
+    // Map each matched key to null so NiFi clears it, then PUT the fresh revision.
+    const clearMap = {};
+    for (const key of matchedKeys) clearMap[key] = null;
+
+    const version = settled.revision?.version ?? 0;
+    const updated = await this._updateProcessorPropertiesWithFreshRevision(
+      gatewayId,
+      version,
+      clearMap
+    );
+
+    // Always try to leave the provisioned gateway RUNNING again, even on failure.
+    await this.setProcessorRunStatusById(gatewayId, 'RUNNING');
+    const running = await this._waitForProcessorRunning(gatewayId);
+
+    if (!updated) {
+      testLogger.error(
+        'Processor',
+        `removeGatewayRouteProperties('${routeName}'): failed to clear properties on gateway ${gatewayId}`
+      );
+      return false;
+    }
+
+    if (!running) {
+      testLogger.warn(
+        'Processor',
+        `removeGatewayRouteProperties('${routeName}'): cleared properties but gateway ${gatewayId} did not confirm RUNNING`
+      );
+      return false;
+    }
+
+    testLogger.info(
+      'Processor',
+      `removeGatewayRouteProperties('${routeName}'): cleared ${matchedKeys.length} property(ies); gateway ${gatewayId} restarted and RUNNING`
+    );
+    return true;
+  }
 }
 
 // Export convenience functions for backward compatibility


### PR DESCRIPTION
## Summary

Replaces the reverted UI-based end-of-test cleanup (PR #445, commit 31e79d45) with a REST-API-based cleanup for the `e2e-modify-test` route created by the "modified badge" test in `06-verify-gateway-tabs.spec.js`. The UI approach failed under CI timing because the processor was still mid-restart after the edit-save, so NiFi rejected the property mutation ("Cannot modify configuration while the Processor is running"). The REST-API approach avoids the UI entirely: it polls processor state until stable, stops the processor if needed, clears the `restapi.e2e-modify-test.*` property via a freshly-fetched revision, and restarts the processor — leaving the gateway processor RUNNING and free of test-added route configuration after the test suite completes.

## Changes

- `e-2-e-playwright/utils/processor-api-manager.js` — extends the existing processor-api-manager with the REST-API route-cleanup capability (poll-until-stable, stop-if-needed, clear property via revision fetch, restart), reused by the spec's `afterAll`.
- `e-2-e-playwright/tests/06-verify-gateway-tabs.spec.js` — replaces the in-code waiver comment (~line 1050-1052) with an `afterAll` REST-API cleanup call that removes the `e2e-modify-test` route from the gateway processor properties; the existing `removeRouteIfPresent` pre-clean (~line 955/988) is retained as defense-in-depth.

## Test Plan

- [ ] Two consecutive runs of `06-verify-gateway-tabs.spec.js` are green with no residue — after each run, no `restapi.e2e-modify-test.*` property remains on the gateway processor.
- [ ] The provisioned processor is RUNNING again after cleanup.
- [ ] Cleanup uses polling (no fixed sleep), consistent with the PR #445-revert lesson.

## Related Issues

N/A

---
Generated by plan-finalize skill


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test cleanup to reliably remove persisted gateway route settings (even when routes are missing).
  * Enhanced gateway update handling by waiting for safe processor shutdown, applying changes with fresh revisions, and verifying the gateway restarts correctly.
  * Added resilience for configuration conflicts by automatically re-syncing revision/config details on retry.
* **Tests**
  * Added authoritative teardown coverage to prevent residual gateway route state from impacting later tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->