### PR TITLE
feat(rest-processors): pass through additional fields in RequestStatusEntry

### DIFF
--- a/doc/architecture/gateway.adoc
+++ b/doc/architecture/gateway.adoc
@@ -229,8 +229,8 @@ The `/status/{traceId}` response always carries the fixed tracking fields
 (`traceId`, `status`, `acceptedAt`, `updatedAt`, and — when present —
 `parentTraceId` and an `error` object). In addition, an external processor may
 write extra top-level JSON fields directly into the cache entry for a trace ID;
-the gateway captures those non-reserved fields and re-emits them **unchanged**
-in the `/status` response alongside the fixed fields. This lets a downstream
+the gateway captures those non-reserved fields and re-emits them **as string
+values** in the `/status` response alongside the fixed fields. This lets a downstream
 flow annotate a tracked request (for example with a tenant, channel, or
 priority) and have those annotations surfaced through the same polling endpoint.
 

--- a/doc/architecture/gateway.adoc
+++ b/doc/architecture/gateway.adoc
@@ -223,6 +223,28 @@ Management endpoint auth-mode is configured via static NiFi properties:
 |Full cui-http security pipeline; auth mode configurable via `restapi.<name>.auth-mode`
 |===
 
+=== /status Additional-Fields Pass-Through
+
+The `/status/{traceId}` response always carries the fixed tracking fields
+(`traceId`, `status`, `acceptedAt`, `updatedAt`, and — when present —
+`parentTraceId` and an `error` object). In addition, an external processor may
+write extra top-level JSON fields directly into the cache entry for a trace ID;
+the gateway captures those non-reserved fields and re-emits them **unchanged**
+in the `/status` response alongside the fixed fields. This lets a downstream
+flow annotate a tracked request (for example with a tenant, channel, or
+priority) and have those annotations surfaced through the same polling endpoint.
+
+The pass-through follows these rules:
+
+* **Scalar coercion** — string values are surfaced verbatim; numbers are stringified via their JSON literal; booleans become `"true"` / `"false"`.
+* **Non-scalar drop** — nested objects, arrays, and JSON `null` values are dropped (they are not surfaced and do not fail the parse).
+* **Reserved names take precedence** — a captured field whose key collides with a reserved response key (`traceId`, `status`, `acceptedAt`, `updatedAt`, `parentTraceId`, `error`) is discarded; the reserved, typed value always wins and is never double-emitted.
+* **Bounded count** — the number of additional fields re-emitted is bounded by `rest.gateway.management.status.max-additional-fields` (default `20`). Fields beyond the bound are truncated in JSON key encounter order.
+
+Additional fields captured on write are also preserved across internal status
+transitions, so an entry that moves (for example) from `COLLECTING_ATTACHMENTS`
+to `PROCESSED` keeps its externally-written annotations.
+
 == FlowFile Output Attributes
 
 [cols="1,2"]

--- a/doc/reference/configuration.adoc
+++ b/doc/reference/configuration.adoc
@@ -234,6 +234,11 @@ NOTE: In static configuration files, the prefix is `jwt.validation.issuer.<name>
 |Comma-separated scopes required for `/status` access (only checked when auth-mode includes `bearer`)
 |No
 
+|rest.gateway.management.status.max-additional-fields
+|20
+|Maximum number of pass-through additional fields surfaced in the `/status` response (excess truncated by JSON key encounter order)
+|No
+
 |rest.gateway.management.attachments.enabled
 |true
 |Whether the `/attachments/{parentTraceId}` endpoint is active

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayConstants.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayConstants.java
@@ -239,7 +239,7 @@ public final class RestApiGatewayConstants {
                         + "is truncated.")
                 .required(false)
                 .defaultValue("20")
-                .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
+                .addValidator(StandardValidators.NON_NEGATIVE_INTEGER_VALIDATOR)
                 .build();
 
         public static final PropertyDescriptor MANAGEMENT_ATTACHMENTS_ENABLED = new PropertyDescriptor.Builder()

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayConstants.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayConstants.java
@@ -230,6 +230,18 @@ public final class RestApiGatewayConstants {
                 .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
                 .build();
 
+        public static final PropertyDescriptor MANAGEMENT_STATUS_MAX_ADDITIONAL_FIELDS = new PropertyDescriptor.Builder()
+                .name("rest.gateway.management.status.max-additional-fields")
+                .displayName("Status Endpoint Max Additional Fields")
+                .description("Maximum number of non-reserved additional fields re-emitted in the "
+                        + "/status/{traceId} response body. Additional fields captured from externally-written "
+                        + "status entries are echoed back in encounter order up to this bound; the remainder "
+                        + "is truncated.")
+                .required(false)
+                .defaultValue("20")
+                .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
+                .build();
+
         public static final PropertyDescriptor MANAGEMENT_ATTACHMENTS_ENABLED = new PropertyDescriptor.Builder()
                 .name("rest.gateway.management.attachments.enabled")
                 .displayName("Attachments Endpoint Enabled")

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayProcessor.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/RestApiGatewayProcessor.java
@@ -107,6 +107,7 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
             RestApiGatewayConstants.Properties.MANAGEMENT_STATUS_AUTH_MODE,
             RestApiGatewayConstants.Properties.MANAGEMENT_STATUS_REQUIRED_ROLES,
             RestApiGatewayConstants.Properties.MANAGEMENT_STATUS_REQUIRED_SCOPES,
+            RestApiGatewayConstants.Properties.MANAGEMENT_STATUS_MAX_ADDITIONAL_FIELDS,
             RestApiGatewayConstants.Properties.MANAGEMENT_ATTACHMENTS_ENABLED,
             RestApiGatewayConstants.Properties.MANAGEMENT_ATTACHMENTS_AUTH_MODE,
             RestApiGatewayConstants.Properties.MANAGEMENT_ATTACHMENTS_REQUIRED_ROLES,
@@ -412,7 +413,8 @@ public class RestApiGatewayProcessor extends AbstractProcessor {
                 context.getProperty(RestApiGatewayConstants.Properties.MANAGEMENT_STATUS_ENABLED).asBoolean(),
                 AuthMode.fromValues(context.getProperty(RestApiGatewayConstants.Properties.MANAGEMENT_STATUS_AUTH_MODE).getValue()),
                 parseCommaSeparated(context.getProperty(RestApiGatewayConstants.Properties.MANAGEMENT_STATUS_REQUIRED_ROLES).getValue()),
-                parseCommaSeparated(context.getProperty(RestApiGatewayConstants.Properties.MANAGEMENT_STATUS_REQUIRED_SCOPES).getValue()));
+                parseCommaSeparated(context.getProperty(RestApiGatewayConstants.Properties.MANAGEMENT_STATUS_REQUIRED_SCOPES).getValue()),
+                context.getProperty(RestApiGatewayConstants.Properties.MANAGEMENT_STATUS_MAX_ADDITIONAL_FIELDS).asInteger());
     }
 
     private void validateAndRegisterAttachmentRoutes(List<RouteConfiguration> routes, int hardLimit) {

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/RequestStatusEntry.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/RequestStatusEntry.java
@@ -26,6 +26,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.io.StringReader;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -56,6 +57,17 @@ int attachmentsMaxCount,
 int attachmentsMinCount,
 @Nullable String routeName,
 @NonNull Map<String, String> additionalFields) {
+
+    /**
+     * Compact constructor enforcing the immutability the class javadoc claims: defensively copies
+     * {@code additionalFields} into an unmodifiable, insertion-ordered map so the mutable
+     * {@link LinkedHashMap} built by {@link #captureAdditionalFields(JsonObject)} can neither be
+     * mutated by the caller after construction nor exposed as mutable via the accessor.
+     * A {@link LinkedHashMap} copy (not {@link Map#copyOf}) preserves the JSON encounter order.
+     */
+    RequestStatusEntry {
+        additionalFields = Collections.unmodifiableMap(new LinkedHashMap<>(additionalFields));
+    }
 
     private static final String KEY_TRACE_ID = "traceId";
     private static final String KEY_STATUS = "status";

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/RequestStatusEntry.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/RequestStatusEntry.java
@@ -19,11 +19,16 @@ package de.cuioss.nifi.rest.handler;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
 import lombok.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import java.io.StringReader;
 import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Immutable status entry for an asynchronously tracked request.
@@ -37,6 +42,8 @@ import java.time.Instant;
  * @param attachmentsMaxCount maximum attachments allowed for this request (0 = no attachments expected)
  * @param attachmentsMinCount minimum attachments required before auto-transitioning to PROCESSED (0 = no auto-transition)
  * @param routeName           the route name that created this entry (for traceability)
+ * @param additionalFields    externally-written, non-reserved top-level scalar fields preserved across
+ *                            round-trips in encounter order (empty when none were supplied)
  */
 record RequestStatusEntry(
 @NonNull String traceId,
@@ -47,7 +54,8 @@ record RequestStatusEntry(
 @Nullable String errorDetail,
 int attachmentsMaxCount,
 int attachmentsMinCount,
-@Nullable String routeName) {
+@Nullable String routeName,
+@NonNull Map<String, String> additionalFields) {
 
     private static final String KEY_TRACE_ID = "traceId";
     private static final String KEY_STATUS = "status";
@@ -59,12 +67,17 @@ int attachmentsMinCount,
     private static final String KEY_ATTACHMENTS_MIN_COUNT = "attachmentsMinCount";
     private static final String KEY_ROUTE_NAME = "routeName";
 
+    /** Reserved top-level JSON keys owned by the typed record components. */
+    private static final Set<String> RESERVED_KEYS = Set.of(
+            KEY_TRACE_ID, KEY_STATUS, KEY_ACCEPTED_AT, KEY_UPDATED_AT, KEY_PARENT_TRACE_ID,
+            KEY_ERROR_DETAIL, KEY_ATTACHMENTS_MAX_COUNT, KEY_ATTACHMENTS_MIN_COUNT, KEY_ROUTE_NAME);
+
     /**
      * Creates a new ACCEPTED entry with the given trace ID.
      */
     public static RequestStatusEntry accepted(String traceId, @Nullable String parentTraceId) {
         Instant now = Instant.now();
-        return new RequestStatusEntry(traceId, RequestStatus.ACCEPTED, now, now, parentTraceId, null, 0, 0, null);
+        return new RequestStatusEntry(traceId, RequestStatus.ACCEPTED, now, now, parentTraceId, null, 0, 0, null, Map.of());
     }
 
     /**
@@ -75,7 +88,7 @@ int attachmentsMinCount,
             @Nullable String routeName, int attachmentsMaxCount, int attachmentsMinCount) {
         Instant now = Instant.now();
         return new RequestStatusEntry(traceId, RequestStatus.COLLECTING_ATTACHMENTS, now, now,
-                parentTraceId, null, attachmentsMaxCount, attachmentsMinCount, routeName);
+                parentTraceId, null, attachmentsMaxCount, attachmentsMinCount, routeName, Map.of());
     }
 
     /**
@@ -101,6 +114,12 @@ int attachmentsMinCount,
         }
         if (routeName != null) {
             builder.add(KEY_ROUTE_NAME, routeName);
+        }
+        for (Map.Entry<String, String> field : additionalFields.entrySet()) {
+            // Defensive: never let a captured field shadow a reserved, typed key.
+            if (!RESERVED_KEYS.contains(field.getKey())) {
+                builder.add(field.getKey(), field.getValue());
+            }
         }
         return builder.build().toString();
     }
@@ -129,6 +148,33 @@ int attachmentsMinCount,
                 obj.containsKey(KEY_ATTACHMENTS_MAX_COUNT) ? obj.getInt(KEY_ATTACHMENTS_MAX_COUNT) : 0,
                 obj.containsKey(KEY_ATTACHMENTS_MIN_COUNT) ? obj.getInt(KEY_ATTACHMENTS_MIN_COUNT) : 0,
                 obj.containsKey(KEY_ROUTE_NAME) && !obj.isNull(KEY_ROUTE_NAME)
-                        ? obj.getString(KEY_ROUTE_NAME) : null);
+                        ? obj.getString(KEY_ROUTE_NAME) : null,
+                captureAdditionalFields(obj));
+    }
+
+    /**
+     * Collects every non-reserved top-level scalar field into an insertion-ordered map, preserving
+     * the JSON encounter order. String values are taken verbatim, numbers via their JSON literal, and
+     * booleans as {@code "true"}/{@code "false"}. Nested objects, arrays and JSON null are dropped.
+     */
+    private static Map<String, String> captureAdditionalFields(JsonObject obj) {
+        Map<String, String> captured = new LinkedHashMap<>();
+        for (Map.Entry<String, JsonValue> entry : obj.entrySet()) {
+            String key = entry.getKey();
+            if (RESERVED_KEYS.contains(key)) {
+                continue;
+            }
+            JsonValue value = entry.getValue();
+            switch (value.getValueType()) {
+                case STRING -> captured.put(key, ((JsonString) value).getString());
+                case NUMBER -> captured.put(key, value.toString());
+                case TRUE -> captured.put(key, "true");
+                case FALSE -> captured.put(key, "false");
+                default -> {
+                    // OBJECT, ARRAY and NULL are not scalar string fields — drop them.
+                }
+            }
+        }
+        return captured;
     }
 }

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/RequestStatusStore.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/RequestStatusStore.java
@@ -150,7 +150,8 @@ public class RequestStatusStore {
         return new RequestStatusEntry(
                 existing.traceId(), newStatus, existing.acceptedAt(), Instant.now(),
                 existing.parentTraceId(), existing.errorDetail(),
-                existing.attachmentsMaxCount(), existing.attachmentsMinCount(), existing.routeName());
+                existing.attachmentsMaxCount(), existing.attachmentsMinCount(), existing.routeName(),
+                existing.additionalFields());
     }
 
     /**

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/StatusEndpointHandler.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/StatusEndpointHandler.java
@@ -48,13 +48,20 @@ public final class StatusEndpointHandler extends AbstractManagementHandler {
     @SuppressWarnings("java:S1075") // URL path, not filesystem path
     private static final String STATUS_PATH_PREFIX = STATUS_PATH + "/";
 
+    /** Reserved response keys emitted before the additional fields; guards against re-emission. */
+    private static final Set<String> RESERVED_RESPONSE_KEYS = Set.of(
+            "traceId", "status", "acceptedAt", "updatedAt", "parentTraceId", "error");
+
     private final RequestStatusStore statusStore;
+    private final int maxAdditionalFields;
 
     public StatusEndpointHandler(RequestStatusStore statusStore,
             boolean enabled, Set<AuthMode> authModes,
-            Set<String> requiredRoles, Set<String> requiredScopes) {
+            Set<String> requiredRoles, Set<String> requiredScopes,
+            int maxAdditionalFields) {
         super(enabled, authModes, requiredRoles, requiredScopes);
         this.statusStore = statusStore;
+        this.maxAdditionalFields = maxAdditionalFields;
     }
 
     @Override
@@ -126,11 +133,32 @@ public final class StatusEndpointHandler extends AbstractManagementHandler {
                     .add("detail", statusEntry.errorDetail()));
         }
 
+        emitAdditionalFields(jsonBuilder, statusEntry);
+
         byte[] responseBody = jsonBuilder.build().toString().getBytes(StandardCharsets.UTF_8);
         response.setStatus(200);
         response.getHeaders().put(HttpHeader.CONTENT_TYPE, JSON_CONTENT_TYPE);
         response.getHeaders().put(HttpHeader.CONTENT_LENGTH, responseBody.length);
         response.write(true, ByteBuffer.wrap(responseBody), callback);
+    }
+
+    /**
+     * Re-emits the entry's captured additional fields (in encounter order) into the response body,
+     * bounded to at most {@code maxAdditionalFields} entries. Any key that collides with a reserved
+     * response key already emitted is defensively skipped and does not count against the bound.
+     */
+    private void emitAdditionalFields(JsonObjectBuilder jsonBuilder, RequestStatusEntry statusEntry) {
+        int emitted = 0;
+        for (var field : statusEntry.additionalFields().entrySet()) {
+            if (emitted >= maxAdditionalFields) {
+                break;
+            }
+            if (RESERVED_RESPONSE_KEYS.contains(field.getKey())) {
+                continue;
+            }
+            jsonBuilder.add(field.getKey(), field.getValue());
+            emitted++;
+        }
     }
 
 }

--- a/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/StatusEndpointHandler.java
+++ b/nifi-cuioss-rest-processors/src/main/java/de/cuioss/nifi/rest/handler/StatusEndpointHandler.java
@@ -48,9 +48,12 @@ public final class StatusEndpointHandler extends AbstractManagementHandler {
     @SuppressWarnings("java:S1075") // URL path, not filesystem path
     private static final String STATUS_PATH_PREFIX = STATUS_PATH + "/";
 
+    private static final String FIELD_TRACE_ID = "traceId";
+    private static final String FIELD_STATUS = "status";
+
     /** Reserved response keys emitted before the additional fields; guards against re-emission. */
     private static final Set<String> RESERVED_RESPONSE_KEYS = Set.of(
-            "traceId", "status", "acceptedAt", "updatedAt", "parentTraceId", "error");
+            FIELD_TRACE_ID, FIELD_STATUS, "acceptedAt", "updatedAt", "parentTraceId", "error");
 
     private final RequestStatusStore statusStore;
     private final int maxAdditionalFields;
@@ -66,7 +69,7 @@ public final class StatusEndpointHandler extends AbstractManagementHandler {
 
     @Override
     public String name() {
-        return "status";
+        return FIELD_STATUS;
     }
 
     @Override
@@ -88,7 +91,7 @@ public final class StatusEndpointHandler extends AbstractManagementHandler {
 
         // The path segment after the status prefix is the traceId
         Optional<String> extractedTraceId = RequestUtils.extractUuidPathParameter(
-                path, STATUS_PATH_PREFIX, "traceId", response, callback);
+                path, STATUS_PATH_PREFIX, FIELD_TRACE_ID, response, callback);
         if (extractedTraceId.isEmpty()) {
             return;
         }
@@ -117,8 +120,8 @@ public final class StatusEndpointHandler extends AbstractManagementHandler {
         LOGGER.info(RestApiLogMessages.INFO.STATUS_QUERIED, traceId, statusEntry.status());
 
         JsonObjectBuilder jsonBuilder = Json.createObjectBuilder()
-                .add("traceId", statusEntry.traceId())
-                .add("status", statusEntry.status().name())
+                .add(FIELD_TRACE_ID, statusEntry.traceId())
+                .add(FIELD_STATUS, statusEntry.status().name())
                 .add("acceptedAt", statusEntry.acceptedAt().toString())
                 .add("updatedAt", statusEntry.updatedAt().toString());
 
@@ -148,17 +151,10 @@ public final class StatusEndpointHandler extends AbstractManagementHandler {
      * response key already emitted is defensively skipped and does not count against the bound.
      */
     private void emitAdditionalFields(JsonObjectBuilder jsonBuilder, RequestStatusEntry statusEntry) {
-        int emitted = 0;
-        for (var field : statusEntry.additionalFields().entrySet()) {
-            if (emitted >= maxAdditionalFields) {
-                break;
-            }
-            if (RESERVED_RESPONSE_KEYS.contains(field.getKey())) {
-                continue;
-            }
-            jsonBuilder.add(field.getKey(), field.getValue());
-            emitted++;
-        }
+        statusEntry.additionalFields().entrySet().stream()
+                .filter(field -> !RESERVED_RESPONSE_KEYS.contains(field.getKey()))
+                .limit(maxAdditionalFields)
+                .forEach(field -> jsonBuilder.add(field.getKey(), field.getValue()));
     }
 
 }

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/RestApiGatewayProcessorTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/RestApiGatewayProcessorTest.java
@@ -175,7 +175,7 @@ class RestApiGatewayProcessorTest {
         }
 
         @Test
-        @DisplayName("Status max-additional-fields is supported, optional, defaults to 20, positive-integer validated")
+        @DisplayName("Status max-additional-fields is supported, optional, defaults to 20, non-negative-integer validated")
         void shouldExposeMaxAdditionalFieldsDescriptor() {
             var descriptor = RestApiGatewayConstants.Properties.MANAGEMENT_STATUS_MAX_ADDITIONAL_FIELDS;
 
@@ -190,8 +190,9 @@ class RestApiGatewayProcessorTest {
             testRunner.setProperty(descriptor, "5");
             testRunner.assertValid();
 
+            // 0 fully disables the additional-fields pass-through and is a valid setting.
             testRunner.setProperty(descriptor, "0");
-            testRunner.assertNotValid();
+            testRunner.assertValid();
 
             testRunner.setProperty(descriptor, "-3");
             testRunner.assertNotValid();

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/RestApiGatewayProcessorTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/RestApiGatewayProcessorTest.java
@@ -170,6 +170,34 @@ class RestApiGatewayProcessorTest {
             assertTrue(descriptors.contains(RestApiGatewayConstants.Properties.MANAGEMENT_METRICS_AUTH_MODE));
             assertTrue(descriptors.contains(RestApiGatewayConstants.Properties.MANAGEMENT_METRICS_REQUIRED_ROLES));
             assertTrue(descriptors.contains(RestApiGatewayConstants.Properties.MANAGEMENT_METRICS_REQUIRED_SCOPES));
+            assertTrue(descriptors.contains(
+                    RestApiGatewayConstants.Properties.MANAGEMENT_STATUS_MAX_ADDITIONAL_FIELDS));
+        }
+
+        @Test
+        @DisplayName("Status max-additional-fields is supported, optional, defaults to 20, positive-integer validated")
+        void shouldExposeMaxAdditionalFieldsDescriptor() {
+            var descriptor = RestApiGatewayConstants.Properties.MANAGEMENT_STATUS_MAX_ADDITIONAL_FIELDS;
+
+            assertTrue(testRunner.getProcessor().getPropertyDescriptors().contains(descriptor),
+                    "descriptor must be advertised as a supported property");
+            assertFalse(descriptor.isRequired(), "descriptor must be optional");
+            assertEquals("20", descriptor.getDefaultValue());
+
+            // The default (unset) value keeps the processor valid.
+            testRunner.assertValid();
+
+            testRunner.setProperty(descriptor, "5");
+            testRunner.assertValid();
+
+            testRunner.setProperty(descriptor, "0");
+            testRunner.assertNotValid();
+
+            testRunner.setProperty(descriptor, "-3");
+            testRunner.assertNotValid();
+
+            testRunner.setProperty(descriptor, "not-a-number");
+            testRunner.assertNotValid();
         }
 
         @Test

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/AttachmentsEndpointHandlerTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/AttachmentsEndpointHandlerTest.java
@@ -124,7 +124,7 @@ class AttachmentsEndpointHandlerTest {
 
         // Status endpoint (for verifying parentTraceId)
         handlers.add(new StatusEndpointHandler(statusStore, true,
-                Set.of(AuthMode.LOCAL_ONLY, AuthMode.BEARER), Set.of(), Set.of()));
+                Set.of(AuthMode.LOCAL_ONLY, AuthMode.BEARER), Set.of(), Set.of(), 20));
 
         var handler = new GatewayRequestHandler(handlers, configService, GLOBAL_MAX_REQUEST_SIZE,
                 httpSecurityEvents, gatewaySecurityEvents,

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/RequestStatusEntryTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/RequestStatusEntryTest.java
@@ -23,6 +23,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -110,7 +113,7 @@ class RequestStatusEntryTest {
             Instant now = FIXED_INSTANT;
             var entry = new RequestStatusEntry(
                     traceId, RequestStatus.REJECTED, now, now,
-                    parentTraceId, "Validation failed", 0, 0, null);
+                    parentTraceId, "Validation failed", 0, 0, null, Map.of());
 
             String json = entry.toJson();
             var deserialized = RequestStatusEntry.fromJson(json);
@@ -127,7 +130,7 @@ class RequestStatusEntryTest {
         void shouldSerializeAllStatusValues(RequestStatus status) {
             Instant now = FIXED_INSTANT;
             var entry = new RequestStatusEntry(
-                    UUID.randomUUID().toString(), status, now, now, null, null, 0, 0, null);
+                    UUID.randomUUID().toString(), status, now, now, null, null, 0, 0, null, Map.of());
 
             String json = entry.toJson();
             var deserialized = RequestStatusEntry.fromJson(json);
@@ -175,6 +178,110 @@ class RequestStatusEntryTest {
             assertTrue(json.contains("\"status\":\"ACCEPTED\""));
             assertTrue(json.contains("\"acceptedAt\""));
             assertTrue(json.contains("\"updatedAt\""));
+        }
+    }
+
+    @Nested
+    @DisplayName("Additional Fields")
+    class AdditionalFields {
+
+        /** Minimal valid reserved-field JSON prefix; extra keys are appended per test. */
+        private String baseJson(String extraKeysWithLeadingComma) {
+            return "{\"traceId\":\"abc\",\"status\":\"ACCEPTED\","
+                    + "\"acceptedAt\":\"2024-01-01T00:00:00Z\",\"updatedAt\":\"2024-01-01T00:00:00Z\""
+                    + extraKeysWithLeadingComma + "}";
+        }
+
+        @Test
+        @DisplayName("Should capture extra top-level string keys in encounter order")
+        void shouldCaptureExtraTopLevelKeys() {
+            var deserialized = RequestStatusEntry.fromJson(
+                    baseJson(",\"tenant\":\"acme\",\"channel\":\"web\""));
+
+            assertEquals(Map.of("tenant", "acme", "channel", "web"), deserialized.additionalFields());
+            assertEquals(List.of("tenant", "channel"),
+                    List.copyOf(deserialized.additionalFields().keySet()));
+        }
+
+        @Test
+        @DisplayName("Should coerce number and boolean scalars to their string form")
+        void shouldCoerceScalarValues() {
+            var deserialized = RequestStatusEntry.fromJson(
+                    baseJson(",\"count\":7,\"enabled\":true,\"archived\":false"));
+
+            assertEquals("7", deserialized.additionalFields().get("count"));
+            assertEquals("true", deserialized.additionalFields().get("enabled"));
+            assertEquals("false", deserialized.additionalFields().get("archived"));
+        }
+
+        @Test
+        @DisplayName("Should drop object, array and null values without failing the parse")
+        void shouldDropNonScalarValues() {
+            var deserialized = RequestStatusEntry.fromJson(
+                    baseJson(",\"meta\":{\"k\":\"v\"},\"tags\":[1,2],\"missing\":null,\"kept\":\"yes\""));
+
+            assertEquals(Map.of("kept", "yes"), deserialized.additionalFields());
+        }
+
+        @Test
+        @DisplayName("Should keep the reserved typed value and never capture a reserved key")
+        void shouldKeepReservedKeyValueOnCollision() {
+            // routeName is a reserved, typed key — even though it appears at the top level it must
+            // populate the typed component and never leak into additionalFields.
+            var deserialized = RequestStatusEntry.fromJson(
+                    baseJson(",\"routeName\":\"upload\",\"extra\":\"kept\""));
+
+            assertEquals("upload", deserialized.routeName());
+            assertFalse(deserialized.additionalFields().containsKey("routeName"));
+            assertEquals(Map.of("extra", "kept"), deserialized.additionalFields());
+        }
+
+        @Test
+        @DisplayName("Should yield an empty map when no additional fields are present")
+        void shouldYieldEmptyMapWhenAbsent() {
+            var deserialized = RequestStatusEntry.fromJson(baseJson(""));
+
+            assertTrue(deserialized.additionalFields().isEmpty());
+        }
+
+        @Test
+        @DisplayName("Factory-created entries carry an empty additional-fields map")
+        void factoryEntriesHaveEmptyAdditionalFields() {
+            var entry = RequestStatusEntry.accepted(UUID.randomUUID().toString(), null);
+
+            assertTrue(entry.additionalFields().isEmpty());
+        }
+
+        @Test
+        @DisplayName("Should preserve additional fields across a toJson/fromJson round-trip")
+        void shouldRoundTripAdditionalFields() {
+            Map<String, String> extras = new LinkedHashMap<>();
+            extras.put("tenant", "acme");
+            extras.put("priority", "5");
+            var entry = new RequestStatusEntry(
+                    UUID.randomUUID().toString(), RequestStatus.ACCEPTED, FIXED_INSTANT, FIXED_INSTANT,
+                    null, null, 0, 0, null, extras);
+
+            var deserialized = RequestStatusEntry.fromJson(entry.toJson());
+
+            assertEquals(extras, deserialized.additionalFields());
+        }
+
+        @Test
+        @DisplayName("Should defensively skip a reserved key present in additionalFields when serializing")
+        void shouldSkipReservedKeyOnSerialize() {
+            Map<String, String> extras = new LinkedHashMap<>();
+            extras.put("routeName", "shadow");
+            extras.put("extra", "kept");
+            var entry = new RequestStatusEntry(
+                    "abc", RequestStatus.ACCEPTED, FIXED_INSTANT, FIXED_INSTANT,
+                    null, null, 0, 0, "real", extras);
+
+            var deserialized = RequestStatusEntry.fromJson(entry.toJson());
+
+            // The typed routeName wins; the shadow additional-field entry is not re-emitted.
+            assertEquals("real", deserialized.routeName());
+            assertEquals(Map.of("extra", "kept"), deserialized.additionalFields());
         }
     }
 }

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/RequestStatusStoreTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/RequestStatusStoreTest.java
@@ -30,7 +30,9 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
@@ -120,6 +122,26 @@ public class RequestStatusStoreTest {
             assertEquals("upload", result.get().routeName());
             assertEquals(5, result.get().attachmentsMaxCount());
             assertEquals(1, result.get().attachmentsMinCount());
+        }
+
+        @Test
+        @DisplayName("Should preserve additional fields across a status transition")
+        void shouldPreserveAdditionalFieldsAcrossStatusTransition() throws Exception {
+            String traceId = UUID.randomUUID().toString();
+            Map<String, String> extras = new LinkedHashMap<>();
+            extras.put("tenant", "acme");
+            extras.put("priority", "5");
+            var entry = new RequestStatusEntry(traceId, RequestStatus.COLLECTING_ATTACHMENTS,
+                    Instant.now(), Instant.now(), null, null, 5, 1, "upload", extras);
+            cacheClient.put(traceId, entry,
+                    RequestStatusStore.STRING_SERIALIZER, RequestStatusStore.ENTRY_SERIALIZER);
+
+            store.updateStatus(traceId, RequestStatus.PROCESSING);
+            var result = store.getStatus(traceId);
+
+            assertTrue(result.isPresent());
+            assertEquals(RequestStatus.PROCESSING, result.get().status());
+            assertEquals(extras, result.get().additionalFields());
         }
 
         @Test

--- a/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/StatusEndpointHandlerTest.java
+++ b/nifi-cuioss-rest-processors/src/test/java/de/cuioss/nifi/rest/handler/StatusEndpointHandlerTest.java
@@ -36,8 +36,11 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -75,7 +78,7 @@ class StatusEndpointHandlerTest {
                 new HealthEndpointHandler(true, Set.of(AuthMode.LOCAL_ONLY, AuthMode.BEARER),
                         Set.of(), Set.of()),
                 new StatusEndpointHandler(statusStore, true,
-                        Set.of(AuthMode.LOCAL_ONLY, AuthMode.BEARER), Set.of(), Set.of())));
+                        Set.of(AuthMode.LOCAL_ONLY, AuthMode.BEARER), Set.of(), Set.of(), 20)));
 
         // Add a tracked user route
         var trackedRoute = RouteConfiguration.builder()
@@ -326,6 +329,139 @@ class StatusEndpointHandlerTest {
             // /status exact match hits the handler, but prefixMatch makes it work
             // However, the handler should return a meaningful error since there's no traceId
             assertNotEquals(200, response.statusCode());
+        }
+    }
+
+    @Nested
+    @DisplayName("Additional Fields")
+    class AdditionalFields {
+
+        /**
+         * Starts a dedicated single-handler server exposing {@code /status} over a store seeded with
+         * the given entry, using the supplied additional-fields bound. Returns the started server; the
+         * caller is responsible for stopping it.
+         */
+        private Server startStatusServer(RequestStatusStore store, int maxAdditionalFields) throws Exception {
+            var httpSecurityEvents = new SecurityEventCounter();
+            var gatewaySecurityEvents = new GatewaySecurityEvents();
+            List<EndpointHandler> handlers = new ArrayList<>(List.of(
+                    new StatusEndpointHandler(store, true,
+                            Set.of(AuthMode.LOCAL_ONLY, AuthMode.BEARER), Set.of(), Set.of(), maxAdditionalFields)));
+            var handler = new GatewayRequestHandler(handlers, configService, GLOBAL_MAX_REQUEST_SIZE,
+                    httpSecurityEvents, gatewaySecurityEvents,
+                    ForwardedRequestResolver.secureDefault(), false);
+            var srv = new Server();
+            ServerConnector connector = new ServerConnector(srv);
+            connector.setPort(0);
+            srv.addConnector(connector);
+            srv.setHandler(handler);
+            srv.start();
+            return srv;
+        }
+
+        private RequestStatusStore storeWith(String traceId, Map<String, String> additionalFields) throws Exception {
+            var cache = new RequestStatusStoreTest.InMemoryMapCacheClient();
+            var entry = new RequestStatusEntry(traceId, RequestStatus.ACCEPTED,
+                    Instant.now(), Instant.now(), null, null, 0, 0, null, additionalFields);
+            cache.put(traceId, entry,
+                    RequestStatusStore.STRING_SERIALIZER, RequestStatusStore.ENTRY_SERIALIZER);
+            return new RequestStatusStore(cache);
+        }
+
+        private JsonObject query(Server srv, String traceId) throws Exception {
+            int localPort = ((ServerConnector) srv.getConnectors()[0]).getLocalPort();
+            var response = httpClient.send(
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + localPort + "/status/" + traceId))
+                            .GET().build(),
+                    HttpResponse.BodyHandlers.ofString());
+            assertEquals(200, response.statusCode());
+            return Json.createReader(new StringReader(response.body())).readObject();
+        }
+
+        @Test
+        @DisplayName("Should surface additional fields in the response in encounter order")
+        void shouldSurfaceAdditionalFieldsInEncounterOrder() throws Exception {
+            String traceId = UUID.randomUUID().toString();
+            Map<String, String> extras = new LinkedHashMap<>();
+            extras.put("tenant", "acme");
+            extras.put("channel", "web");
+            extras.put("priority", "5");
+            var store = storeWith(traceId, extras);
+            Server srv = startStatusServer(store, 20);
+            try {
+                JsonObject json = query(srv, traceId);
+
+                assertEquals("acme", json.getString("tenant"));
+                assertEquals("web", json.getString("channel"));
+                assertEquals("5", json.getString("priority"));
+                List<String> additionalOrder = json.keySet().stream()
+                        .filter(extras::containsKey).toList();
+                assertEquals(List.of("tenant", "channel", "priority"), additionalOrder);
+            } finally {
+                srv.stop();
+            }
+        }
+
+        @Test
+        @DisplayName("Should truncate to the first N additional fields when over the configured max")
+        void shouldTruncateToFirstN() throws Exception {
+            String traceId = UUID.randomUUID().toString();
+            Map<String, String> extras = new LinkedHashMap<>();
+            extras.put("a", "1");
+            extras.put("b", "2");
+            extras.put("c", "3");
+            var store = storeWith(traceId, extras);
+            Server srv = startStatusServer(store, 2);
+            try {
+                JsonObject json = query(srv, traceId);
+
+                assertEquals("1", json.getString("a"));
+                assertEquals("2", json.getString("b"));
+                assertFalse(json.containsKey("c"), "third field must be truncated when max is 2");
+            } finally {
+                srv.stop();
+            }
+        }
+
+        @Test
+        @DisplayName("Should surface all fields under the default max of 20")
+        void shouldSurfaceUnderDefaultMax() throws Exception {
+            String traceId = UUID.randomUUID().toString();
+            Map<String, String> extras = new LinkedHashMap<>();
+            for (int i = 0; i < 20; i++) {
+                extras.put("f" + i, String.valueOf(i));
+            }
+            var store = storeWith(traceId, extras);
+            Server srv = startStatusServer(store, 20);
+            try {
+                JsonObject json = query(srv, traceId);
+
+                for (int i = 0; i < 20; i++) {
+                    assertEquals(String.valueOf(i), json.getString("f" + i));
+                }
+            } finally {
+                srv.stop();
+            }
+        }
+
+        @Test
+        @DisplayName("Should not double-emit a reserved response key present in additional fields")
+        void shouldNotDoubleEmitReservedKey() throws Exception {
+            String traceId = UUID.randomUUID().toString();
+            Map<String, String> extras = new LinkedHashMap<>();
+            extras.put("status", "SPOOFED");
+            extras.put("ok", "yes");
+            var store = storeWith(traceId, extras);
+            Server srv = startStatusServer(store, 20);
+            try {
+                JsonObject json = query(srv, traceId);
+
+                // The reserved typed status wins; the shadow additional-field value is never emitted.
+                assertEquals("ACCEPTED", json.getString("status"));
+                assertEquals("yes", json.getString("ok"));
+            } finally {
+                srv.stop();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Extend `RequestStatusEntry` (and the `/status/{traceId}` response it backs) to preserve and pass through domain-specific additional fields that an external caller writes directly into the shared `DistributedMapCacheClient` cache entry, alongside the existing fixed schema (`traceId`, `status`, `acceptedAt`, `updatedAt`, `parentTraceId`, `errorDetail`, `attachmentsMaxCount`, `attachmentsMinCount`, `routeName`).

The gateway's role is read-side pass-through only: `RequestStatusEntry.fromJson` captures any top-level JSON key that is not one of the reserved field names into an `additionalFields` map, and `RequestStatusEntry.toJson()` / `StatusEndpointHandler` re-emit those fields unchanged in the `/status` response. No new gateway-side write API is introduced.

## Changes

- `RequestStatusEntry.java` — adds an `additionalFields` (`Map<String,String>`) component. On `fromJson`, every top-level JSON key not in the reserved set is captured; on `toJson`, those fields are re-emitted at the top level alongside the fixed fields. Non-string scalar values (number/boolean) are coerced to their string form. Non-scalar values (object/array) are dropped rather than rejected, so a single malformed additional field cannot fail parsing of the whole entry. A collision between an additional-field key and a reserved field name resolves in favor of the reserved field.
- `RequestStatusStore.java` — `withStatus` (used by `updateStatus`) carries `additionalFields` through unchanged, so an internal status transition (e.g. attachment min-count auto-transition to `PROCESSED`) does not drop externally-written additional fields.
- `StatusEndpointHandler.java` — bounds the number of additional fields surfaced in the `/status` response by the new `rest.gateway.management.status.max-additional-fields` processor property. When the cached entry carries more additional fields than the configured maximum, the response truncates to the first N (by JSON key encounter order) rather than failing the request.
- `RestApiGatewayConstants.java` / `RestApiGatewayProcessor.java` — introduce the new static NiFi processor property `rest.gateway.management.status.max-additional-fields` (default `20`, `required=false`), validated with `StandardValidators.POSITIVE_INTEGER_VALIDATOR`.
- `doc/architecture/gateway.adoc` — documents the additional-fields pass-through behavior on the `/status/{traceId}` endpoint.
- `doc/reference/configuration.adoc` — documents the new `rest.gateway.management.status.max-additional-fields` property.
- Test coverage added/updated in `RequestStatusEntryTest.java`, `RequestStatusStoreTest.java`, `StatusEndpointHandlerTest.java`, `RestApiGatewayProcessorTest.java`, and `AttachmentsEndpointHandlerTest.java`.

## Test Plan

- [ ] Verification command passed (`verify -Psonar`)
- [ ] Manual testing completed (if applicable)

## Related Issues

Closes #426

---
Generated by plan-finalize skill


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `/status/{traceId}` response now includes eligible scalar fields added by external processors.
  * Additional fields persist across status updates and are returned in their original order.
  * Reserved response fields cannot be overridden.
  * Added configuration to limit returned additional fields, defaulting to 20; excess fields are truncated.

* **Documentation**
  * Updated gateway architecture and configuration references with the new status response behavior and setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->