### PR TITLE
chore(release): prepare release 0.6.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -2,8 +2,8 @@ name: nifi-extensions
 description: CUI NiFi processor extensions with Keycloak OIDC authentication
 
 release:
-  current-version: 0.5.0
-  next-version: 0.6.0-SNAPSHOT
+  current-version: 0.6.0
+  next-version: 0.7.0-SNAPSHOT
   create-github-release: true
 
 maven-build:


### PR DESCRIPTION
Bump current-version to 0.6.0, next-version to 0.7.0-SNAPSHOT. Triggers the automated Release workflow on merge.

NiFi version unchanged (2.10.0) — README badge left as-is.